### PR TITLE
Refactor docker build push

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -24,7 +24,7 @@ jobs:
       REGISTRY: ${{ env.REGISTRY }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Compute outputs
         run: |
@@ -58,10 +58,10 @@ jobs:
               ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/tess-mediator:${{ needs.generate.outputs.CALVER }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -69,7 +69,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -77,7 +77,7 @@ jobs:
             release
 
       - name: Build Docker images
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@1a162644f9a7e87d8f4b053101d1d9a712edc18c
         with:
           context: .
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,57 +17,69 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-image:
+  generate:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
+    outputs:
+      CALVER: ${{ steps.calculate-calver.outputs.calver }}
+      REGISTRY: ${{ env.REGISTRY }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      
+      - name: Compute outputs
+        run: |
+          echo "REGISTRY=${{ env.REGISTRY }}" >> $GITHUB_OUTPUT
 
+      - name: Calculate Calver
+        id: calculate-calver
+        run: |
+          calver=$(date +'%Y.%m.%d')
+          echo "calver=$calver" >> $GITHUB_ENV
+          echo "::set-output name=calver::$calver"
+          
+  build_test_images:
+    runs-on: ubuntu-latest
+    needs: generate
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: Dockerfile.gatekeeper
+            tags: |
+              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/gatekeeper:${{ needs.generate.outputs.CALVER }}
+          - dockerfile: Dockerfile.keymaster
+            tags: |
+              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/keymaster:${{ needs.generate.outputs.CALVER }}
+          - dockerfile: Dockerfile.hyperswarm
+            tags: |
+              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/hyperswarm-mediator:${{ needs.generate.outputs.CALVER }}
+          - dockerfile: Dockerfile.tess
+            tags: |
+              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/tess-mediator:${{ needs.generate.outputs.CALVER }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Generate CalVer Tag
-        id: calver
-        run: echo "::set-output name=version::v$(date +'%y.%m.%d')"
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            ${{ needs.generate.outputs.CALVER }}
+            release
 
-      - name: Build gatekeeper image
+      - name: Build Docker images
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
-          file: Dockerfile.gatekeeper
+          file: ${{ matrix.dockerfile }}
           push: false
-          tags: |
-            ${{ env.REGISTRY }}/keychainmdip/gatekeeper:${{ steps.calver.outputs.version }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Build keymaster image
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
-        with:
-          context: .
-          file: Dockerfile.keymaster
-          push: false
-          tags: |
-            ${{ env.REGISTRY }}/keychainmdip/keymaster:${{ steps.calver.outputs.version }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Build hyperswarm mediator image
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
-        with:
-          context: .
-          file: Dockerfile.hyperswarm
-          push: false
-          tags: |
-            ${{ env.REGISTRY }}/keychainmdip/hyperswarm-mediator:${{ steps.calver.outputs.version }}
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Build TESS mediator image
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
-        with:
-          context: .
-          file: Dockerfile.tess
-          push: false
-          tags: |
-            ${{ env.REGISTRY }}/keychainmdip/tess-mediator:${{ steps.calver.outputs.version }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@
 # To get a newer version, you will need to update the SHA.
 # You can also reference a tag or branch, but the action may change without warning.
 
-name: Build and publish Docker images
+name: Build & Publish
 
 on:
   push:
@@ -18,19 +18,56 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build-and-push-image:
+  generate:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
+    outputs:
+      CALVER: ${{ steps.calculate-calver.outputs.calver }}
+      REGISTRY: ${{ env.REGISTRY }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      
+      - name: Compute outputs
+        run: |
+          echo "REGISTRY=${{ env.REGISTRY }}" >> $GITHUB_OUTPUT
 
-      - name: Generate CalVer Tag
-        id: calver
-        run: echo "::set-output name=version::v$(date +'%y.%m.%d')"
+      - name: Calculate Calver
+        id: calculate-calver
+        run: |
+          calver=$(date +'%Y.%m.%d')
+          echo "calver=$calver" >> $GITHUB_ENV
+          echo "::set-output name=calver::$calver"
+          
+  build_test_images:
+    runs-on: ubuntu-latest
+    needs: generate
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: Dockerfile.gatekeeper
+            tags: |
+              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/gatekeeper:${{ needs.generate.outputs.CALVER }}
+              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/gatekeeper:release
+          - dockerfile: Dockerfile.keymaster
+            tags: |
+              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/keymaster:${{ needs.generate.outputs.CALVER }}
+              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/keymaster:release
+          - dockerfile: Dockerfile.hyperswarm
+            tags: |
+              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/hyperswarm-mediator:${{ needs.generate.outputs.CALVER }}
+              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/hyperswarm-mediator:release
+          - dockerfile: Dockerfile.tess
+            tags: |
+              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/tess-mediator:${{ needs.generate.outputs.CALVER }}
+              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/tess-mediator:release
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
@@ -45,49 +82,13 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            ${{ steps.calver.outputs.version }}
+            ${{ needs.generate.outputs.CALVER }}
             release
 
-      - name: Build and push gatekeeper image
+      - name: Build and push Docker images
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
-          file: Dockerfile.gatekeeper
+          file: ${{ matrix.dockerfile }}
           push: true
-          tags: |
-            ${{ env.REGISTRY }}/keychainmdip/gatekeeper:${{ steps.calver.outputs.version }}
-            ${{ env.REGISTRY }}/keychainmdip/gatekeeper:release
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Build and push keymaster image
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
-        with:
-          context: .
-          file: Dockerfile.keymaster
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/keychainmdip/keymaster:${{ steps.calver.outputs.version }}
-            ${{ env.REGISTRY }}/keychainmdip/keymaster:release
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Build and push hyperswarm mediator image
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
-        with:
-          context: .
-          file: Dockerfile.hyperswarm
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/keychainmdip/hyperswarm-mediator:${{ steps.calver.outputs.version }}
-            ${{ env.REGISTRY }}/keychainmdip/hyperswarm-mediator:release
-          labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Build and push TESS mediator image
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
-        with:
-          context: .
-          file: Dockerfile.tess
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/keychainmdip/tess-mediator:${{ steps.calver.outputs.version }}
-            ${{ env.REGISTRY }}/keychainmdip/tess-mediator:release
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,7 +25,7 @@ jobs:
       REGISTRY: ${{ env.REGISTRY }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       
       - name: Compute outputs
         run: |
@@ -67,10 +67,10 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -78,7 +78,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -86,7 +86,7 @@ jobs:
             release
 
       - name: Build and push Docker images
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@1a162644f9a7e87d8f4b053101d1d9a712edc18c
         with:
           context: .
           file: ${{ matrix.dockerfile }}


### PR DESCRIPTION
1. This improves maintenance & changes of adding new docker image builds to the CI pipeline. 
2. Also updates the GH actions that are using older node versions. 
3.  Improves build time by about 30-40 seconds as this introduces parallelism, and failure isolation where if one image fails, we are still able to build the rest of the images independently. 

