### PR TITLE
Add issued credentials to web UI

### DIFF
--- a/hyperswarm-mediator.js
+++ b/hyperswarm-mediator.js
@@ -14,7 +14,7 @@ EventEmitter.defaultMaxListeners = 100;
 
 const REGISTRY = 'hyperswarm';
 const BATCH_SIZE = 100;
-const PROTOCOL = '/MDIP/v22.06.20';
+const PROTOCOL = '/MDIP/v22.06.25';
 
 const nodes = {};
 const batchesSeen = {};
@@ -99,13 +99,16 @@ async function createBatch() {
         .map(event => event.operation)
         .filter(op => { // filter out local events
             if (op.mdip) {
+                // create operation
                 return op.mdip.registry !== 'local';
             }
 
-            if (op.doc.mdip) {
+            if (op.doc?.mdip) {
+                // update operation
                 return op.doc.mdip.registry !== 'local';
             }
 
+            // delete operation
             return false;
         })
         .sort((a, b) => new Date(a.signature.signed) - new Date(b.signature.signed));
@@ -444,13 +447,11 @@ function logConnection(name) {
 }
 
 process.on('uncaughtException', (error) => {
-    //console.error('Unhandled exception caught');
     console.error('Unhandled exception caught', error);
 });
 
 process.on('unhandledRejection', (reason, promise) => {
     console.error('Unhandled rejection at:', promise, 'reason:', reason);
-    //console.error('Unhandled rejection caught');
 });
 
 process.stdin.on('data', d => {

--- a/kc-app/src/KeymasterUI.js
+++ b/kc-app/src/KeymasterUI.js
@@ -1117,7 +1117,7 @@ function KeymasterUI({ keymaster, title }) {
                                                                 </Button>
                                                             </Grid>
                                                             <Grid item>
-                                                                <Button variant="contained" color="primary" onClick={() => removeCredential(did)}>
+                                                                <Button variant="contained" color="primary" onClick={() => removeCredential(did)} disabled={!credentialUnpublished(did)}>
                                                                     Remove
                                                                 </Button>
                                                             </Grid>

--- a/kc-app/src/keymaster-sdk.js
+++ b/kc-app/src/keymaster-sdk.js
@@ -408,4 +408,22 @@ export async function unpublishCredential(did) {
     }
 }
 
+export async function listIssued() {
+    try {
+        const response = await axios.get(`/api/v1/issued`);
+        return response.data;
+    }
+    catch (error) {
+        throwError(error);
+    }
+}
 
+export async function revokeCredential(did) {
+    try {
+        const response = await axios.delete(`/api/v1/issued/${did}`);
+        return response.data;
+    }
+    catch (error) {
+        throwError(error);
+    }
+}

--- a/keychain-cli.js
+++ b/keychain-cli.js
@@ -26,9 +26,9 @@ program
     .description('Validate DIDs in wallet')
     .action(async () => {
         try {
-            const { invalid, deleted } = await keymaster.checkWallet();
+            const { checked, invalid, deleted } = await keymaster.checkWallet();
 
-            console.log(`${invalid} invalid DIDs found, ${deleted} deleted DIDs found`);
+            console.log(`${checked} DIDs checked, ${invalid} invalid DIDs found, ${deleted} deleted DIDs found`);
         }
         catch (error) {
             console.error(error);
@@ -40,9 +40,9 @@ program
     .description('Remove invalid DIDs from the wallet')
     .action(async () => {
         try {
-            const { idsRemoved, ownedRemoved } = await keymaster.fixWallet();
+            const { idsRemoved, ownedRemoved, heldRemoved } = await keymaster.fixWallet();
 
-            console.log(`${idsRemoved} IDs and ${ownedRemoved} owned DIDs were removed`);
+            console.log(`${idsRemoved} IDs and ${ownedRemoved} owned DIDs and ${heldRemoved} held DIDs were removed`);
         }
         catch (error) {
             console.error(error);

--- a/keychain-cli.js
+++ b/keychain-cli.js
@@ -26,8 +26,28 @@ program
     .description('Validate DIDs in wallet')
     .action(async () => {
         try {
-            const response = await keymaster.checkWallet();
-            console.log(response);
+            const invalid = await keymaster.checkWallet();
+
+            if (invalid) {
+                console.log(`${invalid} DIDs detected`);
+            }
+            else {
+                console.log('Wallet OK');
+            }
+        }
+        catch (error) {
+            console.error(error);
+        }
+    });
+
+program
+    .command('fix-wallet')
+    .description('Remove invalid DIDs from the wallet')
+    .action(async () => {
+        try {
+            const {idsRemoved, ownedRemoved } = await keymaster.fixWallet();
+
+            console.log(`${idsRemoved} IDs and ${ownedRemoved} owned DIDs were removed`);
         }
         catch (error) {
             console.error(error);

--- a/keychain-cli.js
+++ b/keychain-cli.js
@@ -22,6 +22,19 @@ program
     });
 
 program
+    .command('check-wallet')
+    .description('Validate DIDs in wallet')
+    .action(async () => {
+        try {
+            const response = await keymaster.checkWallet();
+            console.log(response);
+        }
+        catch (error) {
+            console.error(error);
+        }
+    });
+
+program
     .command('import-wallet <recovery-phrase>')
     .description('Create new wallet from a recovery phrase')
     .action((recoveryPhrase) => {
@@ -378,6 +391,20 @@ program
             }
 
             console.log(did);
+        }
+        catch (error) {
+            console.error(error);
+        }
+    });
+
+program
+    .command('list-issued')
+    .description('List issued credentials')
+    .action(async () => {
+        try {
+            const response = await keymaster.listIssued();
+
+            console.log(JSON.stringify(response, null, 4));
         }
         catch (error) {
             console.error(error);

--- a/keychain-cli.js
+++ b/keychain-cli.js
@@ -26,14 +26,9 @@ program
     .description('Validate DIDs in wallet')
     .action(async () => {
         try {
-            const invalid = await keymaster.checkWallet();
+            const { invalid, deleted } = await keymaster.checkWallet();
 
-            if (invalid) {
-                console.log(`${invalid} DIDs detected`);
-            }
-            else {
-                console.log('Wallet OK');
-            }
+            console.log(`${invalid} invalid DIDs found, ${deleted} deleted DIDs found`);
         }
         catch (error) {
             console.error(error);
@@ -45,7 +40,7 @@ program
     .description('Remove invalid DIDs from the wallet')
     .action(async () => {
         try {
-            const {idsRemoved, ownedRemoved } = await keymaster.fixWallet();
+            const { idsRemoved, ownedRemoved } = await keymaster.fixWallet();
 
             console.log(`${idsRemoved} IDs and ${ownedRemoved} owned DIDs were removed`);
         }

--- a/keymaster-api.js
+++ b/keymaster-api.js
@@ -414,6 +414,35 @@ v1router.post('/credentials/:did/unpublish', async (req, res) => {
     }
 });
 
+v1router.get('/issued', async (req, res) => {
+    try {
+        const response = await keymaster.listIssued();
+        res.json(response);
+    } catch (error) {
+        res.status(400).send(error.toString());
+    }
+});
+
+v1router.get('/issued/:did', async (req, res) => {
+    try {
+        const did = req.params.did;
+        const response = await keymaster.getCredential(did);
+        res.json(response);
+    } catch (error) {
+        res.status(400).send(error.toString());
+    }
+});
+
+v1router.delete('/issued/:did', async (req, res) => {
+    try {
+        const did = req.params.did;
+        const response = await keymaster.revokeCredential(did);
+        res.json(response);
+    } catch (error) {
+        res.status(400).send(error.toString());
+    }
+});
+
 app.use('/api/v1', v1router);
 
 app.use((req, res) => {

--- a/keymaster-app/src/KeymasterUI.js
+++ b/keymaster-app/src/KeymasterUI.js
@@ -1117,7 +1117,7 @@ function KeymasterUI({ keymaster, title }) {
                                                                 </Button>
                                                             </Grid>
                                                             <Grid item>
-                                                                <Button variant="contained" color="primary" onClick={() => removeCredential(did)}>
+                                                                <Button variant="contained" color="primary" onClick={() => removeCredential(did)} disabled={!credentialUnpublished(did)}>
                                                                     Remove
                                                                 </Button>
                                                             </Grid>

--- a/keymaster-app/src/KeymasterUI.js
+++ b/keymaster-app/src/KeymasterUI.js
@@ -436,8 +436,8 @@ function KeymasterUI({ keymaster, title }) {
         try {
             const did = await keymaster.issueCredential(JSON.parse(credentialString));
             setCredentialDID(did);
-            refreshIssued();
-            resolveIssued(did);
+            // Add did to issuedList
+            setIssuedList(prevIssuedList => [...prevIssuedList, did]);
         } catch (error) {
             window.alert(error);
         }
@@ -588,7 +588,10 @@ function KeymasterUI({ keymaster, title }) {
         try {
             if (window.confirm(`Revoke credential?`)) {
                 await keymaster.revokeCredential(did);
-                refreshIssued();
+
+                // Remove did from issuedList
+                const newIssuedList = issuedList.filter(item => item !== did);
+                setIssuedList(newIssuedList);
             }
         } catch (error) {
             window.alert(error);

--- a/keymaster-app/src/KeymasterUI.js
+++ b/keymaster-app/src/KeymasterUI.js
@@ -43,6 +43,8 @@ function KeymasterUI({ keymaster, title }) {
     const [heldList, setHeldList] = useState(null);
     const [heldDID, setHeldDID] = useState('');
     const [heldString, setHeldString] = useState('');
+    const [issuedList, setIssuedList] = useState(null);
+    const [issuedString, setIssuedString] = useState('');
     const [mnemonicString, setMnemonicString] = useState('');
     const [walletString, setWalletString] = useState('');
     const [manifest, setManifest] = useState(null);
@@ -71,6 +73,7 @@ function KeymasterUI({ keymaster, title }) {
 
                 refreshNames();
                 refreshHeld();
+                refreshIssued();
 
                 setTab('identity');
                 setCredentialTab('held');
@@ -433,6 +436,8 @@ function KeymasterUI({ keymaster, title }) {
         try {
             const did = await keymaster.issueCredential(JSON.parse(credentialString));
             setCredentialDID(did);
+            refreshIssued();
+            resolveIssued(did);
         } catch (error) {
             window.alert(error);
         }
@@ -443,6 +448,16 @@ function KeymasterUI({ keymaster, title }) {
             const heldList = await keymaster.listCredentials();
             setHeldList(heldList);
             setHeldString('');
+        } catch (error) {
+            window.alert(error);
+        }
+    }
+
+    async function refreshIssued() {
+        try {
+            const issuedList = await keymaster.listIssued();
+            setIssuedList(issuedList);
+            setIssuedString('');
         } catch (error) {
             window.alert(error);
         }
@@ -549,6 +564,35 @@ function KeymasterUI({ keymaster, title }) {
         }
 
         return !manifest[did];
+    }
+
+    async function resolveIssued(did) {
+        try {
+            const doc = await keymaster.resolveDID(did);
+            setIssuedString(JSON.stringify(doc, null, 4));
+        } catch (error) {
+            window.alert(error);
+        }
+    }
+
+    async function decryptIssued(did) {
+        try {
+            const doc = await keymaster.getCredential(did);
+            setIssuedString(JSON.stringify(doc, null, 4));
+        } catch (error) {
+            window.alert(error);
+        }
+    }
+
+    async function revokeIssued(did) {
+        try {
+            if (window.confirm(`Revoke credential?`)) {
+                await keymaster.revokeCredential(did);
+                refreshIssued();
+            }
+        } catch (error) {
+            window.alert(error);
+        }
     }
 
     async function showMnemonic() {
@@ -1045,6 +1089,7 @@ function KeymasterUI({ keymaster, title }) {
                                 >
                                     <Tab key="held" value="held" label={'Held'} />
                                     <Tab key="issue" value="issue" label={'Issue'} />
+                                    <Tab key="issued" value="issued" label={'Issued'} />
                                 </Tabs>
                             </Box>
                             {credentialTab === 'held' &&
@@ -1204,6 +1249,45 @@ function KeymasterUI({ keymaster, title }) {
                                             </Grid>
                                         </Box>
                                     }
+                                </Box>
+                            }
+                            {credentialTab === 'issued' &&
+                                <Box>
+                                    <Table style={{ width: '800px' }}>
+                                        <TableBody>
+                                            {issuedList.map((did, index) => (
+                                                <TableRow key={index}>
+                                                    <TableCell colSpan={6}>
+                                                        <Typography style={{ fontSize: '1em', fontFamily: 'Courier' }}>
+                                                            {did}
+                                                        </Typography>
+                                                        <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
+                                                            <Grid item>
+                                                                <Button variant="contained" color="primary" onClick={() => resolveIssued(did)}>
+                                                                    Resolve
+                                                                </Button>
+                                                            </Grid>
+                                                            <Grid item>
+                                                                <Button variant="contained" color="primary" onClick={() => decryptIssued(did)}>
+                                                                    Decrypt
+                                                                </Button>
+                                                            </Grid>
+                                                            <Grid item>
+                                                                <Button variant="contained" color="primary" onClick={() => revokeIssued(did)}>
+                                                                    Revoke
+                                                                </Button>
+                                                            </Grid>
+                                                        </Grid>
+                                                    </TableCell>
+                                                </TableRow>
+                                            ))}
+                                        </TableBody>
+                                    </Table>
+                                    <textarea
+                                        value={issuedString}
+                                        readOnly
+                                        style={{ width: '800px', height: '600px', overflow: 'auto' }}
+                                    />
                                 </Box>
                             }
                         </Box>

--- a/keymaster-app/src/keymaster-web.js
+++ b/keymaster-app/src/keymaster-web.js
@@ -74,6 +74,73 @@ export function decryptMnemonic() {
     return mnenomic;
 }
 
+export async function checkWallet() {
+    const wallet = loadWallet();
+    let invalid = 0;
+
+    await resolveSeedBank();
+
+    for (const name of Object.keys(wallet.ids)) {
+        try {
+            await resolveDID(wallet.ids[name].did);
+        }
+        catch (error) {
+            invalid += 1;
+        }
+    }
+
+    for (const id of Object.values(wallet.ids)) {
+        for (const did of id.owned) {
+            try {
+                await resolveDID(did);
+            }
+            catch (error) {
+                invalid += 1;
+            }
+        }
+    }
+
+    return invalid;
+}
+
+export async function fixWallet() {
+    const invalid = await checkWallet();
+    let idsRemoved = 0;
+    let ownedRemoved = 0;
+
+    if (invalid === 0) {
+        return { idsRemoved, ownedRemoved };
+    }
+
+    const wallet = loadWallet();
+
+    for (const name of Object.keys(wallet.ids)) {
+        try {
+            await resolveDID(wallet.ids[name].did);
+        }
+        catch (error) {
+            delete wallet.ids[name];
+            idsRemoved += 1;
+        }
+    }
+
+    for (const id of Object.values(wallet.ids)) {
+        for (let i = 0; i < id.owned.length; i++) {
+            try {
+                await resolveDID(id.owned[i]);
+            } catch {
+                id.owned.splice(i, 1);
+                i--; // Decrement index to account for the removed item
+                ownedRemoved += 1;
+            }
+        }
+    }
+
+    saveWallet(wallet);
+
+    return { idsRemoved, ownedRemoved };
+}
+
 export async function resolveSeedBank() {
     const keypair = hdKeyPair();
 
@@ -695,8 +762,11 @@ export async function createAsset(data, registry = defaultRegistry, name = null)
     const signed = await addSignature(operation, name);
     const did = await gatekeeper.createDID(signed);
 
-    // TBD skip if registry is hyperswarm?
-    addToOwned(did);
+    // Keep assets that will be garbage-collected out of the owned list
+    if (registry !== 'hyperswarm') {
+        addToOwned(did);
+    }
+
     return did;
 }
 
@@ -741,10 +811,35 @@ export async function issueCredential(vc, registry = defaultRegistry) {
         throw 'Invalid VC';
     }
 
+    // Don't allow credentials that will be garbage-collected
+    if (registry === 'hyperswarm') {
+        throw 'Invalid VC';
+    }
+
     const signed = await addSignature(vc);
     const cipherDid = await encryptJSON(signed, vc.credentialSubject.id, registry);
     addToOwned(cipherDid);
     return cipherDid;
+}
+
+export async function listIssued(issuer) {
+    const id = fetchId(issuer);
+    const issued = [];
+
+    for (const did of id.owned) {
+        try {
+            const credential = await decryptJSON(did);
+
+            if (credential.issuer === id.did) {
+                issued.push(did);
+            }
+        }
+        catch (error) {
+            continue;
+        }
+    }
+
+    return issued;
 }
 
 export async function revokeCredential(did) {
@@ -803,11 +898,17 @@ export async function publishCredential(did, reveal = false) {
             // Remove the credential values
             vc.credential = null;
         }
+
         doc.didDocumentData.manifest[credential] = vc;
 
-        await updateDID(id.did, doc);
+        const ok = await updateDID(id.did, doc);
 
-        return vc;
+        if (ok) {
+            return vc;
+        }
+        else {
+            return "Update failed";
+        }
     }
     catch (error) {
         return error;

--- a/keymaster-app/src/keymaster-web.js
+++ b/keymaster-app/src/keymaster-web.js
@@ -541,7 +541,13 @@ export async function revokeDID(did) {
 
     const controller = current.didDocument.controller || current.didDocument.id;
     const signed = await addSignature(operation, controller);
-    return gatekeeper.deleteDID(signed);
+    const ok = gatekeeper.deleteDID(signed);
+
+    if (ok && current.didDocument.controller) {
+        removeFromOwned(did, current.didDocument.controller);
+    }
+
+    return ok;
 }
 
 function addToOwned(did) {
@@ -551,6 +557,16 @@ function addToOwned(did) {
 
     owned.add(did);
     id.owned = Array.from(owned);
+
+    saveWallet(wallet);
+    return true;
+}
+
+function removeFromOwned(did, owner) {
+    const wallet = loadWallet();
+    const id = fetchId(owner);
+
+    id.owned = id.owned.filter(item => item !== did);
 
     saveWallet(wallet);
     return true;

--- a/keymaster-lib.js
+++ b/keymaster-lib.js
@@ -79,6 +79,8 @@ export function decryptMnemonic() {
 
 export async function checkWallet() {
     const wallet = loadWallet();
+
+    let checked = 0;
     let invalid = 0;
     let deleted = 0;
 
@@ -96,56 +98,126 @@ export async function checkWallet() {
         catch (error) {
             invalid += 1;
         }
+
+        checked += 1;
     }
 
     for (const id of Object.values(wallet.ids)) {
-        for (const did of id.owned) {
-            try {
-                const doc = await resolveDID(did);
+        if (id.owned) {
+            for (const did of id.owned) {
+                try {
+                    const doc = await resolveDID(did);
 
-                if (doc.didDocumentMetadata.deactivated) {
-                    deleted += 1;
+                    if (doc.didDocumentMetadata.deactivated) {
+                        deleted += 1;
+                    }
                 }
+                catch (error) {
+                    invalid += 1;
+                }
+
+                checked += 1;
             }
-            catch (error) {
-                invalid += 1;
+        }
+
+        if (id.held) {
+            for (const did of id.held) {
+                try {
+                    const doc = await resolveDID(did);
+
+                    if (doc.didDocumentMetadata.deactivated) {
+                        deleted += 1;
+                    }
+                }
+                catch (error) {
+                    invalid += 1;
+                }
+
+                checked += 1;
             }
         }
     }
 
-    return { invalid, deleted };
+    return { checked, invalid, deleted };
 }
 
 export async function fixWallet() {
     const wallet = loadWallet();
     let idsRemoved = 0;
     let ownedRemoved = 0;
+    let heldRemoved = 0;
 
     for (const name of Object.keys(wallet.ids)) {
+        let remove = false;
+
         try {
-            await resolveDID(wallet.ids[name].did);
+            const doc = await resolveDID(wallet.ids[name].did);
+
+            if (doc.didDocumentMetadata.deactivated) {
+                remove = true;
+            }
         }
         catch (error) {
+            remove = true;
+        }
+
+        if (remove) {
             delete wallet.ids[name];
             idsRemoved += 1;
         }
     }
 
     for (const id of Object.values(wallet.ids)) {
-        for (let i = 0; i < id.owned.length; i++) {
-            try {
-                await resolveDID(id.owned[i]);
-            } catch {
-                id.owned.splice(i, 1);
-                i--; // Decrement index to account for the removed item
-                ownedRemoved += 1;
+        if (id.owned) {
+            for (let i = 0; i < id.owned.length; i++) {
+                let remove = false;
+
+                try {
+                    const doc = await resolveDID(id.owned[i]);
+
+                    if (doc.didDocumentMetadata.deactivated) {
+                        remove = true;
+                    }
+                }
+                catch {
+                    remove = true;
+                }
+
+                if (remove) {
+                    id.owned.splice(i, 1);
+                    i--; // Decrement index to account for the removed item
+                    ownedRemoved += 1;
+                }
+            }
+        }
+
+        if (id.held) {
+            for (let i = 0; i < id.held.length; i++) {
+                let remove = false;
+
+                try {
+                    const doc = await resolveDID(id.held[i]);
+
+                    if (doc.didDocumentMetadata.deactivated) {
+                        remove = true;
+                    }
+                }
+                catch {
+                    remove = true;
+                }
+
+                if (remove) {
+                    id.held.splice(i, 1);
+                    i--; // Decrement index to account for the removed item
+                    heldRemoved += 1;
+                }
             }
         }
     }
 
     saveWallet(wallet);
 
-    return { idsRemoved, ownedRemoved };
+    return { idsRemoved, ownedRemoved, heldRemoved };
 }
 
 export async function resolveSeedBank() {

--- a/keymaster-lib.js
+++ b/keymaster-lib.js
@@ -546,8 +546,8 @@ export async function revokeDID(did) {
     const signed = await addSignature(operation, controller);
     const ok = gatekeeper.deleteDID(signed);
 
-    if (ok) {
-        removeFromOwned(did);
+    if (ok && current.didDocument.controller) {
+        removeFromOwned(did, current.didDocument.controller);
     }
 
     return ok;
@@ -565,9 +565,9 @@ function addToOwned(did) {
     return true;
 }
 
-function removeFromOwned(did) {
+function removeFromOwned(did, owner) {
     const wallet = loadWallet();
-    const id = wallet.ids[wallet.current];
+    const id = fetchId(owner);
 
     id.owned = id.owned.filter(item => item !== did);
 

--- a/keymaster-lib.js
+++ b/keymaster-lib.js
@@ -544,7 +544,13 @@ export async function revokeDID(did) {
 
     const controller = current.didDocument.controller || current.didDocument.id;
     const signed = await addSignature(operation, controller);
-    return gatekeeper.deleteDID(signed);
+    const ok = gatekeeper.deleteDID(signed);
+
+    if (ok) {
+        removeFromOwned(did);
+    }
+
+    return ok;
 }
 
 function addToOwned(did) {
@@ -554,6 +560,16 @@ function addToOwned(did) {
 
     owned.add(did);
     id.owned = Array.from(owned);
+
+    saveWallet(wallet);
+    return true;
+}
+
+function removeFromOwned(did) {
+    const wallet = loadWallet();
+    const id = wallet.ids[wallet.current];
+
+    id.owned = id.owned.filter(item => item !== did);
 
     saveWallet(wallet);
     return true;

--- a/keymaster-lib.js
+++ b/keymaster-lib.js
@@ -112,7 +112,7 @@ export async function fixWallet() {
     let ownedRemoved = 0;
 
     if (invalid === 0) {
-        return {idsRemoved, ownedRemoved};
+        return { idsRemoved, ownedRemoved };
     }
 
     const wallet = loadWallet();
@@ -141,7 +141,7 @@ export async function fixWallet() {
 
     saveWallet(wallet);
 
-    return {idsRemoved, ownedRemoved};
+    return { idsRemoved, ownedRemoved };
 }
 
 export async function resolveSeedBank() {
@@ -765,8 +765,11 @@ export async function createAsset(data, registry = defaultRegistry, name = null)
     const signed = await addSignature(operation, name);
     const did = await gatekeeper.createDID(signed);
 
-    // TBD skip if registry is hyperswarm?
-    addToOwned(did);
+    // Keep assets that will be garbage-collected out of the owned list
+    if (registry !== 'hyperswarm') {
+        addToOwned(did);
+    }
+
     return did;
 }
 
@@ -808,6 +811,11 @@ export async function issueCredential(vc, registry = defaultRegistry) {
     const id = fetchId();
 
     if (vc.issuer !== id.did) {
+        throw 'Invalid VC';
+    }
+
+    // Don't allow credentials that will be garbage-collected
+    if (registry === 'hyperswarm') {
         throw 'Invalid VC';
     }
 

--- a/keymaster-lib.js
+++ b/keymaster-lib.js
@@ -80,12 +80,18 @@ export function decryptMnemonic() {
 export async function checkWallet() {
     const wallet = loadWallet();
     let invalid = 0;
+    let deleted = 0;
 
+    // Validate keys
     await resolveSeedBank();
 
     for (const name of Object.keys(wallet.ids)) {
         try {
-            await resolveDID(wallet.ids[name].did);
+            const doc = await resolveDID(wallet.ids[name].did);
+
+            if (doc.didDocumentMetadata.deactivated) {
+                deleted += 1;
+            }
         }
         catch (error) {
             invalid += 1;
@@ -95,7 +101,11 @@ export async function checkWallet() {
     for (const id of Object.values(wallet.ids)) {
         for (const did of id.owned) {
             try {
-                await resolveDID(did);
+                const doc = await resolveDID(did);
+
+                if (doc.didDocumentMetadata.deactivated) {
+                    deleted += 1;
+                }
             }
             catch (error) {
                 invalid += 1;
@@ -103,19 +113,13 @@ export async function checkWallet() {
         }
     }
 
-    return invalid;
+    return { invalid, deleted };
 }
 
 export async function fixWallet() {
-    const invalid = await checkWallet();
+    const wallet = loadWallet();
     let idsRemoved = 0;
     let ownedRemoved = 0;
-
-    if (invalid === 0) {
-        return { idsRemoved, ownedRemoved };
-    }
-
-    const wallet = loadWallet();
 
     for (const name of Object.keys(wallet.ids)) {
         try {

--- a/keymaster-lib.js
+++ b/keymaster-lib.js
@@ -827,18 +827,22 @@ export async function issueCredential(vc, registry = defaultRegistry) {
 
 export async function listIssued(issuer) {
     const id = fetchId(issuer);
+    const issued = [];
 
     for (const did of id.owned) {
         try {
-            const asset = await resolveDID(did);
-            console.log(JSON.stringify(asset, null, 4));
+            const credential = await decryptJSON(did);
+
+            if (credential.issuer === id.did) {
+                issued.push(did);
+            }
         }
         catch (error) {
-            console.log(error);
+            continue;
         }
     }
 
-    return "TBD";
+    return issued;
 }
 
 export async function revokeCredential(did) {

--- a/keymaster-lib.js
+++ b/keymaster-lib.js
@@ -30,6 +30,15 @@ export function saveWallet(wallet) {
     fs.writeFileSync(walletName, JSON.stringify(wallet, null, 4));
 }
 
+export function loadWallet() {
+    if (fs.existsSync(walletName)) {
+        const walletJson = fs.readFileSync(walletName);
+        return JSON.parse(walletJson);
+    }
+
+    return newWallet();
+}
+
 export function newWallet(mnemonic, overwrite = false) {
     if (fs.existsSync(walletName) && !overwrite) {
         throw "Wallet already exists";
@@ -66,15 +75,6 @@ export function decryptMnemonic() {
     const mnenomic = cipher.decryptMessage(keypair.publicJwk, keypair.privateJwk, wallet.seed.mnemonic);
 
     return mnenomic;
-}
-
-export function loadWallet() {
-    if (fs.existsSync(walletName)) {
-        const walletJson = fs.readFileSync(walletName);
-        return JSON.parse(walletJson);
-    }
-
-    return newWallet();
 }
 
 export async function checkWallet() {
@@ -675,7 +675,7 @@ export async function rotateKeys() {
 export function listNames() {
     const wallet = loadWallet();
 
-    return wallet.names;
+    return wallet.names || {};
 }
 
 export function addName(name, did) {
@@ -901,6 +901,7 @@ export async function publishCredential(did, reveal = false) {
             // Remove the credential values
             vc.credential = null;
         }
+
         doc.didDocumentData.manifest[credential] = vc;
 
         const ok = await updateDID(id.did, doc);

--- a/keymaster.test.js
+++ b/keymaster.test.js
@@ -794,18 +794,14 @@ describe('revokeDID', () => {
         await keymaster.createId('Bob');
         const mockAnchor = { name: 'mockAnchor' };
         const dataDid = await keymaster.createAsset(mockAnchor);
+
+        const ok = await keymaster.revokeDID(dataDid);
         const doc = await keymaster.resolveDID(dataDid);
 
-        const dataUpdated = { name: 'updated' };
-        doc.didDocumentData = dataUpdated;
-
-        const ok = await keymaster.revokeDID(dataDid, doc);
-        const doc2 = await keymaster.resolveDID(dataDid);
-
         expect(ok).toBe(true);
-        expect(doc2.didDocument).toStrictEqual({});
-        expect(doc2.didDocumentData).toStrictEqual({});
-        expect(doc2.didDocumentMetadata.deactivated).toBe(true);
+        expect(doc.didDocument).toStrictEqual({});
+        expect(doc.didDocumentData).toStrictEqual({});
+        expect(doc.didDocumentMetadata.deactivated).toBe(true);
     });
 
     it('should revoke an asset DID when current ID is not owner ID', async () => {
@@ -818,20 +814,16 @@ describe('revokeDID', () => {
 
         const mockAnchor = { name: 'mockAnchor' };
         const dataDid = await keymaster.createAsset(mockAnchor);
-        const doc = await keymaster.resolveDID(dataDid);
-
-        const dataUpdated = { name: 'updated' };
-        doc.didDocumentData = dataUpdated;
 
         keymaster.setCurrentId('Alice');
 
-        const ok = await keymaster.revokeDID(dataDid, doc);
-        const doc2 = await keymaster.resolveDID(dataDid);
+        const ok = await keymaster.revokeDID(dataDid);
+        const doc = await keymaster.resolveDID(dataDid);
 
         expect(ok).toBe(true);
-        expect(doc2.didDocument).toStrictEqual({});
-        expect(doc2.didDocumentData).toStrictEqual({});
-        expect(doc2.didDocumentMetadata.deactivated).toBe(true);
+        expect(doc.didDocument).toStrictEqual({});
+        expect(doc.didDocumentData).toStrictEqual({});
+        expect(doc.didDocumentMetadata.deactivated).toBe(true);
     });
 });
 


### PR DESCRIPTION
Adds an `Issued` subtab under Credentials with options to Resolve, Decrypt, and Revoke. Revoke will remove the credential from the list.

![image](https://github.com/KeychainMDIP/kc/assets/434644/81c02dd1-6f3b-4553-8908-8052a53edd30)

## Additionally

On the Credentials Held tab, the Remove button will be disabled unless the credential is unpublished

![image](https://github.com/KeychainMDIP/kc/assets/434644/63620e44-f52d-4057-b128-44e9d1a4089c)

 ## CLI changes
- `check-wallet` reports the number of invalid and deleted DIDs in the wallet
- `fix-wallet` removes invalid and deleted DIDs from the wallet
- `list-issued` returns a list of credentials issued by the current ID

The features to check and fix the wallet were added because of an issue (now fixed) that caused the wallet to fill up with ephemeral DIDs like challenges and responses that become invalid when they are garbage collected.

## hyperswarm-mediator

Another issue discovered and fixed was the hyperswarm-mediator was not properly distributing delete operations (revoke credential).

