### PR TITLE
Added btc-mediator

### DIFF
--- a/Dockerfile.btc
+++ b/Dockerfile.btc
@@ -1,0 +1,17 @@
+# Use the official Node.js as the base image
+FROM node:18.15.0
+
+# Set the working directory
+WORKDIR /app
+
+# Copy package.json and package-lock.json to the working directory
+COPY package*.json ./
+
+# Install dependencies
+RUN npm ci
+
+# Copy app
+COPY *.js ./
+
+# Run...
+CMD ["node", "btc-mediator.js"]

--- a/admin-cli.js
+++ b/admin-cli.js
@@ -146,17 +146,25 @@ program
     });
 
 program
-    .command('import-batch <did> <registry>')
+    .command('import-batch <did> [registry]')
     .description('Import a batch')
     .action(async (did, registry) => {
         try {
-            const batch = await keymaster.resolveAsset(did);
-            const now = new Date().toISOString();
+            if (!registry) {
+                registry = 'local';
+            }
 
-            for (const i in batch) {
-                batch[i].registry = registry;
-                batch[i].time = now;
-                batch[i].ordinal = i;
+            const queue = await keymaster.resolveAsset(did);
+            const batch = [];
+            const now = new Date();
+
+            for (let i = 0; i < queue.length; i++) {
+                batch.push({
+                    registry: registry,
+                    time: now.toISOString(),
+                    ordinal: [now.getTime(), i],
+                    operation: queue[i],
+                });
             }
 
             console.log(JSON.stringify(batch, null, 4));

--- a/btc-mediator.js
+++ b/btc-mediator.js
@@ -27,8 +27,9 @@ function loadDb() {
             height: 0,
             time: "",
             blockCount: 0,
-            scanned: 0,
-            pending: 0,
+            blocksScanned: 0,
+            blocksPending: 0,
+            txnsScanned: 0,
             registered: [],
             discovered: [],
         }
@@ -81,9 +82,10 @@ async function fetchBlock(height, blockCount) {
         const db = loadDb();
         db.height = height;
         db.time = timestamp;
-        db.scanned = height - FIRST + 1;
+        db.blocksScanned = height - FIRST + 1;
+        db.txnsScanned = db.txnsScanned + block.nTx;
         db.blockCount = blockCount;
-        db.pending = blockCount - height;
+        db.blocksPending = blockCount - height;
         writeDb(db);
 
     } catch (error) {
@@ -242,15 +244,15 @@ async function replaceByFee() {
 function checkAnchorInterval() {
     const db = loadDb();
 
-    if (!db.lastAnchorTime) {
-        db.lastAnchorTime = new Date().toISOString();
+    if (!db.lastExport) {
+        db.lastExport = new Date().toISOString();
         writeDb(db);
         return true;
     }
 
-    const lastAnchorTime = new Date(db.lastAnchorTime);
+    const lastExport = new Date(db.lastExport);
     const now = new Date();
-    const elapsedMinutes = (now - lastAnchorTime) / (60 * 1000);
+    const elapsedMinutes = (now - lastExport) / (60 * 1000);
 
     return (elapsedMinutes < config.btcAnchorInterval);
 }
@@ -290,7 +292,7 @@ async function anchorBatch() {
                 })
 
                 db.pendingTxid = txid;
-                db.lastAnchorTime = new Date().toISOString();
+                db.lastExport = new Date().toISOString();
 
                 writeDb(db);
             }

--- a/btc-mediator.js
+++ b/btc-mediator.js
@@ -339,6 +339,7 @@ async function main() {
 
     try {
         await keymaster.resolveDID(config.nodeID);
+        console.log(`Using node ID '${config.nodeID}'`);
     }
     catch (error) {
         console.log(`Cannot resolve node ID '${config.nodeID}'`, error);

--- a/btc-mediator.js
+++ b/btc-mediator.js
@@ -123,16 +123,16 @@ async function importBatch() {
             const batch = [];
 
             for (let i = 0; i < queue.length; i++) {
-                const blockTime = new Date(item.time);
-
                 batch.push({
                     registry: 'BTC',
-                    time: blockTime.toISOString(),
-                    ordinal: [blockTime.getTime(), item.index, i],
+                    time: item.time,
+                    ordinal: [item.height, item.index, i],
                     operation: queue[i],
                     blockchain: {
                         height: item.height,
+                        index: item.index,
                         txid: item.txid,
+                        batch: item.did,
                     }
                 });
             }

--- a/btc-mediator.js
+++ b/btc-mediator.js
@@ -319,6 +319,8 @@ async function anchorLoop() {
 }
 
 async function main() {
+    await keymaster.start(gatekeeper);
+
     console.log(`Connecting to BTC on ${config.btcHost} on port ${config.btcPort} using wallet '${config.btcWallet}'`);
 
     try {
@@ -334,12 +336,18 @@ async function main() {
         console.log('btc-mediator must have a KC_NODE_ID configured');
     }
 
+    try {
+        await keymaster.resolveDID(config.nodeID);
+    }
+    catch (error) {
+        console.log(`Cannot resolve node ID '${config.nodeID}'`, error);
+        return;
+    }
+
     console.log(`Using keymaster ID ${config.nodeID}`);
     console.log(`Scanning blocks every ${config.btcScanInterval} minute(s)`);
     console.log(`Anchoring operations every ${config.btcAnchorInterval} minute(s)`);
     console.log(`Txn fee minimum: ${config.btcFeeMin} BTC, maximum: ${config.btcFeeMax} BTC, increment ${config.btcFeeInc} BTC`);
-
-    await keymaster.start(gatekeeper);
 
     importLoop();
     anchorLoop();

--- a/btc-mediator.js
+++ b/btc-mediator.js
@@ -319,6 +319,7 @@ async function anchorLoop() {
 }
 
 async function main() {
+    await gatekeeper.waitUntilReady();
     await keymaster.start(gatekeeper);
 
     console.log(`Connecting to BTC on ${config.btcHost} on port ${config.btcPort} using wallet '${config.btcWallet}'`);

--- a/btc-mediator.js
+++ b/btc-mediator.js
@@ -15,7 +15,7 @@ const client = new BtcClient({
     password: config.btcPass,
     host: config.btcHost,
     port: config.btcPort,
-    wallet: 'beta',
+    wallet: config.btcWallet,
 });
 
 const dbName = 'data/btc-mediator.json';

--- a/btc-mediator.js
+++ b/btc-mediator.js
@@ -320,6 +320,20 @@ async function anchorLoop() {
 
 async function main() {
     console.log(`Connecting to BTC on ${config.btcHost} on port ${config.btcPort} using wallet '${config.btcWallet}'`);
+
+    try {
+        const walletInfo = await client.getWalletInfo();
+        console.log(JSON.stringify(walletInfo, null, 4));
+    }
+    catch (error) {
+        console.log('Cannot connect to BTC node', error);
+        return;
+    }
+
+    if (!config.nodeID) {
+        console.log('btc-mediator must have a KC_NODE_ID configured');
+    }
+
     console.log(`Using keymaster ID ${config.nodeID}`);
     console.log(`Scanning blocks every ${config.btcScanInterval} minute(s)`);
     console.log(`Anchoring operations every ${config.btcAnchorInterval} minute(s)`);

--- a/btc-mediator.js
+++ b/btc-mediator.js
@@ -1,0 +1,246 @@
+import fs from 'fs';
+import BtcClient from 'bitcoin-core';
+import * as gatekeeper from './gatekeeper-sdk.js';
+import * as keymaster from './keymaster.js';
+import config from './config.js';
+
+const REGISTRY = 'BTC';
+const FIRST = 841600;
+const NODE_ID = config.nodeID;
+
+const client = new BtcClient({
+    network: 'mainnet',
+    username: config.btcUser,
+    password: config.btcPass,
+    host: config.btcHost,
+    port: config.btcPort,
+});
+
+const dbName = 'data/btc-mediator.json';
+
+function loadDb() {
+    if (fs.existsSync(dbName)) {
+        return JSON.parse(fs.readFileSync(dbName));
+    }
+    else {
+        return {
+            height: 0,
+            time: "",
+            blockCount: 0,
+            scanned: 0,
+            pending: 0,
+            registered: [],
+            discovered: [],
+        }
+    }
+}
+
+function writeDb(db) {
+    fs.writeFileSync(dbName, JSON.stringify(db, null, 4));
+}
+
+async function fetchTransaction(height, index, timestamp, txid) {
+    try {
+        const txn = await client.getTransactionByHash(txid);
+        const asm = txn.vout[0].scriptPubKey.asm;
+
+        if (asm.startsWith('OP_RETURN')) {
+            const hexString = asm.slice(10);
+            const textString = Buffer.from(hexString, 'hex').toString('utf8');
+
+            if (textString.startsWith('did:mdip:')) {
+                const db = loadDb();
+                db.discovered.push({
+                    height: height,
+                    index: index,
+                    time: timestamp,
+                    txid: txid,
+                    did: textString,
+                });
+                writeDb(db);
+            }
+        }
+    }
+    catch (error) {
+        console.error(`Error fetching txn: ${error}`);
+    }
+}
+
+async function fetchBlock(height, blockCount) {
+    try {
+        const blockHash = await client.getBlockHash(height);
+        const block = await client.getBlock(blockHash);
+        const timestamp = new Date(block.time * 1000).toISOString();
+
+        for (let i = 0; i < block.nTx; i++) {
+            const txid = block.tx[i];
+            console.log(height, String(i).padStart(4), txid);
+            await fetchTransaction(height, i, timestamp, txid);
+        }
+
+        const db = loadDb();
+        db.height = height;
+        db.time = timestamp;
+        db.scanned = height - FIRST + 1;
+        db.blockCount = blockCount;
+        db.pending = blockCount - height;
+        writeDb(db);
+
+    } catch (error) {
+        console.error(`Error fetching block: ${error}`);
+    }
+}
+
+async function sync() {
+    let start = FIRST;
+    let blockCount = await client.getBlockCount();
+
+    console.log(`current block height: ${blockCount}`);
+
+    const db = loadDb();
+
+    if (db.height) {
+        start = db.height + 1;
+    }
+
+    for (let height = start; height <= blockCount; height++) {
+        console.log(height);
+        await fetchBlock(height, blockCount);
+        blockCount = await client.getBlockCount();
+    }
+}
+
+async function importBatch() {
+    const db = loadDb();
+
+    for (const item of db.discovered) {
+        if (!item.imported) {
+            console.log(JSON.stringify(item, null, 4));
+
+            const batch = await keymaster.resolveAsset(item.did);
+
+            for (let i = 0; i < batch.length; i++) {
+                if (batch[i].registry !== REGISTRY) {
+                    throw "Invalid registry";
+                }
+
+                batch[i].time = item.time;
+                batch[i].ordinal = [item.height, item.index, i];
+                batch[i].txid = item.txid;
+            }
+
+            console.log(JSON.stringify(batch, null, 4));
+            const imported = await gatekeeper.importBatch(batch);
+            item.imported = imported;
+            writeDb(db);
+            console.log(JSON.stringify(item, null, 4));
+        }
+    }
+}
+
+async function registerBatch() {
+    const batch = await gatekeeper.getQueue(REGISTRY);
+    console.log(JSON.stringify(batch, null, 4));
+
+    if (batch.length > 0) {
+        const saveName = keymaster.getCurrentIdName();
+        keymaster.useId(NODE_ID);
+        const did = await keymaster.createAsset(batch);
+        const txid = await createOpReturnTxn(did);
+
+        if (txid) {
+            const ok = await gatekeeper.clearQueue(batch);
+
+            if (ok) {
+                const db = loadDb();
+
+                if (!db.registered) {
+                    db.registered = [];
+                }
+
+                db.registered.push({
+                    did,
+                    txid,
+                })
+
+                writeDb(db);
+            }
+        }
+
+        keymaster.useId(saveName);
+    }
+    else {
+        console.log('empty batch');
+    }
+}
+
+async function importLoop() {
+    try {
+        await sync();
+        await importBatch();
+        console.log('waiting 60s...');
+    } catch (error) {
+        console.error(`Error in importLoop: ${error}`);
+    }
+    setTimeout(importLoop, 60 * 1000);
+}
+
+async function registerLoop() {
+    try {
+        await registerBatch();
+        console.log('waiting 5m...');
+    } catch (error) {
+        console.error(`Error in registerLoop: ${error}`);
+    }
+    setTimeout(registerLoop, 5 * 60 * 1000);
+}
+
+async function main() {
+    console.log(`Connecting to BTC on ${config.btcHost} on port ${config.btcPort}`);
+    console.log(`Using keymaster ID ${NODE_ID}`);
+
+    await keymaster.start(gatekeeper);
+    importLoop();
+    registerLoop();
+    await keymaster.stop();
+}
+
+export async function createOpReturnTxn(opReturnData) {
+    try {
+        const utxos = await client.listUnspent();
+        const utxo = utxos[0];
+        const amountIn = utxo.amount;
+        const txnfee = 0.00010000;
+        const amountBack = amountIn - txnfee;
+
+        // Convert the OP_RETURN data to a hex string
+        const opReturnHex = Buffer.from(opReturnData, 'utf8').toString('hex');
+
+        // Fetch a new address for the transaction output
+        const address = await client.getNewAddress();
+
+        const rawTxn = await client.createRawTransaction([{
+            txid: utxo.txid,
+            vout: utxo.vout
+        }], {
+            data: opReturnHex,
+            [address]: amountBack.toFixed(8)
+        });
+
+        // Sign the raw transaction
+        const signedTxn = await client.signRawTransactionWithWallet(rawTxn);
+
+        console.log(JSON.stringify(signedTxn, null, 4));
+        console.log(amountBack);
+
+        // Broadcast the transaction
+        const txid = await client.sendRawTransaction(signedTxn.hex);
+
+        console.log(`Transaction broadcasted with txid: ${txid}`);
+        return txid;
+    } catch (error) {
+        console.error(`Error creating OP_RETURN transaction: ${error}`);
+    }
+}
+
+main();

--- a/clean-data.sh
+++ b/clean-data.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+git stash
+rm -rfv data
+git reset --hard
+git stash pop

--- a/config.js
+++ b/config.js
@@ -4,22 +4,27 @@ dotenv.config();
 
 const config = {
     didPrefix: process.env.KC_DID_PREFIX || "did:mdip:test",
-    gatekeeperPort: process.env.KC_GATEKEEPER_PORT || 4224,
+    gatekeeperPort: process.env.KC_GATEKEEPER_PORT ? parseInt(process.env.KC_GATEKEEPER_PORT) : 4224,
     gatekeeperURL: process.env.KC_GATEKEEPER_URL || 'http://localhost',
     gatekeeperDb: process.env.KC_GATEKEEPER_DB || 'json',
     nodeName: process.env.KC_NODE_NAME || 'anon',
     nodeID: process.env.KC_NODE_ID,
     mongodbUrl: process.env.KC_MONGODB_URL || 'mongodb://localhost:27017',
     tessHost: process.env.KC_TESS_HOST || 'localhost',
-    tessPort: process.env.KC_TESS_PORT || 8333,
+    tessPort: process.env.KC_TESS_PORT ? parseInt(process.env.KC_TESS_PORT) : 8333,
     tessUser: process.env.KC_TESS_USER || 'tesseract',
     tessPass: process.env.KC_TESS_PASS || 'tesseract',
     tessID: process.env.KC_TESS_ID || 'tesseract',
     btcHost: process.env.KC_BTC_HOST || 'localhost',
-    btcPort: process.env.KC_BTC_PORT || 8332,
+    btcPort: process.env.KC_BTC_PORT ? parseInt(process.env.KC_BTC_PORT) : 8332,
     btcWallet: process.env.KC_BTC_WALLET,
     btcUser: process.env.KC_BTC_USER,
     btcPass: process.env.KC_BTC_PASS,
+    btcScanInterval: process.env.KC_BTC_SCAN_INTERVAL ? parseInt(process.env.KC_BTC_SCAN_INTERVAL) : 1,
+    btcAnchorInterval: process.env.KC_BTC_ANCHOR_INTERVAL ? parseInt(process.env.KC_BTC_ANCHOR_INTERVAL) : 60,
+    btcFeeMin: process.env.KC_BTC_FEE_MIN ? parseFloat(process.env.KC_BTC_FEE_MIN) : 0.00002,
+    btcFeeMax: process.env.KC_BTC_FEE_MAX ? parseFloat(process.env.KC_BTC_FEE_MAX) : 0.00010,
+    btcFeeInc: process.env.KC_BTC_FEE_INC ? parseFloat(process.env.KC_BTC_FEE_INC) : 0.00002,
 };
 
 export default config;

--- a/config.js
+++ b/config.js
@@ -14,7 +14,6 @@ const config = {
     tessPort: process.env.KC_TESS_PORT ? parseInt(process.env.KC_TESS_PORT) : 8333,
     tessUser: process.env.KC_TESS_USER || 'tesseract',
     tessPass: process.env.KC_TESS_PASS || 'tesseract',
-    tessID: process.env.KC_TESS_ID || 'tesseract',
     btcHost: process.env.KC_BTC_HOST || 'localhost',
     btcPort: process.env.KC_BTC_PORT ? parseInt(process.env.KC_BTC_PORT) : 8332,
     btcWallet: process.env.KC_BTC_WALLET,

--- a/config.js
+++ b/config.js
@@ -8,12 +8,17 @@ const config = {
     gatekeeperURL: process.env.KC_GATEKEEPER_URL || 'http://localhost',
     gatekeeperDb: process.env.KC_GATEKEEPER_DB || 'json',
     nodeName: process.env.KC_NODE_NAME || 'anon',
+    nodeID: process.env.KC_NODE_ID,
     mongodbUrl: process.env.KC_MONGODB_URL || 'mongodb://localhost:27017',
     tessHost: process.env.KC_TESS_HOST || 'localhost',
     tessPort: process.env.KC_TESS_PORT || 8333,
     tessUser: process.env.KC_TESS_USER || 'tesseract',
     tessPass: process.env.KC_TESS_PASS || 'tesseract',
     tessID: process.env.KC_TESS_ID || 'tesseract',
+    btcHost: process.env.KC_BTC_HOST || 'localhost',
+    btcPort: process.env.KC_BTC_PORT || 8332,
+    btcUser: process.env.KC_BTC_USER,
+    btcPass: process.env.KC_BTC_PASS,
 };
 
 export default config;

--- a/config.js
+++ b/config.js
@@ -17,6 +17,7 @@ const config = {
     tessID: process.env.KC_TESS_ID || 'tesseract',
     btcHost: process.env.KC_BTC_HOST || 'localhost',
     btcPort: process.env.KC_BTC_PORT || 8332,
+    btcWallet: process.env.KC_BTC_WALLET,
     btcUser: process.env.KC_BTC_USER,
     btcPass: process.env.KC_BTC_PASS,
 };

--- a/db-benchmark.js
+++ b/db-benchmark.js
@@ -15,11 +15,10 @@ async function importDIDs(db) {
 
         for (let j = 0; j < 10; j++) {
 
-            const op = {
+            const event = {
                 "registry": "hyperswarm",
                 "time": "2024-04-04T13:56:09.975Z",
                 "ordinal": 0,
-                "did": did,
                 "operation": {
                     "type": "create",
                     "created": new Date().toISOString(),
@@ -42,7 +41,7 @@ async function importDIDs(db) {
             };
 
             console.time('addOperation');
-            await db.addOperation(op);
+            await db.addEvent(did, event);
             console.timeEnd('addOperation');
         }
 
@@ -60,10 +59,10 @@ async function exportDIDs(db) {
 
     for (const i in ids) {
         const id = ids[i];
-        console.time('getOperations');
-        const ops = await db.getOperations(id);
-        console.timeEnd('getOperations');
-        console.log(i, id, ops);
+        console.time('getEvents');
+        const events = await db.getEvents(id);
+        console.timeEnd('getEvents');
+        console.log(i, id, events);
     }
 }
 

--- a/db-json.js
+++ b/db-json.js
@@ -35,9 +35,14 @@ export async function resetDb() {
     }
 }
 
-export async function addEvent(event) {
+export async function addEvent(did, event) {
     const db = loadDb();
-    const suffix = event.did.split(':').pop();
+
+    if (!did) {
+        throw "Invalid DID";
+    }
+
+    const suffix = did.split(':').pop();
 
     if (Object.prototype.hasOwnProperty.call(db.dids, suffix)) {
         db.dids[suffix].push(event);
@@ -68,6 +73,10 @@ export async function getEvents(did) {
 }
 
 export async function setEvents(did, events) {
+    if (!did) {
+        throw "Invalid DID";
+    }
+
     const db = loadDb();
     const suffix = did.split(':').pop();
 

--- a/db-json.js
+++ b/db-json.js
@@ -132,7 +132,12 @@ export async function clearQueue(registry, batch) {
     try {
         const db = loadDb();
         const oldQueue = db.queue[registry];
-        const newQueue = oldQueue.filter(item => !batch.some(op => op.operation.signature.value === item.operation.signature.value));
+
+        if (!oldQueue) {
+            throw `Unknown registry ${registry}`;
+        }
+
+        const newQueue = oldQueue.filter(item => !batch.some(op => op.signature.value === item.signature.value));
 
         db.queue[registry] = newQueue;
         writeDb(db);

--- a/db-json.js
+++ b/db-json.js
@@ -35,21 +35,21 @@ export async function resetDb() {
     }
 }
 
-export async function addOperation(op) {
+export async function addEvent(event) {
     const db = loadDb();
-    const suffix = op.did.split(':').pop();
+    const suffix = event.did.split(':').pop();
 
     if (Object.prototype.hasOwnProperty.call(db.dids, suffix)) {
-        db.dids[suffix].push(op);
+        db.dids[suffix].push(event);
     }
     else {
-        db.dids[suffix] = [op];
+        db.dids[suffix] = [event];
     }
 
     writeDb(db);
 }
 
-export async function getOperations(did) {
+export async function getEvents(did) {
     try {
         const db = loadDb();
         const suffix = did.split(':').pop();
@@ -67,15 +67,15 @@ export async function getOperations(did) {
     }
 }
 
-export async function setOperations(did, ops) {
+export async function setEvents(did, events) {
     const db = loadDb();
     const suffix = did.split(':').pop();
-    
-    db.dids[suffix] = ops;
+
+    db.dids[suffix] = events;
     writeDb(db);
 }
 
-export async function deleteOperations(did) {
+export async function deleteEvents(did) {
     const db = loadDb();
     const suffix = did.split(':').pop();
 
@@ -85,18 +85,18 @@ export async function deleteOperations(did) {
     }
 }
 
-export async function queueOperation(op) {
+export async function queueOperation(registry, op) {
     const db = loadDb();
 
     if (!db.queue) {
         db.queue = {};
     }
 
-    if (Object.prototype.hasOwnProperty.call(db.queue, op.registry)) {
-        db.queue[op.registry].push(op);
+    if (Object.prototype.hasOwnProperty.call(db.queue, registry)) {
+        db.queue[registry].push(op);
     }
     else {
-        db.queue[op.registry] = [op];
+        db.queue[registry] = [op];
     }
 
     writeDb(db);

--- a/db-mongodb.js
+++ b/db-mongodb.js
@@ -86,14 +86,22 @@ export async function getQueue(registry) {
 }
 
 export async function clearQueue(registry, batch) {
-    const queueCollection = db.collection('queue');
-    const oldQueueDocument = await queueCollection.findOne({ id: registry });
-    const oldQueue = oldQueueDocument.ops;
-    const newQueue = oldQueue.filter(item => !batch.some(op => op.operation.signature.value === item.operation.signature.value));
+    try {
+        const queueCollection = db.collection('queue');
+        const oldQueueDocument = await queueCollection.findOne({ id: registry });
+        const oldQueue = oldQueueDocument.ops;
+        const newQueue = oldQueue.filter(item => !batch.some(op => op.signature.value === item.signature.value));
 
-    await queueCollection.updateOne(
-        { id: registry },
-        { $set: { ops: newQueue } },
-        { upsert: true }
-    );
+        await queueCollection.updateOne(
+            { id: registry },
+            { $set: { ops: newQueue } },
+            { upsert: true }
+        );
+
+        return true;
+    }
+    catch (error) {
+        console.error(error);
+        return false;
+    }
 }

--- a/db-mongodb.js
+++ b/db-mongodb.js
@@ -19,32 +19,44 @@ export async function resetDb() {
     await db.collection('dids').deleteMany({});
 }
 
-export async function addOperation(op) {
-    const id = op.did.split(':').pop();
+export async function addEvent(did, event) {
+    if (!did) {
+        throw "Invalid DID";
+    }
+
+    const id = did.split(':').pop();
 
     console.time('updateOne');
     await db.collection('dids').updateOne(
         { id: id },
-        { $push: { ops: op } },
+        { $push: { events: event } },
         { upsert: true }
     );
     console.timeEnd('updateOne');
 }
 
-export async function getOperations(did) {
+export async function getEvents(did) {
+    if (!did) {
+        throw "Invalid DID";
+    }
+
     try {
         const id = did.split(':').pop();
         console.time('findOne');
         const row = await db.collection('dids').findOne({ id: id });
         console.timeEnd('findOne');
-        return row.ops;
+        return row.events;
     }
     catch {
         return [];
     }
 }
 
-export async function deleteOperations(did) {
+export async function deleteEvents(did) {
+    if (!did) {
+        throw "Invalid DID";
+    }
+
     const id = did.split(':').pop();
     await db.collection('dids').deleteOne({ id: id });
 }
@@ -55,9 +67,9 @@ export async function getAllKeys() {
     return ids;
 }
 
-export async function queueOperation(op) {
+export async function queueOperation(registry, op) {
     await db.collection('queue').updateOne(
-        { id: op.registry },
+        { id: registry },
         { $push: { ops: op } },
         { upsert: true }
     );

--- a/db-sqlite.js
+++ b/db-sqlite.js
@@ -99,10 +99,17 @@ export async function getQueue(registry) {
 }
 
 export async function clearQueue(registry, batch) {
-    const oldQueue = await getQueue(registry);
-    const newQueue = oldQueue.filter(item => !batch.some(op => op.operation.signature.value === item.operation.signature.value));
+    try {
+        const oldQueue = await getQueue(registry);
+        const newQueue = oldQueue.filter(item => !batch.some(op => op.signature.value === item.signature.value));
 
-    await db.run(`INSERT OR REPLACE INTO queue(id, ops) VALUES(?, ?)`, registry, JSON.stringify(newQueue));
+        await db.run(`INSERT OR REPLACE INTO queue(id, ops) VALUES(?, ?)`, registry, JSON.stringify(newQueue));
+        return true;
+    }
+    catch (error) {
+        console.error(error);
+        return false;
+    }
 }
 
 export async function getAllKeys() {

--- a/dc-btc.yml
+++ b/dc-btc.yml
@@ -1,0 +1,81 @@
+version: "3"
+services:
+
+  mongodb:
+    image: mongo:latest
+    volumes:
+      - ./data/db:/data/db
+
+  gatekeeper:
+    build:
+      context: .
+      dockerfile: Dockerfile.gatekeeper
+    image: keychainmdip/gatekeeper
+    environment:
+      - KC_GATEKEEPER_DB=json
+      - KC_MONGODB_URL=mongodb://mongodb:27017
+    volumes:
+      - ./data:/app/data
+    ports:
+      - "4224:4224"
+    depends_on:
+      - mongodb
+
+  hyperswarm:
+    build:
+      context: .
+      dockerfile: Dockerfile.hyperswarm
+    image: keychainmdip/hyperswarm-mediator
+    environment:
+      - KC_GATEKEEPER_URL=http://gatekeeper
+      - KC_GATEKEEPER_PORT=4224
+      - KC_NODE_NAME=${KC_NODE_NAME}
+    volumes:
+      - ./data:/app/data
+    depends_on:
+      - gatekeeper
+
+  tess-node:
+    image: macterra/tesseract-node:v21.08.03
+    ports:
+      - "7333:7333"
+      - "8333:8333"
+    volumes:
+      - ./data/tesseract:/data
+
+  tess-mediator:
+    build:
+      context: .
+      dockerfile: Dockerfile.tess
+    image: keychainmdip/tess-mediator
+    environment:
+      - KC_GATEKEEPER_URL=http://gatekeeper
+      - KC_GATEKEEPER_PORT=4224
+      - KC_TESS_HOST=tess-node
+      - KC_TESS_PORT=8333
+      - KC_TESS_USER=${KC_TESS_USER}
+      - KC_TESS_PASS=${KC_TESS_PASS}
+      - KC_TESS_ID=${KC_TESS_ID}
+    volumes:
+      - ./data:/app/data
+    depends_on:
+      - gatekeeper
+      - tess-node
+
+  btc-mediator:
+    build:
+      context: .
+      dockerfile: Dockerfile.btc
+    image: keychainmdip/btc-mediator
+    environment:
+      - KC_GATEKEEPER_URL=http://gatekeeper
+      - KC_GATEKEEPER_PORT=4224
+      - KC_NODE_ID=${KC_NODE_ID}
+      - KC_BTC_HOST=172.17.0.1
+      - KC_BTC_PORT=${KC_BTC_PORT}
+      - KC_BTC_USER=${KC_BTC_USER}
+      - KC_BTC_PASS=${KC_BTC_PASS}
+    volumes:
+      - ./data:/app/data
+    depends_on:
+      - gatekeeper

--- a/dc-btc.yml
+++ b/dc-btc.yml
@@ -76,6 +76,11 @@ services:
       - KC_BTC_USER=${KC_BTC_USER}
       - KC_BTC_PASS=${KC_BTC_PASS}
       - KC_BTC_WALLET=${KC_BTC_WALLET}
+      - KC_BTC_SCAN_INTERVAL=${KC_BTC_SCAN_INTERVAL}
+      - KC_BTC_ANCHOR_INTERVAL=${KC_BTC_ANCHOR_INTERVAL}
+      - KC_BTC_FEE_MIN=${KC_BTC_FEE_MIN}
+      - KC_BTC_FEE_MAX=${KC_BTC_FEE_MAX}
+      - KC_BTC_FEE_INC=${KC_BTC_FEE_INC}
     volumes:
       - ./data:/app/data
     depends_on:

--- a/dc-btc.yml
+++ b/dc-btc.yml
@@ -51,11 +51,11 @@ services:
     environment:
       - KC_GATEKEEPER_URL=http://gatekeeper
       - KC_GATEKEEPER_PORT=4224
+      - KC_NODE_ID=${KC_NODE_ID}
       - KC_TESS_HOST=tess-node
       - KC_TESS_PORT=8333
       - KC_TESS_USER=${KC_TESS_USER}
       - KC_TESS_PASS=${KC_TESS_PASS}
-      - KC_TESS_ID=${KC_TESS_ID}
     volumes:
       - ./data:/app/data
     depends_on:

--- a/dc-btc.yml
+++ b/dc-btc.yml
@@ -75,6 +75,7 @@ services:
       - KC_BTC_PORT=${KC_BTC_PORT}
       - KC_BTC_USER=${KC_BTC_USER}
       - KC_BTC_PASS=${KC_BTC_PASS}
+      - KC_BTC_WALLET=${KC_BTC_WALLET}
     volumes:
       - ./data:/app/data
     depends_on:

--- a/gatekeeper-sdk.js
+++ b/gatekeeper-sdk.js
@@ -27,6 +27,30 @@ export async function resetDb() {
     }
 }
 
+export async function waitUntilReady(intervalSeconds = 1, chatty = true) {
+    let ready = false;
+
+    if (chatty) {
+        console.log(`Connecting to gatekeeper at ${URL}`);
+    }
+
+    while (!ready) {
+        ready = await isReady();
+
+        if (!ready) {
+            if (chatty) {
+                console.log('Waiting for Gatekeeper to be ready...');
+            }
+            // wait for 1 second before checking again
+            await new Promise(resolve => setTimeout(resolve, intervalSeconds * 1000));
+        }
+    }
+
+    if (chatty) {
+        console.log('Gatekeeper service is ready!');
+    }
+}
+
 export async function isReady() {
     try {
         const response = await axios.get(`${URL}/api/v1/ready`);

--- a/gatekeeper-sdk.js
+++ b/gatekeeper-sdk.js
@@ -57,10 +57,10 @@ export async function createDID(operation) {
     }
 }
 
-export async function resolveDID(did, asof = null) {
+export async function resolveDID(did, asof = null, confirm = false) {
     try {
-        if (asof) {
-            const response = await axios.get(`${URL}/api/v1/did/${did}?asof=${asof}`);
+        if (asof || confirm) {
+            const response = await axios.get(`${URL}/api/v1/did/${did}?asof=${asof}&confirm=${confirm}`);
             return response.data;
         }
         else {

--- a/gatekeeper.js
+++ b/gatekeeper.js
@@ -36,7 +36,7 @@ export async function verifyDb() {
     for (const did of dids) {
         n += 1;
         try {
-            await resolveDID(did, null, true);
+            await resolveDID(did, null, false, true);
             console.log(`${n} ${did} OK`);
         }
         catch (error) {
@@ -282,7 +282,7 @@ async function verifyUpdate(operation, doc) {
     return isValid;
 }
 
-export async function resolveDID(did, asOfTime = null, verify = false) {
+export async function resolveDID(did, asOfTime = null, confirm = false, verify = false) {
     const ops = await db.getOperations(did);
 
     if (ops.length === 0) {
@@ -301,8 +301,12 @@ export async function resolveDID(did, asOfTime = null, verify = false) {
         // TBD What to return if DID was created after specified time?
     }
 
-    for (const { time, operation } of ops) {
+    for (const { time, operation, registry } of ops) {
         if (asOfTime && new Date(time) > new Date(asOfTime)) {
+            break;
+        }
+
+        if (confirm && mdip.registry !== registry) {
             break;
         }
 

--- a/gatekeeper.js
+++ b/gatekeeper.js
@@ -261,25 +261,25 @@ async function verifyUpdate(operation, doc) {
         return verifyUpdate(operation, controllerDoc);
     }
 
-    if (doc.didDocument.verificationMethod) {
-        const jsonCopy = JSON.parse(JSON.stringify(operation));
-
-        const signature = jsonCopy.signature;
-        delete jsonCopy.signature;
-        const msgHash = cipher.hashJSON(jsonCopy);
-
-        if (signature.hash && signature.hash !== msgHash) {
-            return false;
-        }
-
-        // TBD get the right signature, not just the first one
-        const publicJwk = doc.didDocument.verificationMethod[0].publicKeyJwk;
-        const isValid = cipher.verifySig(msgHash, signature.value, publicJwk);
-
-        return isValid;
+    if (!doc.didDocument.verificationMethod) {
+        return false;
     }
 
-    return false;
+    const jsonCopy = JSON.parse(JSON.stringify(operation));
+
+    const signature = jsonCopy.signature;
+    delete jsonCopy.signature;
+    const msgHash = cipher.hashJSON(jsonCopy);
+
+    if (signature.hash && signature.hash !== msgHash) {
+        return false;
+    }
+
+    // TBD get the right signature, not just the first one
+    const publicJwk = doc.didDocument.verificationMethod[0].publicKeyJwk;
+    const isValid = cipher.verifySig(msgHash, signature.value, publicJwk);
+
+    return isValid;
 }
 
 export async function resolveDID(did, asOfTime = null, verify = false) {

--- a/gatekeeper.js
+++ b/gatekeeper.js
@@ -217,6 +217,7 @@ async function generateDoc(did, anchor, asofTime) {
                 },
                 "didDocumentMetadata": {
                     "created": anchor.created,
+                    "version": 1,
                 },
                 "didDocumentData": {},
                 "mdip": anchor.mdip,
@@ -235,6 +236,7 @@ async function generateDoc(did, anchor, asofTime) {
                 },
                 "didDocumentMetadata": {
                     "created": anchor.created,
+                    "version": 1,
                 },
                 "didDocumentData": anchor.data,
                 "mdip": anchor.mdip,
@@ -301,6 +303,8 @@ export async function resolveDID(did, asOfTime = null, confirm = false, verify =
         // TBD What to return if DID was created after specified time?
     }
 
+    let version = 1;
+
     for (const { time, operation, registry } of ops) {
         if (asOfTime && new Date(time) > new Date(asOfTime)) {
             break;
@@ -337,6 +341,9 @@ export async function resolveDID(did, asOfTime = null, confirm = false, verify =
         }
 
         if (operation.type === 'update') {
+            // Increment version
+            version += 1;
+
             // Maintain mdip metadata across versions
             mdip = doc.mdip;
 
@@ -344,6 +351,7 @@ export async function resolveDID(did, asOfTime = null, confirm = false, verify =
             // fetch updates from new registry and search for same operation
             doc = operation.doc;
             doc.didDocumentMetadata.updated = time;
+            doc.didDocumentMetadata.version = version;
             doc.mdip = mdip;
         }
         else if (operation.type === 'delete') {

--- a/gatekeeper.js
+++ b/gatekeeper.js
@@ -217,7 +217,6 @@ async function generateDoc(did, anchor, asofTime) {
                 },
                 "didDocumentMetadata": {
                     "created": anchor.created,
-                    "version": 1,
                 },
                 "didDocumentData": {},
                 "mdip": anchor.mdip,
@@ -236,7 +235,6 @@ async function generateDoc(did, anchor, asofTime) {
                 },
                 "didDocumentMetadata": {
                     "created": anchor.created,
-                    "version": 1,
                 },
                 "didDocumentData": anchor.data,
                 "mdip": anchor.mdip,
@@ -304,13 +302,19 @@ export async function resolveDID(did, asOfTime = null, confirm = false, verify =
     }
 
     let version = 1;
+    let confirmed = true;
+
+    doc.didDocumentMetadata.version = version;
+    doc.didDocumentMetadata.confirmed = confirmed;
 
     for (const { time, operation, registry } of ops) {
         if (asOfTime && new Date(time) > new Date(asOfTime)) {
             break;
         }
 
-        if (confirm && mdip.registry !== registry) {
+        confirmed = confirmed && mdip.registry === registry;
+
+        if (confirm && !confirmed) {
             break;
         }
 
@@ -352,6 +356,7 @@ export async function resolveDID(did, asOfTime = null, confirm = false, verify =
             doc = operation.doc;
             doc.didDocumentMetadata.updated = time;
             doc.didDocumentMetadata.version = version;
+            doc.didDocumentMetadata.confirmed = confirmed;
             doc.mdip = mdip;
         }
         else if (operation.type === 'delete') {
@@ -359,6 +364,7 @@ export async function resolveDID(did, asOfTime = null, confirm = false, verify =
             doc.didDocumentData = {};
             doc.didDocumentMetadata.deactivated = true;
             doc.didDocumentMetadata.updated = time;
+            doc.didDocumentMetadata.confirmed = confirmed;
         }
         else {
             if (verify) {

--- a/gatekeeper.js
+++ b/gatekeeper.js
@@ -7,8 +7,8 @@ import config from './config.js';
 
 const validVersions = [1];
 const validTypes = ['agent', 'asset'];
-const validRegistries = ['local', 'hyperswarm', 'TESS'];
-const queueRegistries = ['TESS'];
+const validRegistries = ['local', 'hyperswarm', 'TESS', 'BTC'];
+const queueRegistries = ['TESS', 'BTC'];
 
 let db = null;
 let helia = null;

--- a/gatekeeper.test.js
+++ b/gatekeeper.test.js
@@ -768,7 +768,7 @@ describe('importDID', () => {
             await gatekeeper.importDID([1, 2, 3]);
             throw 'Expected to throw an exception';
         } catch (error) {
-            expect(error).toBe('Invalid operation');
+            expect(error).toBe('Invalid import');
         }
     });
 });

--- a/gatekeeper.test.js
+++ b/gatekeeper.test.js
@@ -236,6 +236,7 @@ describe('resolveDID', () => {
             didDocumentMetadata: {
                 created: expect.any(String),
                 version: 1,
+                confirmed: true,
             },
             mdip: agentOp.mdip,
         };
@@ -279,6 +280,52 @@ describe('resolveDID', () => {
                 created: expect.any(String),
                 updated: expect.any(String),
                 version: 2,
+                confirmed: true,
+            },
+            mdip: agentOp.mdip,
+        };
+
+        expect(ok).toBe(true);
+        expect(updatedDoc).toStrictEqual(expected);
+    });
+
+    it('should resolve unconfirmed updates when allowed', async () => {
+
+        mockFs({});
+
+        const keypair = cipher.generateRandomJwk();
+        const agentOp = await createAgentOp(keypair, 1, 'BTC'); // Specify BTC registry for this agent
+        const did = await gatekeeper.createDID(agentOp);
+        const doc = await gatekeeper.resolveDID(did);
+        doc.didDocumentData = { mock: 1 };
+        const updateOp = await createUpdateOp(keypair, did, doc);
+        const ok = await gatekeeper.updateDID(updateOp);
+        const updatedDoc = await gatekeeper.resolveDID(did);
+        const expected = {
+            "@context": "https://w3id.org/did-resolution/v1",
+            didDocument: {
+                "@context": [
+                    "https://www.w3.org/ns/did/v1",
+                ],
+                authentication: [
+                    "#key-1",
+                ],
+                id: did,
+                verificationMethod: [
+                    {
+                        controller: did,
+                        id: "#key-1",
+                        publicKeyJwk: agentOp.publicJwk,
+                        type: "EcdsaSecp256k1VerificationKey2019",
+                    },
+                ],
+            },
+            didDocumentData: doc.didDocumentData,
+            didDocumentMetadata: {
+                created: expect.any(String),
+                updated: expect.any(String),
+                version: 2,
+                confirmed: false,
             },
             mdip: agentOp.mdip,
         };
@@ -322,6 +369,7 @@ describe('resolveDID', () => {
             didDocumentMetadata: {
                 created: expect.any(String),
                 version: 1,
+                confirmed: true,
             },
             mdip: agentOp.mdip,
         };
@@ -352,6 +400,7 @@ describe('resolveDID', () => {
             didDocumentMetadata: {
                 created: expect.any(String),
                 version: 1,
+                confirmed: true,
             },
             mdip: assetOp.mdip,
         };

--- a/gatekeeper.test.js
+++ b/gatekeeper.test.js
@@ -235,6 +235,7 @@ describe('resolveDID', () => {
             didDocumentData: {},
             didDocumentMetadata: {
                 created: expect.any(String),
+                version: 1,
             },
             mdip: agentOp.mdip,
         };
@@ -277,6 +278,7 @@ describe('resolveDID', () => {
             didDocumentMetadata: {
                 created: expect.any(String),
                 updated: expect.any(String),
+                version: 2,
             },
             mdip: agentOp.mdip,
         };
@@ -319,6 +321,7 @@ describe('resolveDID', () => {
             didDocumentData: {},
             didDocumentMetadata: {
                 created: expect.any(String),
+                version: 1,
             },
             mdip: agentOp.mdip,
         };
@@ -348,6 +351,7 @@ describe('resolveDID', () => {
             didDocumentData: assetOp.data,
             didDocumentMetadata: {
                 created: expect.any(String),
+                version: 1,
             },
             mdip: assetOp.mdip,
         };
@@ -441,12 +445,13 @@ describe('updateDID', () => {
         const ok = await gatekeeper.updateDID(updateOp);
         const updatedDoc = await gatekeeper.resolveDID(did);
         doc.didDocumentMetadata.updated = expect.any(String);
+        doc.didDocumentMetadata.version = 2;
 
         expect(ok).toBe(true);
         expect(updatedDoc).toStrictEqual(doc);
     });
 
-    it('should return false if update doc is invalid', async () => {
+    it('should return false if update operation is invalid', async () => {
         mockFs({});
 
         const keypair = cipher.generateRandomJwk();

--- a/gatekeeper.test.js
+++ b/gatekeeper.test.js
@@ -199,6 +199,78 @@ describe('createDID', () => {
     });
 });
 
+
+describe('resolveDID', () => {
+
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should resolve a valid agent DID', async () => {
+        mockFs({});
+
+        const keypair = cipher.generateRandomJwk();
+        const agentOp = await createAgentOp(keypair);
+        const did = await gatekeeper.createDID(agentOp);
+        const doc = await gatekeeper.resolveDID(did);
+        const expected = {
+            "@context": "https://w3id.org/did-resolution/v1",
+            didDocument: {
+                "@context": [
+                    "https://www.w3.org/ns/did/v1",
+                ],
+                authentication: [
+                    "#key-1",
+                ],
+                id: did,
+                verificationMethod: [
+                    {
+                        controller: did,
+                        id: "#key-1",
+                        publicKeyJwk: agentOp.publicJwk,
+                        type: "EcdsaSecp256k1VerificationKey2019",
+                    },
+                ],
+            },
+            didDocumentData: {},
+            didDocumentMetadata: {
+                created: expect.any(String),
+            },
+            mdip: agentOp.mdip,
+        };
+
+        expect(doc).toStrictEqual(expected);
+    });
+
+    it('should resolve a valid asset DID', async () => {
+        mockFs({});
+
+        const keypair = cipher.generateRandomJwk();
+        const agentOp = await createAgentOp(keypair);
+        const agent = await gatekeeper.createDID(agentOp);
+        const assetOp = await createAssetOp(agent, keypair);
+        const did = await gatekeeper.createDID(assetOp);
+        const doc = await gatekeeper.resolveDID(did);
+        const expected = {
+            "@context": "https://w3id.org/did-resolution/v1",
+            didDocument: {
+                "@context": [
+                    "https://www.w3.org/ns/did/v1",
+                ],
+                id: did,
+                controller: assetOp.controller,
+            },
+            didDocumentData: assetOp.data,
+            didDocumentMetadata: {
+                created: expect.any(String),
+            },
+            mdip: assetOp.mdip,
+        };
+
+        expect(doc).toStrictEqual(expected);
+    });
+});
+
 describe('exportDID', () => {
 
     afterEach(() => {

--- a/gatekeeper.test.js
+++ b/gatekeeper.test.js
@@ -269,6 +269,73 @@ describe('resolveDID', () => {
 
         expect(doc).toStrictEqual(expected);
     });
+
+    it('should not resolve an invalid DID', async () => {
+        mockFs({});
+
+        try {
+            await gatekeeper.resolveDID();
+            throw 'Expected to throw an exception';
+        } catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+
+        try {
+            await gatekeeper.resolveDID('');
+            throw 'Expected to throw an exception';
+        } catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+
+        try {
+            await gatekeeper.resolveDID('mock');
+            throw 'Expected to throw an exception';
+        } catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+
+        try {
+            await gatekeeper.resolveDID([]);
+            throw 'Expected to throw an exception';
+        } catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+
+        try {
+            await gatekeeper.resolveDID([1, 2, 3]);
+            throw 'Expected to throw an exception';
+        } catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+
+        try {
+            await gatekeeper.resolveDID({});
+            throw 'Expected to throw an exception';
+        } catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+
+        try {
+            await gatekeeper.resolveDID({ mock: 1 });
+            throw 'Expected to throw an exception';
+        } catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+
+        try {
+            await gatekeeper.resolveDID('did:mdip:xxx');
+            throw 'Expected to throw an exception';
+        } catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+
+        try {
+            await gatekeeper.resolveDID('did:mdip:test:z3v8Auah2NPDigFc3qKx183QKL6vY8fJYQk6NeLz7KF2RFtC9c8');
+            throw 'Expected to throw an exception';
+        } catch (error) {
+            expect(error).toBe('Invalid DID');
+        }
+    });
 });
 
 describe('exportDID', () => {

--- a/gatekeeper.test.js
+++ b/gatekeeper.test.js
@@ -531,7 +531,7 @@ describe('exportDID', () => {
         const ops = await gatekeeper.exportDID(did);
 
         expect(ops.length).toBe(1);
-        expect(ops[0].did).toStrictEqual(did);
+        //expect(ops[0].did).toStrictEqual(did);
         expect(ops[0].operation).toStrictEqual(agentOp);
     });
 
@@ -548,9 +548,9 @@ describe('exportDID', () => {
         const ops = await gatekeeper.exportDID(did);
 
         expect(ops.length).toBe(2);
-        expect(ops[0].did).toStrictEqual(did);
+        //expect(ops[0].did).toStrictEqual(did);
         expect(ops[0].operation).toStrictEqual(agentOp);
-        expect(ops[1].did).toStrictEqual(did);
+        //expect(ops[1].did).toStrictEqual(did);
         expect(ops[1].operation).toStrictEqual(updateOp);
     });
 
@@ -706,26 +706,6 @@ describe('importDID', () => {
         const doc = await gatekeeper.resolveDID(did);
 
         expect(doc.didDocument.id).toBe(did);
-    });
-
-    it('should throw an exception on mismatched DID in export', async () => {
-        mockFs({});
-
-        const keypair = cipher.generateRandomJwk();
-        const agentOp1 = await createAgentOp(keypair);
-        const did1 = await gatekeeper.createDID(agentOp1);
-        const agentOp2 = await createAgentOp(keypair);
-        const did2 = await gatekeeper.createDID(agentOp2);
-        const ops = await gatekeeper.exportDID(did1);
-
-        ops[0].did = did2;
-
-        try {
-            await gatekeeper.importDID(ops);
-            throw 'Expected to throw an exception';
-        } catch (error) {
-            expect(error).toBe('Invalid operation');
-        }
     });
 
     it('should throw an exception on undefined', async () => {

--- a/hyperswarm-mediator.js
+++ b/hyperswarm-mediator.js
@@ -10,7 +10,7 @@ import config from './config.js';
 
 EventEmitter.defaultMaxListeners = 100;
 
-const protocol = '/MDIP/v22.05.01';
+const protocol = '/MDIP/v22.05.06';
 const swarm = new Hyperswarm();
 const peerName = b4a.toString(swarm.keyPair.publicKey, 'hex');
 

--- a/hyperswarm-mediator.js
+++ b/hyperswarm-mediator.js
@@ -10,7 +10,7 @@ import config from './config.js';
 
 EventEmitter.defaultMaxListeners = 100;
 
-const protocol = '/MDIP/v22.04.23';
+const protocol = '/MDIP/v22.05.01';
 const swarm = new Hyperswarm();
 const peerName = b4a.toString(swarm.keyPair.publicKey, 'hex');
 

--- a/hyperswarm-mediator.js
+++ b/hyperswarm-mediator.js
@@ -228,8 +228,8 @@ async function start() {
     }, 30000);
 }
 
-function main() {
-    console.log(`connecting to gatekeeper at ${gatekeeper.URL}`);
+async function main() {
+    await gatekeeper.waitUntilReady();
 
     const discovery = swarm.join(topic, { client: true, server: true });
 

--- a/keychain-cli.js
+++ b/keychain-cli.js
@@ -200,11 +200,11 @@ program
     });
 
 program
-    .command('resolve-did <did>')
+    .command('resolve-did <did> [confirm]')
     .description('Return document associated with DID')
-    .action(async (did) => {
+    .action(async (did, confirm) => {
         try {
-            const doc = await keymaster.resolveDID(did);
+            const doc = await keymaster.resolveDID(did, null, !!confirm);
             console.log(JSON.stringify(doc, null, 4));
         }
         catch (error) {

--- a/keymaster.js
+++ b/keymaster.js
@@ -377,8 +377,8 @@ function addToHeld(did) {
     return true;
 }
 
-export async function resolveDID(did, asof) {
-    const doc = await gatekeeper.resolveDID(lookupDID(did), asof);
+export async function resolveDID(did, asof, confirm) {
+    const doc = await gatekeeper.resolveDID(lookupDID(did), asof, confirm);
     return doc;
 }
 

--- a/keymaster.test.js
+++ b/keymaster.test.js
@@ -1121,13 +1121,13 @@ describe('revokeCredential', () => {
         const ok = await keymaster.revokeCredential(did);
         expect(ok).toBe(true);
 
-        const userTxns = await keymaster.exportDID(userDid);
-        const ops = await keymaster.exportDID(did);
+        const userExport = await keymaster.exportDID(userDid);
+        const credentialExport = await keymaster.exportDID(did);
 
         await gatekeeper.resetDb();
 
-        await keymaster.importDID(userTxns);
-        const imported = await keymaster.importDID(ops);
+        await keymaster.importDID(userExport);
+        const imported = await keymaster.importDID(credentialExport);
 
         expect(imported).toBe(2);
     });

--- a/server.js
+++ b/server.js
@@ -62,7 +62,7 @@ v1router.post('/did', async (req, res) => {
 
 v1router.get('/did/:did', async (req, res) => {
     try {
-        const doc = await gatekeeper.resolveDID(req.params.did, req.query.asof);
+        const doc = await gatekeeper.resolveDID(req.params.did, req.query.asof, req.query.confirm);
         res.json(doc);
     } catch (error) {
         console.error(error);

--- a/start-node.sh
+++ b/start-node.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
-docker compose -f dc-tess.yml build
-docker compose -f dc-tess.yml up
+docker compose -f dc-btc.yml build
+docker compose -f dc-btc.yml up

--- a/stop-node.sh
+++ b/stop-node.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-docker compose -f dc-tess.yml down
+docker compose -f dc-btc.yml down

--- a/sync-node.sh
+++ b/sync-node.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-docker compose -f dc-tess.yml up tess-node

--- a/tess-mediator.js
+++ b/tess-mediator.js
@@ -158,16 +158,16 @@ async function importBatch() {
             const batch = [];
 
             for (let i = 0; i < queue.length; i++) {
-                const blockTime = new Date(item.time);
-
                 batch.push({
                     registry: 'TESS',
-                    time: blockTime.toISOString(),
-                    ordinal: [blockTime.getTime(), item.index, i],
+                    time: item.time,
+                    ordinal: [item.height, item.index, i],
                     operation: queue[i],
                     blockchain : {
                         height: item.height,
+                        index: item.index,
                         txid: item.txid,
+                        batch: item.did,
                     }
                 });
             }

--- a/workflow.js
+++ b/workflow.js
@@ -18,12 +18,6 @@ const mockSchema = {
 };
 
 async function runWorkflow() {
-    const walletFile = 'data/wallet.json';
-    const backupFile = 'data/workflow-backup.json';
-
-    if (fs.existsSync(walletFile)) {
-        fs.renameSync(walletFile, backupFile);
-    }
 
     await db_json.start('mdip-workflow');
     await gatekeeper.start(db_json);
@@ -151,6 +145,23 @@ async function runWorkflow() {
 
     keymaster.stop();
 
+}
+
+async function main() {
+    const walletFile = 'data/wallet.json';
+    const backupFile = 'data/workflow-backup.json';
+
+    if (fs.existsSync(walletFile)) {
+        fs.renameSync(walletFile, backupFile);
+    }
+
+    try {
+        await runWorkflow();
+    }
+    catch (error) {
+        console.log(error);
+    }
+
     fs.rmSync(walletFile);
 
     if (fs.existsSync(backupFile)) {
@@ -160,4 +171,4 @@ async function runWorkflow() {
     process.exit();
 }
 
-runWorkflow();
+main();

--- a/workflow.js
+++ b/workflow.js
@@ -113,8 +113,8 @@ async function runWorkflow() {
 
     keymaster.useId('Victor');
 
-    const vcList = await keymaster.verifyResponse(vpDid);
-    console.log(`Victor verified response ${vcList.length} valid credentials`);
+    const verify1 = await keymaster.verifyResponse(vpDid, challengeDid);
+    console.log(`Victor verified response ${verify1.vps.length} valid credentials`);
 
     keymaster.useId('Alice');
     await keymaster.rotateKeys();
@@ -130,24 +130,24 @@ async function runWorkflow() {
 
     console.log(`All agents rotated their keys`);
 
-    const vcList2 = await keymaster.verifyResponse(vpDid);
-    console.log(`Victor verified response ${vcList2.length} valid credentials`);
+    const verify2 = await keymaster.verifyResponse(vpDid, challengeDid);
+    console.log(`Victor verified response ${verify2.vps.length} valid credentials`);
 
     keymaster.useId('Alice');
     await keymaster.revokeCredential(vc1);
     console.log(`Alice revoked vc1`);
 
     keymaster.useId('Victor');
-    const vcList3 = await keymaster.verifyResponse(vpDid);
-    console.log(`Victor verified response ${vcList3.length} valid credentials`);
+    const verify3 = await keymaster.verifyResponse(vpDid, challengeDid);
+    console.log(`Victor verified response ${verify3.vps.length} valid credentials`);
 
     keymaster.useId('Bob');
     await keymaster.revokeCredential(vc3);
     console.log(`Bob revoked vc3`);
 
     keymaster.useId('Victor');
-    const vcList4 = await keymaster.verifyResponse(vpDid);
-    console.log(`Victor verified response ${vcList4.length} valid credentials`);
+    const verify4 = await keymaster.verifyResponse(vpDid, challengeDid);
+    console.log(`Victor verified response ${verify4.vps.length} valid credentials`);
 
     keymaster.stop();
 


### PR DESCRIPTION
Adds a BTC mediator to the node
- Relies on an external BTC node
  - The BTC node must have indexing enabled (`txindex=1`) 
  - The BTC node must have RPC access enabled (e.g. `rpcuser=[username]`, `rpcpassword=[password]`, `rpcport=8332`, `rpcbind=0.0.0.0`, `rpcallowip=0.0.0.0/0`) 
  - The BTC node should have a wallet loaded on startup (e.g. `wallet=beta`)
- The following environment variables should be define in a local `.env` file:
```
KC_BTC_HOST=localhost
KC_BTC_PORT=8332
KC_BTC_USER=username
KC_BTC_PASS=password
KC_BTC_WALLET=beta
KC_BTC_IMPORT_INTERVAL=1
KC_BTC_EXPORT_INTERVAL=15
KC_BTC_FEE_MIN=0.00001500
KC_BTC_FEE_MAX=0.00020000
KC_BTC_FEE_INC=0.00001000
KC_NODE_ID=satoshi
```
Change the values of the first 5 to correspond to the BTC node configuration.

- `KC_BTC_IMPORT_INTERVAL` defines the number of minutes between block scans. 
- `KC_BTC_EXPORT_INTERVAL` defines the number of minutes between gatekeeper queue scans. If the queue for BTC is non-empty, the mediator will create a batch DID, and anchor it on a new BTC transaction, and broadcast it to the network. The mediator will NOT create a new txn if previously created txn has not yet been confirmed. Instead, it will bump the txn fee by an incremental amount (defined below) and retransmit the txn using RBF (replace-by-fee). 
- `KC_BTC_FEE_MIN` defines the initial txn fee in BTC. 
- `KC_BTC_FEE_MAX` defines the maximum txn fee in BTC.
- `KC_BTC_FEE_INC` defines the incremental txn fee (RBF) in BTC. 
- `KC_NODE_ID` defines the name of the agent id that is used to create batch DIDs. (Also used by tess-mediator now)

Be careful specifying the fee parameters. It is recommended that you calculate a theoretical maximum fee expenditure, e.g. using the values defined above it is possible to spend 1500 sats every 15 minutes, or 144000 sats/day.

Upgrading

This is a breaking change, so start by removing current DID data and wallets. A utility script `clean-data.sh` is provided to make this easy. The script will not reset an external mongodb database if that is used.

Before starting the full node with TESS and BTC mediators, sync the node to hyperswarm. Start with `docker compose up` or `docker compose -f dc-mongodb.yml up` if you are using mongo. Create the node id specified in `KC_NODE_ID`.

Once synced, shut down the node and restart with `sh start-node.sh`. The TESS and BTC mediators may take some time to scan the recent blocks before starting to import/export anchored DIDs.
