### PR TITLE
Refactors resolveDID parameters

### DIFF
--- a/admin-cli.js
+++ b/admin-cli.js
@@ -16,7 +16,7 @@ program
     .description('Return document associated with DID')
     .action(async (did, confirm) => {
         try {
-            const doc = await gatekeeper.resolveDID(did, null, !!confirm);
+            const doc = await gatekeeper.resolveDID(did, { confirm: !!confirm });
             console.log(JSON.stringify(doc, null, 4));
         }
         catch (error) {

--- a/admin-cli.js
+++ b/admin-cli.js
@@ -29,12 +29,29 @@ program
     .description('Fetch all DIDs')
     .action(async (updatedAfter, updatedBefore, confirm, resolve) => {
         try {
-            const dids = await gatekeeper.getDIDs({
-                updatedAfter: updatedAfter,
-                updatedBefore: updatedBefore,
-                confirm: confirm,
-                resolve: resolve,
-            });
+            let options = {};
+
+            const after = new Date(updatedAfter);
+
+            if (!isNaN(after.getTime())) {
+                options.updatedAfter = after.toISOString();
+            }
+
+            const before = new Date(updatedBefore);
+
+            if (!isNaN(before.getTime())) {
+                options.updatedBefore = before.toISOString();
+            }
+
+            if (confirm) {
+                options.confirm = confirm === 'true';
+            }
+
+            if (resolve) {
+                options.resolve = resolve === 'true';
+            }
+
+            const dids = await gatekeeper.getDIDs(options);
             console.log(JSON.stringify(dids, null, 4));
         }
         catch (error) {

--- a/doc/DID-scheme/README.md
+++ b/doc/DID-scheme/README.md
@@ -289,7 +289,7 @@ If invalid, the update is ignored, otherwise it is applied to the previous docum
 In pseudo-code:
 
 ```
-function resolveDid(did, asOfTime=now):
+function resolveDid(did, atTme=now):
     get suffix from did
     use suffix as content address to retrieve document seed from CAS
     if fail to retrieve the document seed
@@ -301,7 +301,7 @@ function resolveDid(did, asOfTime=now):
         return
     generate initial document from anchor
     retrieve all update operations from did's registry
-    for all updates until asOfTime:
+    for all updates until atTme:
         if signature is valid and update is valid:
             apply update to DID document
     return DID document

--- a/doc/DID-scheme/README.md
+++ b/doc/DID-scheme/README.md
@@ -289,7 +289,7 @@ If invalid, the update is ignored, otherwise it is applied to the previous docum
 In pseudo-code:
 
 ```
-function resolveDid(did, atTme=now):
+function resolveDid(did, atTime=now):
     get suffix from did
     use suffix as content address to retrieve document seed from CAS
     if fail to retrieve the document seed
@@ -301,7 +301,7 @@ function resolveDid(did, atTme=now):
         return
     generate initial document from anchor
     retrieve all update operations from did's registry
-    for all updates until atTme:
+    for all updates until atTime:
         if signature is valid and update is valid:
             apply update to DID document
     return DID document

--- a/gatekeeper-api.js
+++ b/gatekeeper-api.js
@@ -70,7 +70,7 @@ v1router.post('/did', async (req, res) => {
 
 v1router.get('/did/:did', async (req, res) => {
     try {
-        const doc = await gatekeeper.resolveDID(req.params.did, req.query.asof, req.query.confirm);
+        const doc = await gatekeeper.resolveDID(req.params.did, { asOfTime: req.query.asOfTime, confirm: req.query.confirm });
         res.json(doc);
     } catch (error) {
         console.error(error);
@@ -191,7 +191,7 @@ v1router.get('/registries', async (req, res) => {
 
 app.get('/explore/:did', async (req, res) => {
     try {
-        const doc = await gatekeeper.resolveDID(req.params.did, req.query.asof);
+        const doc = await gatekeeper.resolveDID(req.params.did, { asOfTime: req.query.asOfTime });
         var hthead = '<html><body>';
         hthead = hthead + '<h1>MDIP Network Explorer</h1>';
         hthead = hthead + '<table><tr><td><h3>' + req.params.did + '</h3></td>';

--- a/gatekeeper-api.js
+++ b/gatekeeper-api.js
@@ -70,7 +70,21 @@ v1router.post('/did', async (req, res) => {
 
 v1router.get('/did/:did', async (req, res) => {
     try {
-        const doc = await gatekeeper.resolveDID(req.params.did, { asOfTime: req.query.asOfTime, confirm: req.query.confirm });
+        const options = {};
+
+        if (req.query.asOfTime) {
+            options.asOfTime = req.query.asOfTime;
+        }
+
+        if (req.query.atVersion) {
+            options.atVersion = parseInt(req.query.atVersion);
+        }
+
+        if (req.query.confirm) {
+            options.confirm = req.query.confirm === 'true';
+        }
+
+        const doc = await gatekeeper.resolveDID(req.params.did, options);
         res.json(doc);
     } catch (error) {
         console.error(error);
@@ -102,12 +116,25 @@ v1router.delete('/did/:did', async (req, res) => {
 
 v1router.get('/did/', async (req, res) => {
     try {
-        const dids = await gatekeeper.getDIDs({
-            updatedAfter: req.query.updatedAfter,
-            updatedBefore: req.query.updatedBefore,
-            confirm: req.query.confirm,
-            resolve: req.query.resolve,
-        });
+        const options = {};
+
+        if (req.query.updatedAfter) {
+            options.updatedAfter = req.query.updatedAfter;
+        }
+
+        if (req.query.updatedBefore) {
+            options.updatedBefore = req.query.updatedBefore;
+        }
+
+        if (req.query.confirm) {
+            options.confirm = req.query.confirm === 'true';
+        }
+
+        if (req.query.resolve) {
+            options.resolve = req.query.resolve === 'true';
+        }
+
+        const dids = await gatekeeper.getDIDs(options);
         res.json(dids);
     } catch (error) {
         console.error(error);

--- a/gatekeeper-api.js
+++ b/gatekeeper-api.js
@@ -72,8 +72,8 @@ v1router.get('/did/:did', async (req, res) => {
     try {
         const options = {};
 
-        if (req.query.asOfTime) {
-            options.asOfTime = req.query.asOfTime;
+        if (req.query.atTme) {
+            options.atTme = req.query.atTme;
         }
 
         if (req.query.atVersion) {
@@ -218,7 +218,7 @@ v1router.get('/registries', async (req, res) => {
 
 app.get('/explore/:did', async (req, res) => {
     try {
-        const doc = await gatekeeper.resolveDID(req.params.did, { asOfTime: req.query.asOfTime });
+        const doc = await gatekeeper.resolveDID(req.params.did, { atTme: req.query.atTme });
         var hthead = '<html><body>';
         hthead = hthead + '<h1>MDIP Network Explorer</h1>';
         hthead = hthead + '<table><tr><td><h3>' + req.params.did + '</h3></td>';

--- a/gatekeeper-api.js
+++ b/gatekeeper-api.js
@@ -114,27 +114,9 @@ v1router.delete('/did/:did', async (req, res) => {
     }
 });
 
-v1router.get('/did/', async (req, res) => {
+v1router.post('/dids/', async (req, res) => {
     try {
-        const options = {};
-
-        if (req.query.updatedAfter) {
-            options.updatedAfter = req.query.updatedAfter;
-        }
-
-        if (req.query.updatedBefore) {
-            options.updatedBefore = req.query.updatedBefore;
-        }
-
-        if (req.query.confirm) {
-            options.confirm = req.query.confirm === 'true';
-        }
-
-        if (req.query.resolve) {
-            options.resolve = req.query.resolve === 'true';
-        }
-
-        const dids = await gatekeeper.getDIDs(options);
+        const dids = await gatekeeper.getDIDs(req.body);
         res.json(dids);
     } catch (error) {
         console.error(error);

--- a/gatekeeper-api.js
+++ b/gatekeeper-api.js
@@ -72,8 +72,8 @@ v1router.get('/did/:did', async (req, res) => {
     try {
         const options = {};
 
-        if (req.query.atTme) {
-            options.atTme = req.query.atTme;
+        if (req.query.atTime) {
+            options.atTime = req.query.atTime;
         }
 
         if (req.query.atVersion) {
@@ -200,7 +200,7 @@ v1router.get('/registries', async (req, res) => {
 
 app.get('/explore/:did', async (req, res) => {
     try {
-        const doc = await gatekeeper.resolveDID(req.params.did, { atTme: req.query.atTme });
+        const doc = await gatekeeper.resolveDID(req.params.did, { atTime: req.query.atTime });
         var hthead = '<html><body>';
         hthead = hthead + '<h1>MDIP Network Explorer</h1>';
         hthead = hthead + '<table><tr><td><h3>' + req.params.did + '</h3></td>';

--- a/gatekeeper-lib.js
+++ b/gatekeeper-lib.js
@@ -186,14 +186,10 @@ export async function createDID(operation) {
     }
 }
 
-async function generateDoc(anchor, asOfTime) {
+async function generateDoc(anchor) {
     try {
         if (!anchor?.mdip) {
             return {};
-        }
-
-        if (asOfTime && new Date(anchor.created) < new Date(asOfTime)) {
-            return {}; // DID was not yet created
         }
 
         if (!validVersions.includes(anchor.mdip.version)) {

--- a/gatekeeper-lib.js
+++ b/gatekeeper-lib.js
@@ -102,7 +102,7 @@ async function verifyCreateAsset(operation) {
         throw "Invalid operation";
     }
 
-    const doc = await resolveDID(operation.signature.signer, { asOfTime: operation.signature.signed });
+    const doc = await resolveDID(operation.signature.signer, { atTme: operation.signature.signed });
 
     if (doc.mdip.registry === 'local' && operation.mdip.registry !== 'local') {
         throw "Invalid operation";
@@ -267,7 +267,7 @@ async function verifyUpdate(operation, doc) {
     }
 
     if (doc.didDocument.controller) {
-        const controllerDoc = await resolveDID(doc.didDocument.controller, { asOfTime: operation.signature.signed });
+        const controllerDoc = await resolveDID(doc.didDocument.controller, { atTme: operation.signature.signed });
         return verifyUpdate(operation, controllerDoc);
     }
 
@@ -292,7 +292,7 @@ async function verifyUpdate(operation, doc) {
     return isValid;
 }
 
-export async function resolveDID(did, { asOfTime, atVersion, confirm, verify } = {}) {
+export async function resolveDID(did, { atTme, atVersion, confirm, verify } = {}) {
     const events = await db.getEvents(did);
 
     if (events.length === 0) {
@@ -307,7 +307,7 @@ export async function resolveDID(did, { asOfTime, atVersion, confirm, verify } =
         throw "Invalid DID";
     }
 
-    if (asOfTime && new Date(mdip.created) > new Date(asOfTime)) {
+    if (atTme && new Date(mdip.created) > new Date(atTme)) {
         // TBD What to return if DID was created after specified time?
     }
 
@@ -322,7 +322,7 @@ export async function resolveDID(did, { asOfTime, atVersion, confirm, verify } =
             continue;
         }
 
-        if (asOfTime && new Date(time) > new Date(asOfTime)) {
+        if (atTme && new Date(time) > new Date(atTme)) {
             break;
         }
 

--- a/gatekeeper-lib.js
+++ b/gatekeeper-lib.js
@@ -292,7 +292,7 @@ async function verifyUpdate(operation, doc) {
     return isValid;
 }
 
-export async function resolveDID(did, { asOfTime, confirm, verify } = {}) {
+export async function resolveDID(did, { asOfTime, atVersion, confirm, verify } = {}) {
     const events = await db.getEvents(did);
 
     if (events.length === 0) {
@@ -332,17 +332,6 @@ export async function resolveDID(did, { asOfTime, confirm, verify } = {}) {
             break;
         }
 
-        // const hash = cipher.hashJSON(doc);
-
-        // if (hash !== operation.prev) {
-        //     // hash mismatch
-        //     // if (verify) {
-        //     //     throw "Invalid hash";
-        //     // }
-        //     // !!! This fails on key rotation #3 (!?), disabling for now
-        //     // continue;
-        // }
-
         const valid = await verifyUpdate(operation, doc);
 
         if (!valid) {
@@ -381,6 +370,10 @@ export async function resolveDID(did, { asOfTime, confirm, verify } = {}) {
             }
 
             console.error(`unknown type ${operation.type}`);
+        }
+
+        if (atVersion && version === atVersion) {
+            break;
         }
     }
 

--- a/gatekeeper-lib.js
+++ b/gatekeeper-lib.js
@@ -102,7 +102,7 @@ async function verifyCreateAsset(operation) {
         throw "Invalid operation";
     }
 
-    const doc = await resolveDID(operation.signature.signer, { atTme: operation.signature.signed });
+    const doc = await resolveDID(operation.signature.signer, { atTime: operation.signature.signed });
 
     if (doc.mdip.registry === 'local' && operation.mdip.registry !== 'local') {
         throw "Invalid operation";
@@ -267,7 +267,7 @@ async function verifyUpdate(operation, doc) {
     }
 
     if (doc.didDocument.controller) {
-        const controllerDoc = await resolveDID(doc.didDocument.controller, { atTme: operation.signature.signed });
+        const controllerDoc = await resolveDID(doc.didDocument.controller, { atTime: operation.signature.signed });
         return verifyUpdate(operation, controllerDoc);
     }
 
@@ -292,7 +292,7 @@ async function verifyUpdate(operation, doc) {
     return isValid;
 }
 
-export async function resolveDID(did, { atTme, atVersion, confirm, verify } = {}) {
+export async function resolveDID(did, { atTime, atVersion, confirm, verify } = {}) {
     const events = await db.getEvents(did);
 
     if (events.length === 0) {
@@ -307,7 +307,7 @@ export async function resolveDID(did, { atTme, atVersion, confirm, verify } = {}
         throw "Invalid DID";
     }
 
-    if (atTme && new Date(mdip.created) > new Date(atTme)) {
+    if (atTime && new Date(mdip.created) > new Date(atTime)) {
         // TBD What to return if DID was created after specified time?
     }
 
@@ -322,7 +322,7 @@ export async function resolveDID(did, { atTme, atVersion, confirm, verify } = {}
             continue;
         }
 
-        if (atTme && new Date(time) > new Date(atTme)) {
+        if (atTime && new Date(time) > new Date(atTime)) {
             break;
         }
 

--- a/gatekeeper-lib.js
+++ b/gatekeeper-lib.js
@@ -420,9 +420,11 @@ export async function deleteDID(operation) {
     return updateDID(operation);
 }
 
-export async function getDIDs({ updatedAfter, updatedBefore, confirm, resolve } = {}) {
-    const keys = await db.getAllKeys();
-    const dids = keys.map(key => `${config.didPrefix}:${key}`);
+export async function getDIDs({ dids, updatedAfter, updatedBefore, confirm, resolve } = {}) {
+    if (!dids) {
+        const keys = await db.getAllKeys();
+        dids = keys.map(key => `${config.didPrefix}:${key}`);
+    }
 
     if (updatedAfter || updatedBefore || resolve) {
         const start = updatedAfter ? new Date(updatedAfter) : null;

--- a/gatekeeper-sdk.js
+++ b/gatekeeper-sdk.js
@@ -138,27 +138,37 @@ export async function deleteDID(operation) {
     }
 }
 
-export async function getDIDs({ updatedAfter, updatedBefore, confirm, resolve } = {}) {
+// export async function getDIDs({ updatedAfter, updatedBefore, confirm, resolve } = {}) {
+//     try {
+//         let params = '';
+
+//         if (updatedAfter) {
+//             params += `updatedAfter=${updatedAfter}&`;
+//         }
+
+//         if (updatedBefore) {
+//             params += `updatedBefore=${updatedBefore}&`;
+//         }
+
+//         if (confirm) {
+//             params += `confirm=${confirm}&`;
+//         }
+
+//         if (resolve) {
+//             params += `resolve=${resolve}&`;
+//         }
+
+//         const response = await axios.get(`${URL}/api/v1/dids/?${params}`);
+//         return response.data;
+//     }
+//     catch (error) {
+//         throwError(error);
+//     }
+// }
+
+export async function getDIDs(options = {}) {
     try {
-        let params = '';
-
-        if (updatedAfter) {
-            params += `updatedAfter=${updatedAfter}&`;
-        }
-
-        if (updatedBefore) {
-            params += `updatedBefore=${updatedBefore}&`;
-        }
-
-        if (confirm) {
-            params += `confirm=${confirm}&`;
-        }
-
-        if (resolve) {
-            params += `resolve=${resolve}&`;
-        }
-
-        const response = await axios.get(`${URL}/api/v1/did/?${params}`);
+        const response = await axios.post(`${URL}/api/v1/dids/`, options);
         return response.data;
     }
     catch (error) {

--- a/gatekeeper-sdk.js
+++ b/gatekeeper-sdk.js
@@ -94,12 +94,12 @@ export async function createDID(operation) {
     }
 }
 
-export async function resolveDID(did, { atTme, atVersion, confirm } = {}) {
+export async function resolveDID(did, { atTime, atVersion, confirm } = {}) {
     try {
         let params = '';
 
-        if (atTme) {
-            params += `atTme=${atTme}&`;
+        if (atTime) {
+            params += `atTime=${atTime}&`;
         }
 
         if (atVersion) {

--- a/gatekeeper-sdk.js
+++ b/gatekeeper-sdk.js
@@ -94,12 +94,16 @@ export async function createDID(operation) {
     }
 }
 
-export async function resolveDID(did, { asOfTime, confirm } = {}) {
+export async function resolveDID(did, { asOfTime, atVersion, confirm } = {}) {
     try {
         let params = '';
 
         if (asOfTime) {
             params += `asOfTime=${asOfTime}&`;
+        }
+
+        if (atVersion) {
+            params += `atVersion=${atVersion}&`;
         }
 
         if (confirm) {

--- a/gatekeeper-sdk.js
+++ b/gatekeeper-sdk.js
@@ -94,12 +94,12 @@ export async function createDID(operation) {
     }
 }
 
-export async function resolveDID(did, { asOfTime, atVersion, confirm } = {}) {
+export async function resolveDID(did, { atTme, atVersion, confirm } = {}) {
     try {
         let params = '';
 
-        if (asOfTime) {
-            params += `asOfTime=${asOfTime}&`;
+        if (atTme) {
+            params += `atTme=${atTme}&`;
         }
 
         if (atVersion) {

--- a/gatekeeper-sdk.js
+++ b/gatekeeper-sdk.js
@@ -94,16 +94,20 @@ export async function createDID(operation) {
     }
 }
 
-export async function resolveDID(did, asof = null, confirm = false) {
+export async function resolveDID(did, { asOfTime, confirm } = {}) {
     try {
-        if (asof || confirm) {
-            const response = await axios.get(`${URL}/api/v1/did/${did}?asof=${asof}&confirm=${confirm}`);
-            return response.data;
+        let params = '';
+
+        if (asOfTime) {
+            params += `asOfTime=${asOfTime}&`;
         }
-        else {
-            const response = await axios.get(`${URL}/api/v1/did/${did}`);
-            return response.data;
+
+        if (confirm) {
+            params += `confirm=${confirm}&`;
         }
+
+        const response = await axios.get(`${URL}/api/v1/did/${did}?${params}`);
+        return response.data;
     }
     catch (error) {
         throwError(error);
@@ -130,7 +134,7 @@ export async function deleteDID(operation) {
     }
 }
 
-export async function getDIDs({updatedAfter, updatedBefore, confirm, resolve} = {}) {
+export async function getDIDs({ updatedAfter, updatedBefore, confirm, resolve } = {}) {
     try {
         let params = '';
 

--- a/gatekeeper.test.js
+++ b/gatekeeper.test.js
@@ -379,6 +379,33 @@ describe('resolveDID', () => {
         expect(doc).toStrictEqual(expected);
     });
 
+    it('should resolve specified version', async () => {
+
+        mockFs({});
+
+        const keypair = cipher.generateRandomJwk();
+        const agentOp = await createAgentOp(keypair);
+        const did = await gatekeeper.createDID(agentOp);
+
+        let expected;
+
+        // Add 10 versions, save one from the middle
+        for (let i = 0; i < 10; i++) {
+            const update = await gatekeeper.resolveDID(did);
+
+            if (i == 5) {
+                expected = update;
+            }
+
+            update.didDocumentData = { mock: 1 };
+            const updateOp = await createUpdateOp(keypair, did, update);
+            await gatekeeper.updateDID(updateOp);
+        }
+
+        const doc = await gatekeeper.resolveDID(did, { atVersion: expected.didDocumentMetadata.version });
+        expect(doc).toStrictEqual(expected);
+    });
+
     it('should resolve a valid asset DID', async () => {
         mockFs({});
 

--- a/gatekeeper.test.js
+++ b/gatekeeper.test.js
@@ -375,7 +375,7 @@ describe('resolveDID', () => {
             await gatekeeper.updateDID(updateOp);
         }
 
-        const doc = await gatekeeper.resolveDID(did, { asOfTime: expected.didDocumentMetadata.updated });
+        const doc = await gatekeeper.resolveDID(did, { atTme: expected.didDocumentMetadata.updated });
         expect(doc).toStrictEqual(expected);
     });
 

--- a/gatekeeper.test.js
+++ b/gatekeeper.test.js
@@ -375,7 +375,7 @@ describe('resolveDID', () => {
             await gatekeeper.updateDID(updateOp);
         }
 
-        const doc = await gatekeeper.resolveDID(did, { atTme: expected.didDocumentMetadata.updated });
+        const doc = await gatekeeper.resolveDID(did, { atTime: expected.didDocumentMetadata.updated });
         expect(doc).toStrictEqual(expected);
     });
 

--- a/gatekeeper.test.js
+++ b/gatekeeper.test.js
@@ -1241,6 +1241,34 @@ describe('getDids', () => {
         expect(recentDIDs.includes(dids[6])).toBe(true);
         expect(recentDIDs.includes(dids[7])).toBe(true);
     });
+
+    it('should resolve all specified DIDs', async () => {
+        mockFs({});
+
+        const keypair = cipher.generateRandomJwk();
+        const agentOp = await createAgentOp(keypair);
+        const agentDID = await gatekeeper.createDID(agentOp);
+        const dids = [];
+        const expected = [];
+
+        for (let i = 0; i < 10; i++) {
+            const assetOp = await createAssetOp(agentDID, keypair);
+            const assetDID = await gatekeeper.createDID(assetOp);
+            dids.push(assetDID);
+            expected.push(await gatekeeper.resolveDID(assetDID));
+        }
+
+        const resolvedDIDs = await gatekeeper.getDIDs({
+            dids: dids,
+            resolve: true
+        });
+
+        expect(resolvedDIDs.length).toBe(10);
+
+        for (let i = 0; i < 10; i++) {
+            expect(resolvedDIDs[i]).toStrictEqual(expected[i]);
+        }
+    });
 });
 
 describe('listRegistries', () => {

--- a/keychain-cli.js
+++ b/keychain-cli.js
@@ -243,6 +243,19 @@ program
     });
 
 program
+    .command('resolve-did-version <did> <version>')
+    .description('Return specified version of document associated with DID')
+    .action(async (did, version) => {
+        try {
+            const doc = await keymaster.resolveDID(did, { atVersion: version });
+            console.log(JSON.stringify(doc, null, 4));
+        }
+        catch (error) {
+            console.error(`cannot resolve ${did}`);
+        }
+    });
+
+program
     .command('encrypt-msg <msg> <did>')
     .description('Encrypt a message for a DID')
     .action(async (msg, did) => {

--- a/keychain-cli.js
+++ b/keychain-cli.js
@@ -234,7 +234,7 @@ program
     .description('Return document associated with DID')
     .action(async (did, confirm) => {
         try {
-            const doc = await keymaster.resolveDID(did, null, !!confirm);
+            const doc = await keymaster.resolveDID(did, { confirm: !!confirm });
             console.log(JSON.stringify(doc, null, 4));
         }
         catch (error) {

--- a/keymaster-app/src/gatekeeper-sdk.js
+++ b/keymaster-app/src/gatekeeper-sdk.js
@@ -138,27 +138,37 @@ export async function deleteDID(operation) {
     }
 }
 
-export async function getDIDs({ updatedAfter, updatedBefore, confirm, resolve } = {}) {
+// export async function getDIDs({ updatedAfter, updatedBefore, confirm, resolve } = {}) {
+//     try {
+//         let params = '';
+
+//         if (updatedAfter) {
+//             params += `updatedAfter=${updatedAfter}&`;
+//         }
+
+//         if (updatedBefore) {
+//             params += `updatedBefore=${updatedBefore}&`;
+//         }
+
+//         if (confirm) {
+//             params += `confirm=${confirm}&`;
+//         }
+
+//         if (resolve) {
+//             params += `resolve=${resolve}&`;
+//         }
+
+//         const response = await axios.get(`${URL}/api/v1/dids/?${params}`);
+//         return response.data;
+//     }
+//     catch (error) {
+//         throwError(error);
+//     }
+// }
+
+export async function getDIDs(options = {}) {
     try {
-        let params = '';
-
-        if (updatedAfter) {
-            params += `updatedAfter=${updatedAfter}&`;
-        }
-
-        if (updatedBefore) {
-            params += `updatedBefore=${updatedBefore}&`;
-        }
-
-        if (confirm) {
-            params += `confirm=${confirm}&`;
-        }
-
-        if (resolve) {
-            params += `resolve=${resolve}&`;
-        }
-
-        const response = await axios.get(`${URL}/api/v1/did/?${params}`);
+        const response = await axios.post(`${URL}/api/v1/dids/`, options);
         return response.data;
     }
     catch (error) {

--- a/keymaster-app/src/gatekeeper-sdk.js
+++ b/keymaster-app/src/gatekeeper-sdk.js
@@ -94,12 +94,12 @@ export async function createDID(operation) {
     }
 }
 
-export async function resolveDID(did, { atTme, atVersion, confirm } = {}) {
+export async function resolveDID(did, { atTime, atVersion, confirm } = {}) {
     try {
         let params = '';
 
-        if (atTme) {
-            params += `atTme=${atTme}&`;
+        if (atTime) {
+            params += `atTime=${atTime}&`;
         }
 
         if (atVersion) {

--- a/keymaster-app/src/gatekeeper-sdk.js
+++ b/keymaster-app/src/gatekeeper-sdk.js
@@ -94,12 +94,16 @@ export async function createDID(operation) {
     }
 }
 
-export async function resolveDID(did, { asOfTime, confirm } = {}) {
+export async function resolveDID(did, { atTme, atVersion, confirm } = {}) {
     try {
         let params = '';
 
-        if (asOfTime) {
-            params += `asOfTime=${asOfTime}&`;
+        if (atTme) {
+            params += `atTme=${atTme}&`;
+        }
+
+        if (atVersion) {
+            params += `atVersion=${atVersion}&`;
         }
 
         if (confirm) {

--- a/keymaster-app/src/gatekeeper-sdk.js
+++ b/keymaster-app/src/gatekeeper-sdk.js
@@ -94,16 +94,20 @@ export async function createDID(operation) {
     }
 }
 
-export async function resolveDID(did, asof = null, confirm = false) {
+export async function resolveDID(did, { asOfTime, confirm } = {}) {
     try {
-        if (asof || confirm) {
-            const response = await axios.get(`${URL}/api/v1/did/${did}?asof=${asof}&confirm=${confirm}`);
-            return response.data;
+        let params = '';
+
+        if (asOfTime) {
+            params += `asOfTime=${asOfTime}&`;
         }
-        else {
-            const response = await axios.get(`${URL}/api/v1/did/${did}`);
-            return response.data;
+
+        if (confirm) {
+            params += `confirm=${confirm}&`;
         }
+
+        const response = await axios.get(`${URL}/api/v1/did/${did}?${params}`);
+        return response.data;
     }
     catch (error) {
         throwError(error);
@@ -130,9 +134,27 @@ export async function deleteDID(operation) {
     }
 }
 
-export async function getDIDs() {
+export async function getDIDs({ updatedAfter, updatedBefore, confirm, resolve } = {}) {
     try {
-        const response = await axios.get(`${URL}/api/v1/did/`);
+        let params = '';
+
+        if (updatedAfter) {
+            params += `updatedAfter=${updatedAfter}&`;
+        }
+
+        if (updatedBefore) {
+            params += `updatedBefore=${updatedBefore}&`;
+        }
+
+        if (confirm) {
+            params += `confirm=${confirm}&`;
+        }
+
+        if (resolve) {
+            params += `resolve=${resolve}&`;
+        }
+
+        const response = await axios.get(`${URL}/api/v1/did/?${params}`);
         return response.data;
     }
     catch (error) {

--- a/keymaster-app/src/keymaster-lib.js
+++ b/keymaster-app/src/keymaster-lib.js
@@ -397,7 +397,7 @@ export async function decrypt(did) {
         throw "DID is not encrypted";
     }
 
-    const doc = await resolveDID(crypt.sender, { asOfTime: crypt.created });
+    const doc = await resolveDID(crypt.sender, { atTme: crypt.created });
     const publicJwk = doc.didDocument.verificationMethod[0].publicKeyJwk;
     const hdkey = cipher.generateHDKeyJSON(wallet.seed.hdkey);
     const ciphertext = (crypt.sender === id.did && crypt.cipher_sender) ? crypt.cipher_sender : crypt.cipher_receiver;
@@ -466,7 +466,7 @@ export async function verifySignature(obj) {
         return false;
     }
 
-    const doc = await resolveDID(signature.signer, { asOfTime: signature.signed });
+    const doc = await resolveDID(signature.signer, { atTme: signature.signed });
 
     // TBD get the right signature, not just the first one
     const publicJwk = doc.didDocument.verificationMethod[0].publicKeyJwk;

--- a/keymaster-app/src/keymaster-lib.js
+++ b/keymaster-app/src/keymaster-lib.js
@@ -397,7 +397,7 @@ export async function decrypt(did) {
         throw "DID is not encrypted";
     }
 
-    const doc = await resolveDID(crypt.sender, { atTme: crypt.created });
+    const doc = await resolveDID(crypt.sender, { atTime: crypt.created });
     const publicJwk = doc.didDocument.verificationMethod[0].publicKeyJwk;
     const hdkey = cipher.generateHDKeyJSON(wallet.seed.hdkey);
     const ciphertext = (crypt.sender === id.did && crypt.cipher_sender) ? crypt.cipher_sender : crypt.cipher_receiver;
@@ -466,7 +466,7 @@ export async function verifySignature(obj) {
         return false;
     }
 
-    const doc = await resolveDID(signature.signer, { atTme: signature.signed });
+    const doc = await resolveDID(signature.signer, { atTime: signature.signed });
 
     // TBD get the right signature, not just the first one
     const publicJwk = doc.didDocument.verificationMethod[0].publicKeyJwk;

--- a/keymaster-app/src/keymaster-lib.js
+++ b/keymaster-app/src/keymaster-lib.js
@@ -397,7 +397,7 @@ export async function decrypt(did) {
         throw "DID is not encrypted";
     }
 
-    const doc = await resolveDID(crypt.sender, crypt.created);
+    const doc = await resolveDID(crypt.sender, { asOfTime: crypt.created });
     const publicJwk = doc.didDocument.verificationMethod[0].publicKeyJwk;
     const hdkey = cipher.generateHDKeyJSON(wallet.seed.hdkey);
     const ciphertext = (crypt.sender === id.did && crypt.cipher_sender) ? crypt.cipher_sender : crypt.cipher_receiver;
@@ -466,7 +466,7 @@ export async function verifySignature(obj) {
         return false;
     }
 
-    const doc = await resolveDID(signature.signer, signature.signed);
+    const doc = await resolveDID(signature.signer, { asOfTime: signature.signed });
 
     // TBD get the right signature, not just the first one
     const publicJwk = doc.didDocument.verificationMethod[0].publicKeyJwk;
@@ -564,8 +564,8 @@ function removeFromHeld(did) {
     return false;
 }
 
-export async function resolveDID(did, asof, confirm) {
-    const doc = await gatekeeper.resolveDID(lookupDID(did), asof, confirm);
+export async function resolveDID(did, options = {}) {
+    const doc = await gatekeeper.resolveDID(lookupDID(did), options);
     return doc;
 }
 

--- a/keymaster-lib.js
+++ b/keymaster-lib.js
@@ -397,7 +397,7 @@ export async function decrypt(did) {
         throw "DID is not encrypted";
     }
 
-    const doc = await resolveDID(crypt.sender, { asOfTime: crypt.created });
+    const doc = await resolveDID(crypt.sender, { atTme: crypt.created });
     const publicJwk = doc.didDocument.verificationMethod[0].publicKeyJwk;
     const hdkey = cipher.generateHDKeyJSON(wallet.seed.hdkey);
     const ciphertext = (crypt.sender === id.did && crypt.cipher_sender) ? crypt.cipher_sender : crypt.cipher_receiver;
@@ -466,7 +466,7 @@ export async function verifySignature(obj) {
         return false;
     }
 
-    const doc = await resolveDID(signature.signer, { asOfTime: signature.signed });
+    const doc = await resolveDID(signature.signer, { atTme: signature.signed });
 
     // TBD get the right signature, not just the first one
     const publicJwk = doc.didDocument.verificationMethod[0].publicKeyJwk;

--- a/keymaster-lib.js
+++ b/keymaster-lib.js
@@ -397,7 +397,7 @@ export async function decrypt(did) {
         throw "DID is not encrypted";
     }
 
-    const doc = await resolveDID(crypt.sender, { atTme: crypt.created });
+    const doc = await resolveDID(crypt.sender, { atTime: crypt.created });
     const publicJwk = doc.didDocument.verificationMethod[0].publicKeyJwk;
     const hdkey = cipher.generateHDKeyJSON(wallet.seed.hdkey);
     const ciphertext = (crypt.sender === id.did && crypt.cipher_sender) ? crypt.cipher_sender : crypt.cipher_receiver;
@@ -466,7 +466,7 @@ export async function verifySignature(obj) {
         return false;
     }
 
-    const doc = await resolveDID(signature.signer, { atTme: signature.signed });
+    const doc = await resolveDID(signature.signer, { atTime: signature.signed });
 
     // TBD get the right signature, not just the first one
     const publicJwk = doc.didDocument.verificationMethod[0].publicKeyJwk;

--- a/keymaster-lib.js
+++ b/keymaster-lib.js
@@ -397,7 +397,7 @@ export async function decrypt(did) {
         throw "DID is not encrypted";
     }
 
-    const doc = await resolveDID(crypt.sender, crypt.created);
+    const doc = await resolveDID(crypt.sender, { asOfTime: crypt.created });
     const publicJwk = doc.didDocument.verificationMethod[0].publicKeyJwk;
     const hdkey = cipher.generateHDKeyJSON(wallet.seed.hdkey);
     const ciphertext = (crypt.sender === id.did && crypt.cipher_sender) ? crypt.cipher_sender : crypt.cipher_receiver;
@@ -466,7 +466,7 @@ export async function verifySignature(obj) {
         return false;
     }
 
-    const doc = await resolveDID(signature.signer, signature.signed);
+    const doc = await resolveDID(signature.signer, { asOfTime: signature.signed });
 
     // TBD get the right signature, not just the first one
     const publicJwk = doc.didDocument.verificationMethod[0].publicKeyJwk;
@@ -564,8 +564,8 @@ function removeFromHeld(did) {
     return false;
 }
 
-export async function resolveDID(did, asof, confirm) {
-    const doc = await gatekeeper.resolveDID(lookupDID(did), asof, confirm);
+export async function resolveDID(did, options = {}) {
+    const doc = await gatekeeper.resolveDID(lookupDID(did), options);
     return doc;
 }
 


### PR DESCRIPTION
`resolveDID` options are now specified by name instead of position, e.g.

```
const doc = await resolveDID(operation.signature.signer, { 
    atTime: operation.signature.signed, 
    confirm: true
});
```

Also adds `dids` parameter to `getDIDs` (defaults to all DIDs). In order to accomodate an array of DIDs, the corresponding gatekeeper endpoint has changed from 
```
GET /api/v1/did
```
to
```
POST /api/v1/dids
```