### PR TITLE
Hyperswarm mediator removes stale connections

### DIFF
--- a/admin-cli.js
+++ b/admin-cli.js
@@ -10,6 +10,19 @@ program
     .configureHelp({ sortSubcommands: true });
 
 program
+    .command('resolve-did <did> [confirm]')
+    .description('Return document associated with DID')
+    .action(async (did, confirm) => {
+        try {
+            const doc = await gatekeeper.resolveDID(did, null, !!confirm);
+            console.log(JSON.stringify(doc, null, 4));
+        }
+        catch (error) {
+            console.error(`cannot resolve ${did}`);
+        }
+    });
+
+program
     .command('get-dids')
     .description('Fetch all DIDs')
     .action(async () => {

--- a/gatekeeper-lib.js
+++ b/gatekeeper-lib.js
@@ -38,7 +38,7 @@ export async function verifyDID(did) {
         const controller = await resolveDID(doc.didDocument.controller);
 
         if (controller.mdip.registry === 'local' && doc.mdip.registry !== 'local') {
-            console.log(`registry mistmatch ${JSON.stringify(doc, null, 4)}`);
+            throw "Registry mistmatch";
         }
     }
 }

--- a/gatekeeper-lib.js
+++ b/gatekeeper-lib.js
@@ -8,7 +8,6 @@ import config from './config.js';
 const validVersions = [1];
 const validTypes = ['agent', 'asset'];
 const validRegistries = ['local', 'hyperswarm', 'TESS'];
-//const queueRegistries = ['TESS'];
 
 let db = null;
 let helia = null;
@@ -32,6 +31,18 @@ export async function stop() {
     await db.stop();
 }
 
+export async function verifyDID(did) {
+    const doc = await resolveDID(did, null, false, true);
+
+    if (doc.didDocument.controller) {
+        const controller = await resolveDID(doc.didDocument.controller);
+
+        if (controller.mdip.registry === 'local' && doc.mdip.registry !== 'local') {
+            console.log(`registry mistmatch ${JSON.stringify(doc, null, 4)}`);
+        }
+    }
+}
+
 export async function verifyDb() {
     const dids = await db.getAllKeys();
     let n = 0;
@@ -40,7 +51,7 @@ export async function verifyDb() {
     for (const did of dids) {
         n += 1;
         try {
-            await resolveDID(did, null, false, true);
+            await verifyDID(did);
             console.log(`${n} ${did} OK`);
         }
         catch (error) {
@@ -171,7 +182,7 @@ export async function createDID(operation) {
     }
 }
 
-async function generateDoc(did, anchor, asofTime) {
+async function generateDoc(anchor, asofTime) {
     try {
         if (!anchor?.mdip) {
             return {};
@@ -192,6 +203,8 @@ async function generateDoc(did, anchor, asofTime) {
         if (!validRegistries.includes(anchor.mdip.registry)) {
             return {};
         }
+
+        const did = await anchorSeed(anchor);
 
         if (anchor.mdip.type === 'agent') {
             // TBD support different key types?
@@ -287,7 +300,7 @@ export async function resolveDID(did, asOfTime = null, confirm = false, verify =
     }
 
     const anchor = events[0];
-    let doc = await generateDoc(did, anchor.operation);
+    let doc = await generateDoc(anchor.operation);
     let mdip = doc?.mdip;
 
     if (!mdip) {

--- a/hyperswarm-mediator.js
+++ b/hyperswarm-mediator.js
@@ -14,7 +14,7 @@ EventEmitter.defaultMaxListeners = 100;
 
 const REGISTRY = 'hyperswarm';
 const BATCH_SIZE = 100;
-const PROTOCOL = '/MDIP/v22.06.19';
+const PROTOCOL = '/MDIP/v22.06.20';
 
 const nodes = {};
 const batchesSeen = {};

--- a/hyperswarm-mediator.js
+++ b/hyperswarm-mediator.js
@@ -96,9 +96,20 @@ async function createBatch() {
     console.timeEnd('exportDIDs');
     console.log(`${exports.length} DIDs fetched`);
 
-    const events = exports.flat();
-    let operations = events.map(event => event.operation);
-    operations = operations.sort((a, b) => new Date(a.signature.signed) - new Date(b.signature.signed));
+    const operations = exports.flat()
+        .map(event => event.operation)
+        .filter(op => { // filter out local events
+            if (op.mdip) {
+                return op.mdip.registry !== 'local';
+            }
+
+            if (op.doc.mdip) {
+                return op.doc.mdip.registry !== 'local';
+            }
+
+            return false;
+        })
+        .sort((a, b) => new Date(a.signature.signed) - new Date(b.signature.signed));
 
     return operations;
 }


### PR DESCRIPTION
Significant refactor of the hyperswarm-mediator to improve resilience
- Connections that haven't pinged in >3 minutes are dropped
- The mediator will reconnect to swarm with a new ID if all connections are dropped
- Adds logging for connection changes

Also includes
- Added `resolve-did` command to admin CLI
- Refactored gatekeeper.generateDoc to ensure DIDs always have a prefix even when resolving a raw suffix DID
- Added verifyDID function to gatekeeper 
  - Currently ensures DID can resolve OK as before
  - Also ensures non-local assets have non-local controllers, otherwise delete (which fixes a syncing error I was seeing)
- Locally registered DIDs are no longer distributed by the initial DID sync logic