### PR TITLE
Added credential pub features to web UI

### DIFF
--- a/gatekeeper-lib.js
+++ b/gatekeeper-lib.js
@@ -418,7 +418,7 @@ export async function updateDID(operation) {
         return true;
     }
     catch (error) {
-        //console.error(error);
+        console.error(error);
         return false;
     }
 }

--- a/kc-app/src/KeymasterUI.js
+++ b/kc-app/src/KeymasterUI.js
@@ -45,6 +45,7 @@ function KeymasterUI({ keymaster, title }) {
     const [heldString, setHeldString] = useState('');
     const [mnemonicString, setMnemonicString] = useState('');
     const [walletString, setWalletString] = useState('');
+    const [manifest, setManifest] = useState(null);
 
     useEffect(() => {
         refreshAll();
@@ -65,6 +66,7 @@ function KeymasterUI({ keymaster, title }) {
 
                 const docs = await keymaster.resolveId(currentId);
                 setCurrentDID(docs.didDocument.id);
+                setManifest(docs.didDocumentData.manifest);
                 setDocsString(JSON.stringify(docs, null, 4));
 
                 refreshNames();
@@ -122,6 +124,7 @@ function KeymasterUI({ keymaster, title }) {
     async function resolveId() {
         try {
             const docs = await keymaster.resolveId(selectedId);
+            setManifest(docs.didDocumentData.manifest);
             setDocsString(JSON.stringify(docs, null, 4));
         } catch (error) {
             window.alert(error);
@@ -493,7 +496,6 @@ function KeymasterUI({ keymaster, title }) {
         try {
             await keymaster.publishCredential(did, false);
             resolveId();
-            window.alert('Credential published');
         } catch (error) {
             window.alert(error);
         }
@@ -503,7 +505,6 @@ function KeymasterUI({ keymaster, title }) {
         try {
             await keymaster.publishCredential(did, true);
             resolveId();
-            window.alert('Credential revealed');
         } catch (error) {
             window.alert(error);
         }
@@ -513,10 +514,41 @@ function KeymasterUI({ keymaster, title }) {
         try {
             await keymaster.unpublishCredential(did);
             resolveId();
-            window.alert('Credential unpublished');
         } catch (error) {
             window.alert(error);
         }
+    }
+
+    function credentialPublished(did) {
+        if (!manifest) {
+            return false;
+        }
+
+        if (!manifest[did]) {
+            return false;
+        }
+
+        return manifest[did].credential === null;
+    }
+
+    function credentialRevealed(did) {
+        if (!manifest) {
+            return false;
+        }
+
+        if (!manifest[did]) {
+            return false;
+        }
+
+        return manifest[did].credential !== null;
+    }
+
+    function credentialUnpublished(did) {
+        if (!manifest) {
+            return true;
+        }
+
+        return !manifest[did];
     }
 
     async function showMnemonic() {
@@ -1042,17 +1074,17 @@ function KeymasterUI({ keymaster, title }) {
                                                                 </Button>
                                                             </Grid>
                                                             <Grid item>
-                                                                <Button variant="contained" color="primary" onClick={() => publishCredential(did)}>
+                                                                <Button variant="contained" color="primary" onClick={() => publishCredential(did)} disabled={credentialPublished(did)}>
                                                                     Publish
                                                                 </Button>
                                                             </Grid>
                                                             <Grid item>
-                                                                <Button variant="contained" color="primary" onClick={() => revealCredential(did)}>
+                                                                <Button variant="contained" color="primary" onClick={() => revealCredential(did)} disabled={credentialRevealed(did)}>
                                                                     Reveal
                                                                 </Button>
                                                             </Grid>
                                                             <Grid item>
-                                                                <Button variant="contained" color="primary" onClick={() => unpublishCredential(did)}>
+                                                                <Button variant="contained" color="primary" onClick={() => unpublishCredential(did)} disabled={credentialUnpublished(did)}>
                                                                     Unpublish
                                                                 </Button>
                                                             </Grid>

--- a/kc-app/src/KeymasterUI.js
+++ b/kc-app/src/KeymasterUI.js
@@ -489,6 +489,36 @@ function KeymasterUI({ keymaster, title }) {
         }
     }
 
+    async function publishCredential(did) {
+        try {
+            await keymaster.publishCredential(did, false);
+            resolveId();
+            window.alert('Credential published');
+        } catch (error) {
+            window.alert(error);
+        }
+    }
+
+    async function revealCredential(did) {
+        try {
+            await keymaster.publishCredential(did, true);
+            resolveId();
+            window.alert('Credential revealed');
+        } catch (error) {
+            window.alert(error);
+        }
+    }
+
+    async function unpublishCredential(did) {
+        try {
+            await keymaster.unpublishCredential(did);
+            resolveId();
+            window.alert('Credential unpublished');
+        } catch (error) {
+            window.alert(error);
+        }
+    }
+
     async function showMnemonic() {
         try {
             const response = await keymaster.decryptMnemonic();
@@ -991,25 +1021,42 @@ function KeymasterUI({ keymaster, title }) {
                                         <TableBody>
                                             {heldList.map((did, index) => (
                                                 <TableRow key={index}>
-                                                    <TableCell>
-                                                        <Typography style={{ fontSize: '.9em', fontFamily: 'Courier' }}>
+                                                    <TableCell colSpan={6}>
+                                                        <Typography style={{ fontSize: '1em', fontFamily: 'Courier' }}>
                                                             {did}
                                                         </Typography>
-                                                    </TableCell>
-                                                    <TableCell>
-                                                        <Button variant="contained" color="primary" onClick={() => resolveCredential(did)}>
-                                                            Resolve
-                                                        </Button>
-                                                    </TableCell>
-                                                    <TableCell>
-                                                        <Button variant="contained" color="primary" onClick={() => decryptCredential(did)}>
-                                                            Decrypt
-                                                        </Button>
-                                                    </TableCell>
-                                                    <TableCell>
-                                                        <Button variant="contained" color="primary" onClick={() => removeCredential(did)}>
-                                                            Remove
-                                                        </Button>
+                                                        <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
+                                                            <Grid item>
+                                                                <Button variant="contained" color="primary" onClick={() => resolveCredential(did)}>
+                                                                    Resolve
+                                                                </Button>
+                                                            </Grid>
+                                                            <Grid item>
+                                                                <Button variant="contained" color="primary" onClick={() => decryptCredential(did)}>
+                                                                    Decrypt
+                                                                </Button>
+                                                            </Grid>
+                                                            <Grid item>
+                                                                <Button variant="contained" color="primary" onClick={() => removeCredential(did)}>
+                                                                    Remove
+                                                                </Button>
+                                                            </Grid>
+                                                            <Grid item>
+                                                                <Button variant="contained" color="primary" onClick={() => publishCredential(did)}>
+                                                                    Publish
+                                                                </Button>
+                                                            </Grid>
+                                                            <Grid item>
+                                                                <Button variant="contained" color="primary" onClick={() => revealCredential(did)}>
+                                                                    Reveal
+                                                                </Button>
+                                                            </Grid>
+                                                            <Grid item>
+                                                                <Button variant="contained" color="primary" onClick={() => unpublishCredential(did)}>
+                                                                    Unpublish
+                                                                </Button>
+                                                            </Grid>
+                                                        </Grid>
                                                     </TableCell>
                                                 </TableRow>
                                             ))}

--- a/kc-app/src/keymaster-sdk.js
+++ b/kc-app/src/keymaster-sdk.js
@@ -388,4 +388,24 @@ export async function removeCredential(did) {
     }
 }
 
+export async function publishCredential(did, reveal) {
+    try {
+        const response = await axios.post(`/api/v1/credentials/${did}/publish`, { reveal });
+        return response.data;
+    }
+    catch (error) {
+        throwError(error);
+    }
+}
+
+export async function unpublishCredential(did) {
+    try {
+        const response = await axios.post(`/api/v1/credentials/${did}/unpublish`);
+        return response.data;
+    }
+    catch (error) {
+        throwError(error);
+    }
+}
+
 

--- a/keychain-cli.js
+++ b/keychain-cli.js
@@ -425,8 +425,8 @@ program
     .description('Publish the existence of a credential to the current user manifest')
     .action(async (did) => {
         try {
-            const vc = await keymaster.publishCredential(did, false);
-            console.log(JSON.stringify(vc, null, 4));
+            const response = await keymaster.publishCredential(did, false);
+            console.log(JSON.stringify(response, null, 4));
         }
         catch (error) {
             console.error(error);
@@ -438,8 +438,8 @@ program
     .description('Reveal a credential to the current user manifest')
     .action(async (did) => {
         try {
-            const vc = await keymaster.publishCredential(did, true);
-            console.log(JSON.stringify(vc, null, 4));
+            const response = await keymaster.publishCredential(did, true);
+            console.log(JSON.stringify(response, null, 4));
         }
         catch (error) {
             console.error(error);

--- a/keymaster-api.js
+++ b/keymaster-api.js
@@ -393,6 +393,27 @@ v1router.delete('/credentials/:did', async (req, res) => {
     }
 });
 
+v1router.post('/credentials/:did/publish', async (req, res) => {
+    try {
+        const did = req.params.did;
+        const { reveal } = req.body;
+        const response = await keymaster.publishCredential(did, reveal);
+        res.json(response);
+    } catch (error) {
+        res.status(400).send(error.toString());
+    }
+});
+
+v1router.post('/credentials/:did/unpublish', async (req, res) => {
+    try {
+        const did = req.params.did;
+        const response = await keymaster.unpublishCredential(did);
+        res.json(response);
+    } catch (error) {
+        res.status(400).send(error.toString());
+    }
+});
+
 app.use('/api/v1', v1router);
 
 app.use((req, res) => {

--- a/keymaster-app/src/KeymasterUI.js
+++ b/keymaster-app/src/KeymasterUI.js
@@ -45,6 +45,7 @@ function KeymasterUI({ keymaster, title }) {
     const [heldString, setHeldString] = useState('');
     const [mnemonicString, setMnemonicString] = useState('');
     const [walletString, setWalletString] = useState('');
+    const [manifest, setManifest] = useState(null);
 
     useEffect(() => {
         refreshAll();
@@ -65,6 +66,7 @@ function KeymasterUI({ keymaster, title }) {
 
                 const docs = await keymaster.resolveId(currentId);
                 setCurrentDID(docs.didDocument.id);
+                setManifest(docs.didDocumentData.manifest);
                 setDocsString(JSON.stringify(docs, null, 4));
 
                 refreshNames();
@@ -122,6 +124,7 @@ function KeymasterUI({ keymaster, title }) {
     async function resolveId() {
         try {
             const docs = await keymaster.resolveId(selectedId);
+            setManifest(docs.didDocumentData.manifest);
             setDocsString(JSON.stringify(docs, null, 4));
         } catch (error) {
             window.alert(error);
@@ -493,7 +496,6 @@ function KeymasterUI({ keymaster, title }) {
         try {
             await keymaster.publishCredential(did, false);
             resolveId();
-            window.alert('Credential published');
         } catch (error) {
             window.alert(error);
         }
@@ -503,7 +505,6 @@ function KeymasterUI({ keymaster, title }) {
         try {
             await keymaster.publishCredential(did, true);
             resolveId();
-            window.alert('Credential revealed');
         } catch (error) {
             window.alert(error);
         }
@@ -513,10 +514,41 @@ function KeymasterUI({ keymaster, title }) {
         try {
             await keymaster.unpublishCredential(did);
             resolveId();
-            window.alert('Credential unpublished');
         } catch (error) {
             window.alert(error);
         }
+    }
+
+    function credentialPublished(did) {
+        if (!manifest) {
+            return false;
+        }
+
+        if (!manifest[did]) {
+            return false;
+        }
+
+        return manifest[did].credential === null;
+    }
+
+    function credentialRevealed(did) {
+        if (!manifest) {
+            return false;
+        }
+
+        if (!manifest[did]) {
+            return false;
+        }
+
+        return manifest[did].credential !== null;
+    }
+
+    function credentialUnpublished(did) {
+        if (!manifest) {
+            return true;
+        }
+
+        return !manifest[did];
     }
 
     async function showMnemonic() {
@@ -1042,17 +1074,17 @@ function KeymasterUI({ keymaster, title }) {
                                                                 </Button>
                                                             </Grid>
                                                             <Grid item>
-                                                                <Button variant="contained" color="primary" onClick={() => publishCredential(did)}>
+                                                                <Button variant="contained" color="primary" onClick={() => publishCredential(did)} disabled={credentialPublished(did)}>
                                                                     Publish
                                                                 </Button>
                                                             </Grid>
                                                             <Grid item>
-                                                                <Button variant="contained" color="primary" onClick={() => revealCredential(did)}>
+                                                                <Button variant="contained" color="primary" onClick={() => revealCredential(did)} disabled={credentialRevealed(did)}>
                                                                     Reveal
                                                                 </Button>
                                                             </Grid>
                                                             <Grid item>
-                                                                <Button variant="contained" color="primary" onClick={() => unpublishCredential(did)}>
+                                                                <Button variant="contained" color="primary" onClick={() => unpublishCredential(did)} disabled={credentialUnpublished(did)}>
                                                                     Unpublish
                                                                 </Button>
                                                             </Grid>

--- a/keymaster-app/src/KeymasterUI.js
+++ b/keymaster-app/src/KeymasterUI.js
@@ -489,6 +489,33 @@ function KeymasterUI({ keymaster, title }) {
         }
     }
 
+    async function publishCredential(did) {
+        try {
+            await keymaster.publishCredential(did, false);
+            resolveId();
+        } catch (error) {
+            window.alert(error);
+        }
+    }
+
+    async function revealCredential(did) {
+        try {
+            await keymaster.publishCredential(did, true);
+            resolveId();
+        } catch (error) {
+            window.alert(error);
+        }
+    }
+
+    async function unpublishCredential(did) {
+        try {
+            await keymaster.unpublishCredential(did);
+            resolveId();
+        } catch (error) {
+            window.alert(error);
+        }
+    }
+
     async function showMnemonic() {
         try {
             const response = await keymaster.decryptMnemonic();
@@ -991,25 +1018,42 @@ function KeymasterUI({ keymaster, title }) {
                                         <TableBody>
                                             {heldList.map((did, index) => (
                                                 <TableRow key={index}>
-                                                    <TableCell>
-                                                        <Typography style={{ fontSize: '.9em', fontFamily: 'Courier' }}>
+                                                    <TableCell colSpan={6}>
+                                                        <Typography style={{ fontSize: '1em', fontFamily: 'Courier' }}>
                                                             {did}
                                                         </Typography>
-                                                    </TableCell>
-                                                    <TableCell>
-                                                        <Button variant="contained" color="primary" onClick={() => resolveCredential(did)}>
-                                                            Resolve
-                                                        </Button>
-                                                    </TableCell>
-                                                    <TableCell>
-                                                        <Button variant="contained" color="primary" onClick={() => decryptCredential(did)}>
-                                                            Decrypt
-                                                        </Button>
-                                                    </TableCell>
-                                                    <TableCell>
-                                                        <Button variant="contained" color="primary" onClick={() => removeCredential(did)}>
-                                                            Remove
-                                                        </Button>
+                                                        <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
+                                                            <Grid item>
+                                                                <Button variant="contained" color="primary" onClick={() => resolveCredential(did)}>
+                                                                    Resolve
+                                                                </Button>
+                                                            </Grid>
+                                                            <Grid item>
+                                                                <Button variant="contained" color="primary" onClick={() => decryptCredential(did)}>
+                                                                    Decrypt
+                                                                </Button>
+                                                            </Grid>
+                                                            <Grid item>
+                                                                <Button variant="contained" color="primary" onClick={() => removeCredential(did)}>
+                                                                    Remove
+                                                                </Button>
+                                                            </Grid>
+                                                            <Grid item>
+                                                                <Button variant="contained" color="primary" onClick={() => publishCredential(did)}>
+                                                                    Publish
+                                                                </Button>
+                                                            </Grid>
+                                                            <Grid item>
+                                                                <Button variant="contained" color="primary" onClick={() => revealCredential(did)}>
+                                                                    Reveal
+                                                                </Button>
+                                                            </Grid>
+                                                            <Grid item>
+                                                                <Button variant="contained" color="primary" onClick={() => unpublishCredential(did)}>
+                                                                    Unpublish
+                                                                </Button>
+                                                            </Grid>
+                                                        </Grid>
                                                     </TableCell>
                                                 </TableRow>
                                             ))}

--- a/keymaster-app/src/KeymasterUI.js
+++ b/keymaster-app/src/KeymasterUI.js
@@ -493,6 +493,7 @@ function KeymasterUI({ keymaster, title }) {
         try {
             await keymaster.publishCredential(did, false);
             resolveId();
+            window.alert('Credential published');
         } catch (error) {
             window.alert(error);
         }
@@ -502,6 +503,7 @@ function KeymasterUI({ keymaster, title }) {
         try {
             await keymaster.publishCredential(did, true);
             resolveId();
+            window.alert('Credential revealed');
         } catch (error) {
             window.alert(error);
         }
@@ -511,6 +513,7 @@ function KeymasterUI({ keymaster, title }) {
         try {
             await keymaster.unpublishCredential(did);
             resolveId();
+            window.alert('Credential unpublished');
         } catch (error) {
             window.alert(error);
         }

--- a/keymaster-lib.js
+++ b/keymaster-lib.js
@@ -808,9 +808,14 @@ export async function publishCredential(did, reveal = false) {
         }
         doc.didDocumentData.manifest[credential] = vc;
 
-        await updateDID(id.did, doc);
+        const ok = await updateDID(id.did, doc);
 
-        return vc;
+        if (ok) {
+            return vc;
+        }
+        else {
+            return "Update failed";
+        }
     }
     catch (error) {
         return error;


### PR DESCRIPTION
Adds buttons to publish, reveal, or unpublish a held credential. Only 2 of the buttons will be enabled at a time because the credential is in one of the 3 states.

![image](https://github.com/KeychainMDIP/kc/assets/434644/2117f473-0b24-4b7a-bb3a-194550f977f6)

