### PR TITLE
Added params to getDIDs

### DIFF
--- a/admin-cli.js
+++ b/admin-cli.js
@@ -25,11 +25,11 @@ program
     });
 
 program
-    .command('get-dids')
+    .command('get-dids [updatedAfter]')
     .description('Fetch all DIDs')
-    .action(async () => {
+    .action(async (updatedAfter) => {
         try {
-            const dids = await gatekeeper.getDIDs();
+            const dids = await gatekeeper.getDIDs(updatedAfter);
             console.log(JSON.stringify(dids, null, 4));
         }
         catch (error) {

--- a/admin-cli.js
+++ b/admin-cli.js
@@ -25,11 +25,16 @@ program
     });
 
 program
-    .command('get-dids [updatedAfter]')
+    .command('get-dids [updatedAfter] [updatedBefore] [confirm] [resolve]')
     .description('Fetch all DIDs')
-    .action(async (updatedAfter) => {
+    .action(async (updatedAfter, updatedBefore, confirm, resolve) => {
         try {
-            const dids = await gatekeeper.getDIDs(updatedAfter);
+            const dids = await gatekeeper.getDIDs({
+                updatedAfter: updatedAfter,
+                updatedBefore: updatedBefore,
+                confirm: confirm,
+                resolve: resolve,
+            });
             console.log(JSON.stringify(dids, null, 4));
         }
         catch (error) {

--- a/gatekeeper-api.js
+++ b/gatekeeper-api.js
@@ -102,7 +102,12 @@ v1router.delete('/did/:did', async (req, res) => {
 
 v1router.get('/did/', async (req, res) => {
     try {
-        const dids = await gatekeeper.getDIDs(req.query.updatedAfter);
+        const dids = await gatekeeper.getDIDs({
+            updatedAfter: req.query.updatedAfter,
+            updatedBefore: req.query.updatedBefore,
+            confirm: req.query.confirm,
+            resolve: req.query.resolve,
+        });
         res.json(dids);
     } catch (error) {
         console.error(error);

--- a/gatekeeper-api.js
+++ b/gatekeeper-api.js
@@ -102,7 +102,7 @@ v1router.delete('/did/:did', async (req, res) => {
 
 v1router.get('/did/', async (req, res) => {
     try {
-        const dids = await gatekeeper.getDIDs();
+        const dids = await gatekeeper.getDIDs(req.query.updatedAfter);
         res.json(dids);
     } catch (error) {
         console.error(error);

--- a/gatekeeper-lib.js
+++ b/gatekeeper-lib.js
@@ -36,6 +36,10 @@ export async function verifyDID(did) {
 }
 
 export async function verifyDb(chatty = true) {
+    if (chatty) {
+        console.time('verifyDb');
+    }
+
     const dids = await db.getAllKeys();
     let n = 0;
     let invalid = 0;
@@ -55,6 +59,10 @@ export async function verifyDb(chatty = true) {
             invalid += 1;
             await db.deleteEvents(did);
         }
+    }
+
+    if (chatty) {
+        console.timeEnd('verifyDb');
     }
 
     return invalid;
@@ -328,16 +336,16 @@ export async function resolveDID(did, asOfTime = null, confirm = false, verify =
             break;
         }
 
-        const hash = cipher.hashJSON(doc);
+        // const hash = cipher.hashJSON(doc);
 
-        if (hash !== operation.prev) {
-            // hash mismatch
-            // if (verify) {
-            //     throw "Invalid hash";
-            // }
-            // !!! This fails on key rotation #3 (!?), disabling for now
-            // continue;
-        }
+        // if (hash !== operation.prev) {
+        //     // hash mismatch
+        //     // if (verify) {
+        //     //     throw "Invalid hash";
+        //     // }
+        //     // !!! This fails on key rotation #3 (!?), disabling for now
+        //     // continue;
+        // }
 
         const valid = await verifyUpdate(operation, doc);
 
@@ -423,9 +431,30 @@ export async function deleteDID(operation) {
     return updateDID(operation);
 }
 
-export async function getDIDs() {
+export async function getDIDs(updatedAfter) {
     const keys = await db.getAllKeys();
     const dids = keys.map(key => `${config.didPrefix}:${key}`);
+
+    if (updatedAfter) {
+        const start = new Date(updatedAfter);
+        const recent = [];
+
+        //console.time('resolveAll');
+        for (const did of dids) {
+            //console.time('resolveDID');
+            const doc = await resolveDID(did);
+            //console.timeEnd('resolveDID');
+            const updated = new Date(doc.didDocumentMetadata.updated || doc.didDocumentMetadata.created);
+
+            if (updated > start) {
+                recent.push(did);
+            }
+        }
+        //console.timeEnd('resolveAll');
+
+        return recent;
+    }
+
     return dids;
 }
 

--- a/gatekeeper-lib.js
+++ b/gatekeeper-lib.js
@@ -431,17 +431,17 @@ export async function deleteDID(operation) {
     return updateDID(operation);
 }
 
-export async function getDIDs({updatedAfter, updatedBefore} = {}) {
+export async function getDIDs({updatedAfter, updatedBefore, confirm, resolve} = {}) {
     const keys = await db.getAllKeys();
     const dids = keys.map(key => `${config.didPrefix}:${key}`);
 
-    if (updatedAfter || updatedBefore) {
+    if (updatedAfter || updatedBefore || resolve) {
         const start = updatedAfter ? new Date(updatedAfter) : null;
         const end = updatedBefore ? new Date(updatedBefore) : null;
-        const recent = [];
+        const response = [];
 
         for (const did of dids) {
-            const doc = await resolveDID(did);
+            const doc = await resolveDID(did, null, confirm);
             const updated = new Date(doc.didDocumentMetadata.updated || doc.didDocumentMetadata.created);
 
             if (start && updated <= start) {
@@ -452,10 +452,10 @@ export async function getDIDs({updatedAfter, updatedBefore} = {}) {
                 continue;
             }
 
-            recent.push(did);
+            response.push(resolve ? doc : did);
         }
 
-        return recent;
+        return response;
     }
 
     return dids;

--- a/gatekeeper-sdk.js
+++ b/gatekeeper-sdk.js
@@ -130,16 +130,28 @@ export async function deleteDID(operation) {
     }
 }
 
-export async function getDIDs(updatedAfter) {
+export async function getDIDs({updatedAfter, updatedBefore, confirm, resolve} = {}) {
     try {
+        let params = '';
+
         if (updatedAfter) {
-            const response = await axios.get(`${URL}/api/v1/did/?updatedAfter=${updatedAfter}`);
-            return response.data;
+            params += `updatedAfter=${updatedAfter}&`;
         }
-        else {
-            const response = await axios.get(`${URL}/api/v1/did/`);
-            return response.data;
+
+        if (updatedBefore) {
+            params += `updatedBefore=${updatedBefore}&`;
         }
+
+        if (confirm) {
+            params += `confirm=${confirm}&`;
+        }
+
+        if (resolve) {
+            params += `resolve=${resolve}&`;
+        }
+
+        const response = await axios.get(`${URL}/api/v1/did/?${params}`);
+        return response.data;
     }
     catch (error) {
         throwError(error);

--- a/gatekeeper-sdk.js
+++ b/gatekeeper-sdk.js
@@ -130,10 +130,16 @@ export async function deleteDID(operation) {
     }
 }
 
-export async function getDIDs() {
+export async function getDIDs(updatedAfter) {
     try {
-        const response = await axios.get(`${URL}/api/v1/did/`);
-        return response.data;
+        if (updatedAfter) {
+            const response = await axios.get(`${URL}/api/v1/did/?updatedAfter=${updatedAfter}`);
+            return response.data;
+        }
+        else {
+            const response = await axios.get(`${URL}/api/v1/did/`);
+            return response.data;
+        }
     }
     catch (error) {
         throwError(error);

--- a/gatekeeper.test.js
+++ b/gatekeeper.test.js
@@ -1086,6 +1086,55 @@ describe('getDids', () => {
         expect(allDocs[1]).toStrictEqual(assetDoc);
     });
 
+    it('should return all DIDs confirmed and resolved', async () => {
+        mockFs({});
+
+        const keypair = cipher.generateRandomJwk();
+        const agentOp = await createAgentOp(keypair, 1, 'TESS');
+        const agentDID = await gatekeeper.createDID(agentOp);
+        const agentDoc = await gatekeeper.resolveDID(agentDID);
+
+        const updatedAgentDoc = JSON.parse(JSON.stringify(agentDoc));
+        updatedAgentDoc.didDocumentData = { mock: 1 };
+        const updateOp = await createUpdateOp(keypair, agentDID, updatedAgentDoc);
+        await gatekeeper.updateDID(updateOp);
+
+        const assetOp = await createAssetOp(agentDID, keypair);
+        const assetDID = await gatekeeper.createDID(assetOp);
+        const assetDoc = await gatekeeper.resolveDID(assetDID);
+
+        const allDocs = await gatekeeper.getDIDs({confirm: true, resolve: true});
+
+        expect(allDocs.length).toBe(2);
+        expect(allDocs[0]).toStrictEqual(agentDoc); // version 1
+        expect(allDocs[1]).toStrictEqual(assetDoc);
+    });
+
+    it('should return all DIDs unconfirmed and resolved', async () => {
+        mockFs({});
+
+        const keypair = cipher.generateRandomJwk();
+        const agentOp = await createAgentOp(keypair, 1, 'TESS');
+        const agentDID = await gatekeeper.createDID(agentOp);
+        const agentDoc = await gatekeeper.resolveDID(agentDID);
+
+        const updatedAgentDoc = JSON.parse(JSON.stringify(agentDoc));
+        updatedAgentDoc.didDocumentData = { mock: 1 };
+        const updateOp = await createUpdateOp(keypair, agentDID, updatedAgentDoc);
+        await gatekeeper.updateDID(updateOp);
+        const agentDocv2 = await gatekeeper.resolveDID(agentDID);
+
+        const assetOp = await createAssetOp(agentDID, keypair);
+        const assetDID = await gatekeeper.createDID(assetOp);
+        const assetDoc = await gatekeeper.resolveDID(assetDID);
+
+        const allDocs = await gatekeeper.getDIDs({confirm: false, resolve: true});
+
+        expect(allDocs.length).toBe(2);
+        expect(allDocs[0]).toStrictEqual(agentDocv2);
+        expect(allDocs[1]).toStrictEqual(assetDoc);
+    });
+
     it('should return all DIDs after specified time', async () => {
         mockFs({});
 

--- a/gatekeeper.test.js
+++ b/gatekeeper.test.js
@@ -1064,6 +1064,31 @@ describe('getDids', () => {
         expect(allDIDs.includes(agentDID)).toBe(true);
         expect(allDIDs.includes(assetDID)).toBe(true);
     });
+
+    it('should return all DIDs after specified time', async () => {
+        mockFs({});
+
+        const keypair = cipher.generateRandomJwk();
+        const agentOp = await createAgentOp(keypair);
+        const agentDID = await gatekeeper.createDID(agentOp);
+        const dids = [];
+
+        for (let i = 0; i < 10; i++) {
+            const assetOp = await createAssetOp(agentDID, keypair);
+            const assetDID = await gatekeeper.createDID(assetOp);
+            dids.push(assetDID);
+        }
+
+        const doc = await gatekeeper.resolveDID(dids[4]);
+        const recentDIDs = await gatekeeper.getDIDs(doc.didDocumentMetadata.created);
+
+        expect(recentDIDs.length).toBe(5);
+        expect(recentDIDs.includes(dids[5])).toBe(true);
+        expect(recentDIDs.includes(dids[6])).toBe(true);
+        expect(recentDIDs.includes(dids[7])).toBe(true);
+        expect(recentDIDs.includes(dids[8])).toBe(true);
+        expect(recentDIDs.includes(dids[9])).toBe(true);
+    });
 });
 
 describe('listRegistries', () => {

--- a/gatekeeper.test.js
+++ b/gatekeeper.test.js
@@ -1016,7 +1016,7 @@ describe('clearQueue', () => {
 
     it('should return true if invalid queue specified', async () => {
         mockFs({});
-        
+
         const registry = 'TESS';
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, 1, registry);
@@ -1065,6 +1065,25 @@ describe('getDids', () => {
         expect(allDIDs.length).toBe(2);
         expect(allDIDs.includes(agentDID)).toBe(true);
         expect(allDIDs.includes(assetDID)).toBe(true);
+    });
+
+    it('should return all DIDs resolved', async () => {
+        mockFs({});
+
+        const keypair = cipher.generateRandomJwk();
+        const agentOp = await createAgentOp(keypair);
+        const agentDID = await gatekeeper.createDID(agentOp);
+        const agentDoc = await gatekeeper.resolveDID(agentDID);
+
+        const assetOp = await createAssetOp(agentDID, keypair);
+        const assetDID = await gatekeeper.createDID(assetOp);
+        const assetDoc = await gatekeeper.resolveDID(assetDID);
+
+        const allDocs = await gatekeeper.getDIDs({resolve: true});
+
+        expect(allDocs.length).toBe(2);
+        expect(allDocs[0]).toStrictEqual(agentDoc);
+        expect(allDocs[1]).toStrictEqual(assetDoc);
     });
 
     it('should return all DIDs after specified time', async () => {

--- a/keymaster-app/src/cipher-lib.js
+++ b/keymaster-app/src/cipher-lib.js
@@ -9,23 +9,34 @@ import { base64url } from 'multiformats/bases/base64';
 import canonicalize from 'canonicalize';
 
 let HDKey;
-if (typeof process !== 'undefined' && process.versions && process.versions.node) {
-    // Node.js environment
-    import('hdkey').then(module => {
-        HDKey = module.default || module;
-    });
-    import('node:crypto').then(({ webcrypto }) => {
-        if (!globalThis.crypto) globalThis.crypto = webcrypto;
-    });
-} else {
-    // Browser environment
-    import('browser-hdkey').then(module => {
-        HDKey = module.default || module;
-    });
-    import('buffer').then(({ Buffer }) => {
-        global.Buffer = Buffer;
-    });
-}
+
+// Temporary workaround for webpack issue.
+
+// if (typeof process !== 'undefined' && process.versions && process.versions.node) {
+//     // Node.js environment
+//     import('hdkey').then(module => {
+//         HDKey = module.default || module;
+//     });
+//     import('node:crypto').then(({ webcrypto }) => {
+//         if (!globalThis.crypto) globalThis.crypto = webcrypto;
+//     });
+// } else {
+//     // Browser environment
+//     import('browser-hdkey').then(module => {
+//         HDKey = module.default || module;
+//     });
+//     import('buffer').then(({ Buffer }) => {
+//         global.Buffer = Buffer;
+//     });
+// }
+
+// Browser environment
+import('browser-hdkey').then(module => {
+    HDKey = module.default || module;
+});
+import('buffer').then(({ Buffer }) => {
+    global.Buffer = Buffer;
+});
 
 // Polyfill for synchronous signatures
 // Recommendation from https://github.com/paulmillr/noble-secp256k1/blob/main/README.md


### PR DESCRIPTION
Adds 4 new parameters to gatekeeper.getDIDs:
- `updatedAfter` timestamp in ISO format, e.g. "2024-07-01T20:00Z" : return DIDs created or updated after timestamp
- `updatedBefore` timestamp in ISO format : return DIDs created or updated before timestamp
- `confirm` : return only confirmed updates
- `resolve` : return JSON list of resolved docs instead of DIDs

The corresponding API endpoint `/api/v1/did` takes the same parameters:

```
GET /api/v1/did/?updatedAfter=2024-07-01T20:00Z&updatedBefore=2024-07-021T20:00Z&confirm=null&resolve=true
```