### PR TITLE
Run as daemon (not tied to teminal session)

### DIFF
--- a/start-node.sh
+++ b/start-node.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 docker compose -f dc-btc.yml build
-docker compose -f dc-btc.yml up
+docker compose -f dc-btc.yml up -d


### PR DESCRIPTION
Adds the `-d` flag to the `start-node.sh` script, so that the process is persistent if the terminal session is ended.