### PR TITLE
Support groups within groups

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -827,6 +827,17 @@ export async function groupAdd(group, member) {
     }
 
     const didMember = lookupDID(member);
+
+    if (didMember === didGroup) {
+        throw "Invalid member";
+    }
+
+    const isMember = await groupTest(member, group);
+
+    if (isMember) {
+        throw "Invalid member";
+    }
+
     // test for valid member DID
     await resolveDID(didMember);
 

--- a/keymaster.js
+++ b/keymaster.js
@@ -888,19 +888,28 @@ export async function groupTest(group, member) {
         return false;
     }
 
-    // Check if data.members is an array
     if (!Array.isArray(data.members)) {
         return false;
     }
 
-    if (member) {
-        const didMember = lookupDID(member);
-        // TBD implement recursive test for groups within groups
-        const isMember = data.members.includes(didMember);
-        return isMember;
+    if (!member) {
+        return true;
     }
 
-    return true;
+    const didMember = lookupDID(member);
+    let isMember = data.members.includes(didMember);
+
+    if (!isMember) {
+        for (const did of data.members) {
+            isMember = await groupTest(did, didMember);
+
+            if (isMember) {
+                break;
+            }
+        }
+    }
+
+    return isMember;
 }
 
 export async function createSchema(schema) {

--- a/keymaster.test.js
+++ b/keymaster.test.js
@@ -1989,7 +1989,33 @@ describe('groupTest', () => {
         expect(test).toBe(false);
     });
 
-    // TBD test recursive groups
+    it('should return true when testing recursive groups', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const group1Did = await keymaster.createGroup('level-1');
+        const group2Did = await keymaster.createGroup('level-2');
+        const group3Did = await keymaster.createGroup('level-3');
+        const group4Did = await keymaster.createGroup('level-4');
+        const group5Did = await keymaster.createGroup('level-5');
+
+        await keymaster.groupAdd(group1Did, group2Did);
+        await keymaster.groupAdd(group2Did, group3Did);
+        await keymaster.groupAdd(group3Did, group4Did);
+        await keymaster.groupAdd(group4Did, group5Did);
+
+        const test1 = await keymaster.groupTest(group1Did, group2Did);
+        expect(test1).toBe(true);
+
+        const test2 = await keymaster.groupTest(group1Did, group3Did);
+        expect(test2).toBe(true);
+
+        const test3 = await keymaster.groupTest(group1Did, group4Did);
+        expect(test3).toBe(true);
+
+        const test4 = await keymaster.groupTest(group1Did, group5Did);
+        expect(test4).toBe(true);
+    });
 });
 
 describe('pollTemplate', () => {

--- a/keymaster.test.js
+++ b/keymaster.test.js
@@ -1744,9 +1744,40 @@ describe('groupAdd', () => {
         }
     });
 
-    // TBD should not be able to add a group to itself
+    it('should not add a group to itself', async () => {
+        mockFs({});
 
-    // TBD should not be able to create groups that contain themselves
+        await keymaster.createId('Bob');
+        const groupDid = await keymaster.createGroup('group');
+
+        try {
+            await keymaster.groupAdd(groupDid, groupDid);
+            throw 'Expected to throw an exception';
+        }
+        catch (error) {
+            expect(error).toBe('Invalid member');
+        }
+    });
+
+    it('should not add a member that contains group', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const group1Did = await keymaster.createGroup('group-1');
+        const group2Did = await keymaster.createGroup('group-2');
+        const group3Did = await keymaster.createGroup('group-3');
+
+        await keymaster.groupAdd(group1Did, group2Did);
+        await keymaster.groupAdd(group2Did, group3Did);
+
+        try {
+            await keymaster.groupAdd(group3Did, group1Did);
+            throw 'Expected to throw an exception';
+        }
+        catch (error) {
+            expect(error).toBe('Invalid member');
+        }
+    });
 });
 
 describe('groupRemove', () => {


### PR DESCRIPTION
Groups may be added to groups to define a hierarchy.

Groups may not contain themselves (no circular references allowed).