### PR TITLE
Adds support for voting

### DIFF
--- a/keychain-cli.js
+++ b/keychain-cli.js
@@ -717,11 +717,11 @@ program
     });
 
 program
-    .command('poll-add <poll> <ballot>')
+    .command('poll-update <ballot>')
     .description('Add a ballot to the poll')
-    .action(async (poll, ballot) => {
+    .action(async (ballot) => {
         try {
-            const response = await keymaster.addBallot(poll, ballot);
+            const response = await keymaster.updatePoll(ballot);
             console.log(response);
         }
         catch (error) {

--- a/keychain-cli.js
+++ b/keychain-cli.js
@@ -677,7 +677,7 @@ program
     .action(async (file) => {
         try {
             const poll = JSON.parse(fs.readFileSync(file).toString());
-            const did = await keymaster.pollCreate(poll);
+            const did = await keymaster.createPoll(poll);
             console.log(did);
         }
         catch (error) {
@@ -699,11 +699,11 @@ program
     });
 
 program
-    .command('poll-vote <poll> <vote>')
+    .command('poll-vote <poll> <vote> [spoil]')
     .description('Vote in a poll')
-    .action(async (poll, vote) => {
+    .action(async (poll, vote, spoil) => {
         try {
-            const did = await keymaster.votePoll(poll, vote);
+            const did = await keymaster.votePoll(poll, vote, spoil);
             console.log(did);
         }
         catch (error) {

--- a/keychain-cli.js
+++ b/keychain-cli.js
@@ -724,6 +724,45 @@ program
         }
     });
 
+program
+    .command('poll-publish <poll>')
+    .description('Publish results to poll manifest')
+    .action(async (poll) => {
+        try {
+            const response = await keymaster.publishPoll(poll);
+            console.log(response);
+        }
+        catch (error) {
+            console.error(error);
+        }
+    });
+
+program
+    .command('poll-reveal <poll>')
+    .description('Reveal results to poll manifest')
+    .action(async (poll) => {
+        try {
+            const response = await keymaster.publishPoll(poll, true);
+            console.log(response);
+        }
+        catch (error) {
+            console.error(error);
+        }
+    });
+
+program
+    .command('poll-unpublish <poll>')
+    .description('Removed results to poll manifest')
+    .action(async (poll) => {
+        try {
+            const response = await keymaster.unpublishPoll(poll);
+            console.log(response);
+        }
+        catch (error) {
+            console.error(error);
+        }
+    });
+
 async function run() {
     await keymaster.start(gatekeeper);
     program.parse(process.argv);

--- a/keychain-cli.js
+++ b/keychain-cli.js
@@ -564,7 +564,7 @@ program
     .description('Create a new group')
     .action(async (name) => {
         try {
-            const did = await keymaster.groupCreate(name);
+            const did = await keymaster.createGroup(name);
             console.log(did);
             keymaster.addName(name, did);
         }

--- a/keychain-cli.js
+++ b/keychain-cli.js
@@ -612,6 +612,91 @@ program
         }
     });
 
+program
+    .command('create-schema <file> [name]')
+    .description('Create schema from a file')
+    .action(async (file, name) => {
+        try {
+            const schema = JSON.parse(fs.readFileSync(file).toString());
+            const did = await keymaster.createSchema(schema);
+
+            if (name) {
+                keymaster.addName(name, did);
+            }
+
+            console.log(did);
+        }
+        catch (error) {
+            console.error(error);
+        }
+    });
+
+program
+    .command('create-template <schema>')
+    .description('Create a template from a schema')
+    .action(async (schema) => {
+        try {
+            const template = await keymaster.createTemplate(schema);
+            console.log(JSON.stringify(template, null, 4));
+        }
+        catch (error) {
+            console.error(error);
+        }
+    });
+
+program
+    .command('poll-create <file>')
+    .description('Create poll')
+    .action(async (file) => {
+        try {
+            const poll = JSON.parse(fs.readFileSync(file).toString());
+            const did = await keymaster.createPoll(poll);
+            console.log(did);
+        }
+        catch (error) {
+            console.error(error);
+        }
+    });
+
+program
+    .command('poll-view <poll>')
+    .description('View poll details')
+    .action(async (poll) => {
+        try {
+            const response = await keymaster.viewPoll(poll);
+            console.log(JSON.stringify(response, null, 4));
+        }
+        catch (error) {
+            console.error(error);
+        }
+    });
+
+program
+    .command('poll-vote <poll> <vote>')
+    .description('Vote in a poll')
+    .action(async (poll, vote) => {
+        try {
+            const did = await keymaster.votePoll(poll, vote);
+            console.log(did);
+        }
+        catch (error) {
+            console.error(error);
+        }
+    });
+
+program
+    .command('poll-add <poll> <ballot>')
+    .description('Add a ballot to the poll')
+    .action(async (poll, ballot) => {
+        try {
+            const response = await keymaster.addBallot(poll, ballot);
+            console.log(response);
+        }
+        catch (error) {
+            console.error(error);
+        }
+    });
+
 async function run() {
     await keymaster.start(gatekeeper);
     program.parse(process.argv);

--- a/keychain-cli.js
+++ b/keychain-cli.js
@@ -672,12 +672,17 @@ program
     });
 
 program
-    .command('poll-create <file>')
+    .command('poll-create <file> [name]')
     .description('Create poll')
-    .action(async (file) => {
+    .action(async (file, name) => {
         try {
             const poll = JSON.parse(fs.readFileSync(file).toString());
             const did = await keymaster.createPoll(poll);
+
+            if (name) {
+                keymaster.addName(name, did);
+            }
+
             console.log(did);
         }
         catch (error) {
@@ -726,7 +731,7 @@ program
 
 program
     .command('poll-publish <poll>')
-    .description('Publish results to poll manifest')
+    .description('Publish results to poll, hiding ballots')
     .action(async (poll) => {
         try {
             const response = await keymaster.publishPoll(poll);
@@ -739,7 +744,7 @@ program
 
 program
     .command('poll-reveal <poll>')
-    .description('Reveal results to poll manifest')
+    .description('Publish results to poll, revealing ballots')
     .action(async (poll) => {
         try {
             const response = await keymaster.publishPoll(poll, true);
@@ -752,7 +757,7 @@ program
 
 program
     .command('poll-unpublish <poll>')
-    .description('Removed results to poll manifest')
+    .description('Remove results from poll')
     .action(async (poll) => {
         try {
             const response = await keymaster.unpublishPoll(poll);

--- a/keychain-cli.js
+++ b/keychain-cli.js
@@ -560,11 +560,11 @@ program
     });
 
 program
-    .command('create-group <name>')
+    .command('group-create <name>')
     .description('Create a new group')
     .action(async (name) => {
         try {
-            const did = await keymaster.createGroup(name);
+            const did = await keymaster.groupCreate(name);
             console.log(did);
             keymaster.addName(name, did);
         }
@@ -600,7 +600,7 @@ program
     });
 
 program
-    .command('group-test <group> <member>')
+    .command('group-test <group> [member]')
     .description('Determine if a member is in a group')
     .action(async (group, member) => {
         try {
@@ -645,12 +645,39 @@ program
     });
 
 program
+    .command('create-asset <file>')
+    .description('Create an asset from a JSON file')
+    .action(async (file) => {
+        try {
+            const asset = JSON.parse(fs.readFileSync(file).toString());
+            const did = await keymaster.createAsset(asset);
+            console.log(did);
+        }
+        catch (error) {
+            console.error(error);
+        }
+    });
+
+program
+    .command('poll-template')
+    .description('Generate a poll template')
+    .action(async () => {
+        try {
+            const template = await keymaster.pollTemplate();
+            console.log(JSON.stringify(template, null, 4));
+        }
+        catch (error) {
+            console.error(error);
+        }
+    });
+
+program
     .command('poll-create <file>')
     .description('Create poll')
     .action(async (file) => {
         try {
             const poll = JSON.parse(fs.readFileSync(file).toString());
-            const did = await keymaster.createPoll(poll);
+            const did = await keymaster.pollCreate(poll);
             console.log(did);
         }
         catch (error) {

--- a/keychain-cli.js
+++ b/keychain-cli.js
@@ -559,6 +559,59 @@ program
         }
     });
 
+program
+    .command('create-group <name>')
+    .description('Create a new group')
+    .action(async (name) => {
+        try {
+            const did = await keymaster.createGroup(name);
+            console.log(did);
+            keymaster.addName(name, did);
+        }
+        catch (error) {
+            console.error(error);
+        }
+    });
+
+program
+    .command('group-add <group> <member>')
+    .description('Add a member to a group')
+    .action(async (group, member) => {
+        try {
+            const response = await keymaster.groupAdd(group, member);
+            console.log(response);
+        }
+        catch (error) {
+            console.error(error);
+        }
+    });
+
+program
+    .command('group-remove <group> <member>')
+    .description('Remove a member from a group')
+    .action(async (group, member) => {
+        try {
+            const response = await keymaster.groupRemove(group, member);
+            console.log(response);
+        }
+        catch (error) {
+            console.error(error);
+        }
+    });
+
+program
+    .command('group-test <group> <member>')
+    .description('Determine if a member is in a group')
+    .action(async (group, member) => {
+        try {
+            const response = await keymaster.groupTest(group, member);
+            console.log(response);
+        }
+        catch (error) {
+            console.error(error);
+        }
+    });
+
 async function run() {
     await keymaster.start(gatekeeper);
     program.parse(process.argv);

--- a/keychain-cli.js
+++ b/keychain-cli.js
@@ -721,8 +721,13 @@ program
     .description('Add a ballot to the poll')
     .action(async (ballot) => {
         try {
-            const response = await keymaster.updatePoll(ballot);
-            console.log(response);
+            const ok = await keymaster.updatePoll(ballot);
+            if (ok) {
+                console.log("OK");
+            }
+            else {
+                console.log("Update failed");
+            }
         }
         catch (error) {
             console.error(error);
@@ -734,8 +739,13 @@ program
     .description('Publish results to poll, hiding ballots')
     .action(async (poll) => {
         try {
-            const response = await keymaster.publishPoll(poll);
-            console.log(response);
+            const ok = await keymaster.publishPoll(poll);
+            if (ok) {
+                console.log("OK");
+            }
+            else {
+                console.log("Update failed");
+            }
         }
         catch (error) {
             console.error(error);
@@ -747,8 +757,13 @@ program
     .description('Publish results to poll, revealing ballots')
     .action(async (poll) => {
         try {
-            const response = await keymaster.publishPoll(poll, true);
-            console.log(response);
+            const ok = await keymaster.publishPoll(poll, true);
+            if (ok) {
+                console.log("OK");
+            }
+            else {
+                console.log("Update failed");
+            }
         }
         catch (error) {
             console.error(error);
@@ -760,8 +775,13 @@ program
     .description('Remove results from poll')
     .action(async (poll) => {
         try {
-            const response = await keymaster.unpublishPoll(poll);
-            console.log(response);
+            const ok = await keymaster.unpublishPoll(poll);
+            if (ok) {
+                console.log("OK");
+            }
+            else {
+                console.log("Update failed");
+            }
         }
         catch (error) {
             console.error(error);

--- a/keymaster.js
+++ b/keymaster.js
@@ -486,12 +486,13 @@ export function removeName(name) {
 }
 
 export function lookupDID(name) {
-    if (!name) {
-        throw "Invalid DID";
+    try {
+        if (name.startsWith('did:')) {
+            return name;
+        }
     }
-
-    if (name.startsWith('did:mdip:')) {
-        return name;
+    catch {
+        throw "Invalid DID";
     }
 
     const wallet = loadWallet();
@@ -807,7 +808,7 @@ export async function importDID(ops) {
     return gatekeeper.importDID(ops);
 }
 
-export async function groupCreate(name) {
+export async function createGroup(name) {
     const group = {
         name: name,
         members: []
@@ -818,13 +819,16 @@ export async function groupCreate(name) {
 
 export async function groupAdd(group, member) {
     const didGroup = lookupDID(group);
-    const didMember = lookupDID(member);
     const doc = await resolveDID(didGroup);
     const data = doc.didDocumentData;
 
     if (!data.members) {
         throw "Invalid group";
     }
+
+    const didMember = lookupDID(member);
+    // test for valid member DID
+    await resolveDID(didMember);
 
     const members = new Set(data.members);
     members.add(didMember);

--- a/keymaster.js
+++ b/keymaster.js
@@ -930,7 +930,7 @@ export async function pollTemplate() {
     };
 }
 
-export async function pollCreate(poll) {
+export async function createPoll(poll) {
     if (poll.type !== 'poll') {
         throw "Invalid poll type";
     }
@@ -999,7 +999,7 @@ export async function viewPoll(poll) {
     };
 }
 
-export async function votePoll(poll, vote) {
+export async function votePoll(poll, vote, spoil = false) {
     const id = getCurrentId();
     const didPoll = lookupDID(poll);
     const doc = await resolveDID(didPoll);
@@ -1016,10 +1016,29 @@ export async function votePoll(poll, vote) {
         throw "The deadline to vote has passed for this poll";
     }
 
-    const ballot = {
-        poll,
-        vote
-    };
+    let ballot;
+
+    if (spoil) {
+        ballot = {
+            poll: poll,
+            vote: 0,
+            option: 'spoil'
+        };
+    }
+    else {
+        const max = data.options.length;
+        vote = parseInt(vote);
+
+        if (!Number.isInteger(vote) || vote < 1 || vote > max) {
+            return `Vote must be a number between 1 and ${max}`;
+        }
+
+        ballot = {
+            poll: poll,
+            vote: vote,
+            option: data.options[vote-1]
+        };
+    }
 
     const didBallot = await encryptJSON(ballot, owner);
 

--- a/keymaster.js
+++ b/keymaster.js
@@ -845,13 +845,16 @@ export async function groupAdd(group, member) {
 
 export async function groupRemove(group, member) {
     const didGroup = lookupDID(group);
-    const didMember = lookupDID(member);
     const doc = await resolveDID(didGroup);
     const data = doc.didDocumentData;
 
     if (!data.members) {
         throw "Invalid group";
     }
+
+    const didMember = lookupDID(member);
+    // test for valid member DID
+    await resolveDID(didMember);
 
     const members = new Set(data.members);
     members.delete(didMember);

--- a/keymaster.js
+++ b/keymaster.js
@@ -1174,10 +1174,6 @@ export async function updatePoll(ballot) {
 
     const ok = await updateDID(didPoll, docPoll);
 
-    if (!ok) {
-        throw "Error: poll update failed";
-    }
-
     return ok;
 }
 
@@ -1205,11 +1201,7 @@ export async function publishPoll(poll, reveal = false) {
 
     const ok = await updateDID(didPoll, doc);
 
-    if (!ok) {
-        throw "Error: poll update failed";
-    }
-
-    return "OK poll results published";
+    return ok;
 }
 
 export async function unpublishPoll(poll) {
@@ -1226,9 +1218,5 @@ export async function unpublishPoll(poll) {
 
     const ok = await updateDID(didPoll, doc);
 
-    if (!ok) {
-        throw "Error: poll update failed";
-    }
-
-    return "OK poll results removed";
+    return ok;
 }

--- a/keymaster.test.js
+++ b/keymaster.test.js
@@ -2386,3 +2386,30 @@ describe('publishPoll', () => {
         });
     });
 });
+
+describe('unpublishPoll', () => {
+
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should remove results from poll', async () => {
+        mockFs({});
+
+        const bobDid = await keymaster.createId('Bob');
+        const rosterDid = await keymaster.createGroup('mockRoster');
+        await keymaster.groupAdd(rosterDid, bobDid);
+        const template = await keymaster.pollTemplate();
+        template.roster = rosterDid;
+        const pollDid = await keymaster.createPoll(template);
+        const ballotDid = await keymaster.votePoll(pollDid, 1);
+        await keymaster.updatePoll(ballotDid);
+        await keymaster.publishPoll(pollDid);
+        const ok = await keymaster.unpublishPoll(pollDid);
+
+        const pollData = await keymaster.resolveAsset(pollDid);
+
+        expect(ok).toBe(true);
+        expect(pollData.results).toBe(undefined);
+    });
+});

--- a/keymaster.test.js
+++ b/keymaster.test.js
@@ -1743,4 +1743,189 @@ describe('groupAdd', () => {
             expect(error).toBe('Invalid group');
         }
     });
+
+    // TBD should not be able to add a group to itself
+
+    // TBD should not be able to create groups that contain themselves
+});
+
+describe('groupRemove', () => {
+
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should remove a DID member from a group', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const groupName = 'mockGroup';
+        const groupDid = await keymaster.createGroup(groupName);
+        const mockAnchor = { name: 'mockData' };
+        const dataDid = await keymaster.createData(mockAnchor);
+        await keymaster.groupAdd(groupDid, dataDid);
+
+        const data = await keymaster.groupRemove(groupDid, dataDid);
+
+        const expectedGroup = {
+            name: groupName,
+            members: [],
+        };
+
+        expect(data).toStrictEqual(expectedGroup);
+    });
+
+    it('should remove a DID alias from a group', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const groupName = 'mockGroup';
+        const groupDid = await keymaster.createGroup(groupName);
+        const mockAnchor = { name: 'mockData' };
+        const dataDid = await keymaster.createData(mockAnchor);
+        await keymaster.groupAdd(groupDid, dataDid);
+
+        const alias = 'mockAlias';
+        keymaster.addName(alias, dataDid);
+
+        const data = await keymaster.groupRemove(groupDid, alias);
+
+        const expectedGroup = {
+            name: groupName,
+            members: [],
+        };
+
+        expect(data).toStrictEqual(expectedGroup);
+    });
+
+    it('should be OK to remove a DID that is not in the group', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const groupName = 'mockGroup';
+        const groupDid = await keymaster.createGroup(groupName);
+        const mockAnchor = { name: 'mockData' };
+        const dataDid = await keymaster.createData(mockAnchor);
+
+        const data = await keymaster.groupRemove(groupDid, dataDid);
+
+        const expectedGroup = {
+            name: groupName,
+            members: [],
+        };
+
+        expect(data).toStrictEqual(expectedGroup);
+    });
+
+    it('should not remove a non-DID from the group', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const groupName = 'mockGroup';
+        const groupDid = await keymaster.createGroup(groupName);
+
+        try {
+            await keymaster.groupRemove(groupDid);
+            throw 'Expected to throw an exception';
+        }
+        catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+
+        try {
+            await keymaster.groupRemove(groupDid, 100);
+            throw 'Expected to throw an exception';
+        }
+        catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+
+        try {
+            await keymaster.groupRemove(groupDid, [1, 2, 3]);
+            throw 'Expected to throw an exception';
+        }
+        catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+
+        try {
+            await keymaster.groupRemove(groupDid, { name: 'mock' });
+            throw 'Expected to throw an exception';
+        }
+        catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+
+        try {
+            await keymaster.groupRemove(groupDid, 'did:mock');
+            throw 'Expected to throw an exception';
+        }
+        catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+    });
+
+    it('should not remove a member from a non-group', async () => {
+        mockFs({});
+
+        const agentDid = await keymaster.createId('Bob');
+        const mockAnchor = { name: 'mockData' };
+        const dataDid = await keymaster.createData(mockAnchor);
+
+        try {
+            await keymaster.groupRemove();
+            throw 'Expected to throw an exception';
+        }
+        catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+
+        try {
+            await keymaster.groupRemove(null, dataDid);
+            throw 'Expected to throw an exception';
+        }
+        catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+
+        try {
+            await keymaster.groupRemove(100, dataDid);
+            throw 'Expected to throw an exception';
+        }
+        catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+
+        try {
+            await keymaster.groupRemove([1, 2, 3], dataDid);
+            throw 'Expected to throw an exception';
+        }
+        catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+
+        try {
+            await keymaster.groupRemove({ name: 'mock' }, dataDid);
+            throw 'Expected to throw an exception';
+        }
+        catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+
+        try {
+            await keymaster.groupRemove(agentDid, dataDid);
+            throw 'Expected to throw an exception';
+        }
+        catch (error) {
+            expect(error).toBe('Invalid group');
+        }
+
+        try {
+            await keymaster.groupRemove(dataDid, agentDid);
+            throw 'Expected to throw an exception';
+        }
+        catch (error) {
+            expect(error).toBe('Invalid group');
+        }
+    });
 });

--- a/keymaster.test.js
+++ b/keymaster.test.js
@@ -1929,3 +1929,65 @@ describe('groupRemove', () => {
         }
     });
 });
+
+describe('groupTest', () => {
+
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should return true when member in group', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const groupName = 'mockGroup';
+        const groupDid = await keymaster.createGroup(groupName);
+        const mockAnchor = { name: 'mockData' };
+        const dataDid = await keymaster.createData(mockAnchor);
+        await keymaster.groupAdd(groupDid, dataDid);
+
+        const test = await keymaster.groupTest(groupDid, dataDid);
+
+        expect(test).toBe(true);
+    });
+
+    it('should return false when member not in group', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const groupName = 'mockGroup';
+        const groupDid = await keymaster.createGroup(groupName);
+        const mockAnchor = { name: 'mockData' };
+        const dataDid = await keymaster.createData(mockAnchor);
+
+        const test = await keymaster.groupTest(groupDid, dataDid);
+
+        expect(test).toBe(false);
+    });
+
+    it('should return true when testing group only', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const groupName = 'mockGroup';
+        const groupDid = await keymaster.createGroup(groupName);
+
+        const test = await keymaster.groupTest(groupDid);
+
+        expect(test).toBe(true);
+    });
+
+    it('should return false when testing non-group only', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const mockAnchor = { name: 'mockData' };
+        const dataDid = await keymaster.createData(mockAnchor);
+
+        const test = await keymaster.groupTest(dataDid);
+
+        expect(test).toBe(false);
+    });
+
+    // TBD test recursive groups
+});

--- a/keymaster.test.js
+++ b/keymaster.test.js
@@ -548,7 +548,7 @@ describe('resolveDID', () => {
             await keymaster.resolveDID('mock');
             throw 'Expected to throw an exception';
         } catch (error) {
-            expect(error).toBe('Invalid DID');
+            expect(error).toBe('Unknown DID');
         }
     });
 });
@@ -1448,11 +1448,11 @@ describe('unpublishCredential', () => {
         await keymaster.createId('Bob');
 
         try {
-            await keymaster.unpublishCredential('mock');
+            await keymaster.unpublishCredential('did:mdip:mock');
             throw 'Expected to throw an exception';
         }
         catch (error) {
-            expect(error).toBe('Error: credential mock not found in manifest');
+            expect(error).toBe('Error: credential did:mdip:mock not found in manifest');
         }
     });
 

--- a/keymaster.test.js
+++ b/keymaster.test.js
@@ -1561,6 +1561,43 @@ describe('groupAdd', () => {
         }
     });
 
+    it('should add a DID to a group alias', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const groupName = 'mockGroup';
+        const groupDid = await keymaster.createGroup(groupName);
+        const mockAnchor = { name: 'mockData' };
+        const dataDid = await keymaster.createData(mockAnchor);
+
+        const alias = 'mockAlias';
+        keymaster.addName(alias, groupDid);
+        const data = await keymaster.groupAdd(alias, dataDid);
+
+        const expectedGroup = {
+            name: groupName,
+            members: [dataDid],
+        };
+
+        expect(data).toStrictEqual(expectedGroup);
+    });
+
+    it('should not add a DID member to an unknown group alias', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const mockAnchor = { name: 'mockData' };
+        const dataDid = await keymaster.createData(mockAnchor);
+
+        try {
+            await keymaster.groupAdd('mockAlias', dataDid);
+            throw 'Expected to throw an exception';
+        }
+        catch (error) {
+            expect(error).toBe('Unknown DID');
+        }
+    });
+
     it('should add a member to the group only once', async () => {
         mockFs({});
 
@@ -1648,6 +1685,62 @@ describe('groupAdd', () => {
         }
         catch (error) {
             expect(error).toBe('Invalid DID');
+        }
+    });
+
+    it('should not add a member to a non-group', async () => {
+        mockFs({});
+
+        const agentDid = await keymaster.createId('Bob');
+        const mockAnchor = { name: 'mockData' };
+        const dataDid = await keymaster.createData(mockAnchor);
+
+        try {
+            await keymaster.groupAdd(null, dataDid);
+            throw 'Expected to throw an exception';
+        }
+        catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+
+        try {
+            await keymaster.groupAdd(100, dataDid);
+            throw 'Expected to throw an exception';
+        }
+        catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+
+        try {
+            await keymaster.groupAdd([1, 2, 3], dataDid);
+            throw 'Expected to throw an exception';
+        }
+        catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+
+        try {
+            await keymaster.groupAdd({ name: 'mock' }, dataDid);
+            throw 'Expected to throw an exception';
+        }
+        catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+
+        try {
+            await keymaster.groupAdd(agentDid, dataDid);
+            throw 'Expected to throw an exception';
+        }
+        catch (error) {
+            expect(error).toBe('Invalid group');
+        }
+
+        try {
+            await keymaster.groupAdd(dataDid, agentDid);
+            throw 'Expected to throw an exception';
+        }
+        catch (error) {
+            expect(error).toBe('Invalid group');
         }
     });
 });

--- a/keymaster.test.js
+++ b/keymaster.test.js
@@ -1991,3 +1991,27 @@ describe('groupTest', () => {
 
     // TBD test recursive groups
 });
+
+describe('pollTemplate', () => {
+
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should return a poll template', async () => {
+        mockFs({});
+
+        const template = await keymaster.pollTemplate();
+
+        const expectedTemplate = {
+            type: 'poll',
+            version: 1,
+            description: 'What is this poll about?',
+            roster: 'DID of the eligible voter group',
+            options: ['yes', 'no', 'abstain'],
+            deadline: expect.any(String),
+        };
+
+        expect(template).toStrictEqual(expectedTemplate);
+    });
+});


### PR DESCRIPTION
This PR adds support for poll voting:

```
  poll-create <file> [name]                   Create poll
  poll-publish <poll>                         Publish results to poll, hiding ballots
  poll-reveal <poll>                          Publish results to poll, revealing ballots
  poll-template                               Generate a poll template
  poll-unpublish <poll>                       Remove results from poll
  poll-update <ballot>                        Add a ballot to the poll
  poll-view <poll>                            View poll details
  poll-vote <poll> <vote> [spoil]             Vote in a poll
```

The poll requires a roster which is a list of eligible voters. The roster is created separately with group commands:
```
  group-add <group> <member>                  Add a member to a group
  group-create <name>                         Create a new group
  group-remove <group> <member>               Remove a member from a group
  group-test <group> [member]                 Determine if a member is in a group
```