### PR TITLE
enables parallel keymasters on individual ports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tmp/
 ipfs/
 .env
 last-compose-file.txt
+custodials

--- a/config.js
+++ b/config.js
@@ -7,6 +7,7 @@ const config = {
     gatekeeperPort: process.env.KC_GATEKEEPER_PORT ? parseInt(process.env.KC_GATEKEEPER_PORT) : 4224,
     gatekeeperURL: process.env.KC_GATEKEEPER_URL || 'http://localhost',
     gatekeeperDb: process.env.KC_GATEKEEPER_DB || 'json',
+    keymasterPort: process.env.KC_KEYMASTER_PORT ? parseInt(process.env.KC_KEYMASTER_PORT) : 4226,
     nodeName: process.env.KC_NODE_NAME || 'anon',
     nodeID: process.env.KC_NODE_ID,
     mongodbUrl: process.env.KC_MONGODB_URL || 'mongodb://localhost:27017',

--- a/kc-app/src/App.js
+++ b/kc-app/src/App.js
@@ -49,18 +49,15 @@ function App() {
                 setCurrentDID(docs.didDocument.id);
                 setDocsString(JSON.stringify(docs, null, 4));
 
-                const registries = await keymaster.listRegistries();
-                setRegistries(registries);
-
                 refreshNames();
 
                 setTab('identity');
             }
             else {
-                const registries = await keymaster.listRegistries();
-                setRegistries(registries);
                 setTab('create');
             }
+            const registries = await keymaster.listRegistries();
+            setRegistries(registries);
         } catch (error) {
             window.alert(error);
         }

--- a/kc-app/src/App.js
+++ b/kc-app/src/App.js
@@ -57,6 +57,8 @@ function App() {
                 setTab('identity');
             }
             else {
+                const registries = await keymaster.listRegistries();
+                setRegistries(registries);
                 setTab('create');
             }
         } catch (error) {

--- a/keymaster-api.js
+++ b/keymaster-api.js
@@ -4,7 +4,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import * as gatekeeper from './gatekeeper-sdk.js';
 import * as keymaster from './keymaster-lib.js';
-
+import config from './config.js';
 const app = express();
 const v1router = express.Router();
 
@@ -263,7 +263,7 @@ process.on('unhandledRejection', (reason, promise) => {
     //console.error('Unhandled rejection caught');
 });
 
-const port = 4226;
+const port = config.keymasterPort;
 
 app.listen(port, async () => {
     await keymaster.start(gatekeeper);


### PR DESCRIPTION
@macterra - I had to make these edits to enable parallel keymaster containers running on their individual ports while sharing a common gatekeeper process.

With this change, I'm able to easily provision new "Keymasters" with the following simple docker compose file. In my current deployment, I put the additional keymasters in seperate ./custodials/account-name folders.

```
version: "3"
services:

  keymaster-flaxscrip:
    build:
      context: ../..
      dockerfile: Dockerfile.keymaster
    image: keychainmdip/keymaster
    environment:
      - KC_GATEKEEPER_URL=http://172.17.0.1
      - KC_GATEKEEPER_PORT=4224
      - KC_KEYMASTER_PORT=4240
    volumes:
      - ./data:/app/data
    ports:
      - "4240:4240"
```