### PR TITLE
Add hyperswarm DID garbage collection

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,6 +59,17 @@ jobs:
             ${{ env.REGISTRY }}/keychainmdip/gatekeeper:release
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Build and push keymaster image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          file: Dockerfile.keymaster
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/keychainmdip/keymaster:${{ steps.calver.outputs.version }}
+            ${{ env.REGISTRY }}/keychainmdip/keymaster:release
+          labels: ${{ steps.meta.outputs.labels }}
+
       - name: Build and push hyperswarm mediator image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:

--- a/admin-cli.js
+++ b/admin-cli.js
@@ -125,13 +125,13 @@ program
     });
 
 program
-    .command('clear-queue <batch>')
+    .command('clear-queue <registry> <batch>')
     .description('Clear a registry queue')
-    .action(async (batch) => {
+    .action(async (registry, batch) => {
         try {
             const events = await keymaster.resolveAsset(batch);
             console.log(JSON.stringify(events, null, 4));
-            const ok = await gatekeeper.clearQueue(events);
+            const ok = await gatekeeper.clearQueue(registry, events);
 
             if (ok) {
                 console.log("Batch cleared");

--- a/btc-mediator.js
+++ b/btc-mediator.js
@@ -277,7 +277,7 @@ async function anchorBatch() {
         const txid = await createOpReturnTxn(did);
 
         if (txid) {
-            const ok = await gatekeeper.clearQueue(batch);
+            const ok = await gatekeeper.clearQueue(REGISTRY, batch);
 
             if (ok) {
                 const db = loadDb();

--- a/gatekeeper-api.js
+++ b/gatekeeper-api.js
@@ -123,6 +123,17 @@ v1router.post('/export-dids', async (req, res) => {
     }
 });
 
+v1router.post('/remove-dids', async (req, res) => {
+    try {
+        const dids = req.body;
+        const response = await gatekeeper.removeDIDs(dids);
+        res.json(response);
+    } catch (error) {
+        console.error(error);
+        res.status(500).send(error.toString());
+    }
+});
+
 v1router.post('/import-batch', async (req, res) => {
     try {
         const batch = req.body;

--- a/gatekeeper-api.js
+++ b/gatekeeper-api.js
@@ -155,10 +155,10 @@ v1router.get('/queue/:registry', async (req, res) => {
     }
 });
 
-v1router.post('/queue/clear', async (req, res) => {
+v1router.post('/queue/:registry/clear', async (req, res) => {
     try {
         const events = req.body;
-        const queue = await gatekeeper.clearQueue(events);
+        const queue = await gatekeeper.clearQueue(req.params.registry, events);
         res.json(queue);
     } catch (error) {
         console.error(error);

--- a/gatekeeper-lib.js
+++ b/gatekeeper-lib.js
@@ -416,6 +416,12 @@ export async function exportDIDs(dids) {
     return batch;
 }
 
+export async function removeDIDs(dids) {
+    for (const did of dids) {
+        await db.deleteEvents(did);
+    }
+}
+
 async function importCreateEvent(event) {
     try {
         const valid = await verifyCreate(event.operation);

--- a/gatekeeper-lib.js
+++ b/gatekeeper-lib.js
@@ -151,6 +151,10 @@ export async function createDID(operation) {
             });
 
             await db.queueOperation(operation.mdip.registry, operation);
+
+            if (operation.mdip.registry !== 'hyperswarm') {
+                await db.queueOperation('hyperswarm', operation);
+            }
         }
 
         return did;
@@ -384,6 +388,10 @@ export async function updateDID(operation) {
 
         await db.queueOperation(registry, operation);
 
+        if (registry !== 'hyperswarm') {
+            await db.queueOperation('hyperswarm', operation);
+        }
+
         return true;
     }
     catch (error) {
@@ -566,8 +574,7 @@ export async function getQueue(registry) {
     return queue;
 }
 
-export async function clearQueue(events) {
-    const registry = events[0].mdip.registry;
+export async function clearQueue(registry, events) {
     const ok = db.clearQueue(registry, events);
     return ok;
 }

--- a/gatekeeper-sdk.js
+++ b/gatekeeper-sdk.js
@@ -157,6 +157,16 @@ export async function exportDIDs(dids) {
     }
 }
 
+export async function removeDIDs(dids) {
+    try {
+        const response = await axios.post(`${URL}/api/v1/remove-dids`, dids);
+        return response.data;
+    }
+    catch (error) {
+        throwError(error);
+    }
+}
+
 export async function importBatch(batch) {
     try {
         const response = await axios.post(`${URL}/api/v1/import-batch/`, batch);

--- a/gatekeeper-sdk.js
+++ b/gatekeeper-sdk.js
@@ -187,9 +187,9 @@ export async function getQueue(registry) {
     }
 }
 
-export async function clearQueue(events) {
+export async function clearQueue(registry, events) {
     try {
-        const response = await axios.post(`${URL}/api/v1/queue/clear`, events);
+        const response = await axios.post(`${URL}/api/v1/queue/${registry}/clear`, events);
         return response.data;
     }
     catch (error) {

--- a/hyperswarm-mediator.js
+++ b/hyperswarm-mediator.js
@@ -316,6 +316,8 @@ async function collectGarbage() {
     const expired = [];
 
     for (const did of didList) {
+        console.log(`gc check: ${did}`);
+
         const doc = await gatekeeper.resolveDID(did);
         const now = new Date();
         const created = new Date(doc.didDocumentMetadata.created);

--- a/hyperswarm-mediator.js
+++ b/hyperswarm-mediator.js
@@ -12,7 +12,9 @@ import config from './config.js';
 EventEmitter.defaultMaxListeners = 100;
 
 const REGISTRY = 'hyperswarm';
-const protocol = '/MDIP/v22.05.28';
+const BATCH_SIZE = 100;
+const PROTOCOL = '/MDIP/v22.05.28';
+
 const swarm = new Hyperswarm();
 const peerName = b4a.toString(swarm.keyPair.publicKey, 'hex');
 
@@ -93,7 +95,7 @@ async function initializeBatchesSeen() {
     for (const events of batch) {
         chunk.push(events);
 
-        if (chunk.length >= 100) {
+        if (chunk.length >= BATCH_SIZE) {
             cacheBatch(chunk);
             chunk = [];
         }
@@ -172,7 +174,7 @@ async function mergeBatch(batch) {
     for (const events of batch) {
         chunk.push(events);
 
-        if (chunk.length >= 100) {
+        if (chunk.length >= BATCH_SIZE) {
             await importBatch(chunk);
             chunk = [];
         }
@@ -364,13 +366,13 @@ process.stdin.on('data', d => {
 });
 
 // Join a common topic
-const hash = sha256(protocol);
+const hash = sha256(PROTOCOL);
 const networkID = Buffer.from(hash).toString('hex');
 const topic = b4a.from(networkID, 'hex');
 
 async function start() {
     console.log(`hyperswarm peer id: ${shortName(peerName)} (${config.nodeName})`);
-    console.log(`joined topic: ${shortName(b4a.toString(topic, 'hex'))} using protocol: ${protocol}`);
+    console.log(`joined topic: ${shortName(b4a.toString(topic, 'hex'))} using protocol: ${PROTOCOL}`);
     exportLoop();
     pingLoop();
     gcLoop();

--- a/hyperswarm-mediator.js
+++ b/hyperswarm-mediator.js
@@ -275,7 +275,7 @@ async function flushQueue() {
 
         await relayMsg(msg);
         await importBatch(batch);
-        await gatekeeper.clearQueue(queue);
+        await gatekeeper.clearQueue(REGISTRY, queue);
     }
     else {
         console.log('empty queue');

--- a/hyperswarm-mediator.js
+++ b/hyperswarm-mediator.js
@@ -292,20 +292,16 @@ async function exportLoop() {
     setTimeout(exportLoop, 10 * 1000);
 }
 
-async function pingConnections() {
-    const msg = {
-        type: 'ping',
-        time: new Date().toISOString(),
-        relays: [],
-        node: config.nodeName,
-    };
-
-    await relayMsg(msg);
-}
-
 async function pingLoop() {
     try {
-        await pingConnections();
+        const msg = {
+            type: 'ping',
+            time: new Date().toISOString(),
+            relays: [],
+            node: config.nodeName,
+        };
+
+        await relayMsg(msg);
         console.log('ping loop waiting 60s...');
     } catch (error) {
         console.error(`Error in pingLoop: ${error}`);

--- a/tess-mediator.js
+++ b/tess-mediator.js
@@ -192,7 +192,7 @@ async function anchorBatch() {
         const txid = await createOpReturnTxn(did);
 
         if (txid) {
-            const ok = await gatekeeper.clearQueue(batch);
+            const ok = await gatekeeper.clearQueue(REGISTRY, batch);
 
             if (ok) {
                 const db = loadDb();


### PR DESCRIPTION
Adds garbage collection to hyperswarm-mediator
- gc is triggered at startup, and every 10 minutes after
- a DID is removed from the gatekeeper db if the following criteria are met
  - registered on hyperswarm
  - type asset (not agent)
  - created <24 hours ago

This PR also fixes an issue with clearing registry queues