### PR TITLE
feat: Add registry dropdowns to create assets

### DIFF
--- a/kc-app/src/KeymasterUI.js
+++ b/kc-app/src/KeymasterUI.js
@@ -435,7 +435,7 @@ function KeymasterUI({ keymaster, title }) {
 
     async function issueCredential() {
         try {
-            const did = await keymaster.issueCredential(JSON.parse(credentialString));
+            const did = await keymaster.issueCredential(JSON.parse(credentialString), registry);
             setCredentialDID(did);
             // Add did to issuedList
             setIssuedList(prevIssuedList => [...prevIssuedList, did]);
@@ -1261,14 +1261,28 @@ function KeymasterUI({ keymaster, title }) {
                                                             Issue Credential
                                                         </Button>
                                                     </Grid>
-                                                    {credentialDID &&
-                                                        <Grid item>
-                                                            <Typography style={{ fontSize: '1em', fontFamily: 'Courier' }}>
-                                                                {credentialDID}
-                                                            </Typography>
-                                                        </Grid>
-                                                    }
+                                                    <Grid item>on registry:
+                                                        <Select
+                                                            style={{ width: '300px' }}
+                                                            value={registry}
+                                                            fullWidth
+                                                            onChange={(event) => setRegistry(event.target.value)}
+                                                        >
+                                                            {registries.map((registry, index) => (
+                                                                <MenuItem value={registry} key={index}>
+                                                                    {registry}
+                                                                </MenuItem>
+                                                            ))}
+                                                        </Select>
+                                                    </Grid>
                                                 </Grid>
+                                                {credentialDID &&
+                                                    <Grid item>
+                                                        <Typography style={{ fontSize: '1em', fontFamily: 'Courier' }}>
+                                                            {credentialDID}
+                                                        </Typography>
+                                                    </Grid>
+                                                }
                                             </Grid>
                                         </Box>
                                     }

--- a/kc-app/src/KeymasterUI.js
+++ b/kc-app/src/KeymasterUI.js
@@ -332,7 +332,7 @@ function KeymasterUI({ keymaster, title }) {
                 return;
             }
 
-            const groupDID = await keymaster.createGroup(groupName);
+            const groupDID = await keymaster.createGroup(groupName, registry);
             await keymaster.addName(groupName, groupDID);
 
             setGroupName('');
@@ -391,7 +391,7 @@ function KeymasterUI({ keymaster, title }) {
                 return;
             }
 
-            const schemaDID = await keymaster.createSchema();
+            const schemaDID = await keymaster.createSchema(null, registry);
             await keymaster.addName(schemaName, schemaDID);
 
             setSchemaName('');
@@ -941,6 +941,20 @@ function KeymasterUI({ keymaster, title }) {
                                         Create Group
                                     </Button>
                                 </Grid>
+                                <Grid item>
+                                    <Select
+                                        style={{ width: '300px' }}
+                                        value={registry}
+                                        fullWidth
+                                        onChange={(event) => setRegistry(event.target.value)}
+                                    >
+                                        {registries.map((registry, index) => (
+                                            <MenuItem value={registry} key={index}>
+                                                {registry}
+                                            </MenuItem>
+                                        ))}
+                                    </Select>
+                                </Grid>
                             </Grid>
                             {groupList &&
                                 <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
@@ -1047,6 +1061,20 @@ function KeymasterUI({ keymaster, title }) {
                                     <Button variant="contained" color="primary" onClick={createSchema} disabled={!schemaName}>
                                         Create Schema
                                     </Button>
+                                </Grid>
+                                <Grid item>
+                                    <Select
+                                        style={{ width: '300px' }}
+                                        value={registry}
+                                        fullWidth
+                                        onChange={(event) => setRegistry(event.target.value)}
+                                    >
+                                        {registries.map((registry, index) => (
+                                            <MenuItem value={registry} key={index}>
+                                                {registry}
+                                            </MenuItem>
+                                        ))}
+                                    </Select>
                                 </Grid>
                             </Grid>
                             {schemaList &&
@@ -1261,7 +1289,7 @@ function KeymasterUI({ keymaster, title }) {
                                                             Issue Credential
                                                         </Button>
                                                     </Grid>
-                                                    <Grid item>on registry:
+                                                    <Grid item>
                                                         <Select
                                                             style={{ width: '300px' }}
                                                             value={registry}

--- a/kc-app/src/keymaster-sdk.js
+++ b/kc-app/src/keymaster-sdk.js
@@ -248,9 +248,9 @@ export async function verifyResponse(responseDID, challengeDID) {
     }
 }
 
-export async function createGroup(group) {
+export async function createGroup(name, registry) {
     try {
-        const response = await axios.post(`/api/v1/groups`, { name: group });
+        const response = await axios.post(`/api/v1/groups`, { name, registry });
         return response.data;
     }
     catch (error) {
@@ -298,9 +298,9 @@ export async function groupTest(group, member) {
     }
 }
 
-export async function createSchema(schema) {
+export async function createSchema(schema, registry) {
     try {
-        const response = await axios.post(`/api/v1/schemas`, { schema });
+        const response = await axios.post(`/api/v1/schemas`, { schema, registry });
         return response.data;
     }
     catch (error) {

--- a/kc-app/src/keymaster-sdk.js
+++ b/kc-app/src/keymaster-sdk.js
@@ -358,9 +358,9 @@ export async function bindCredential(schema, subject) {
     }
 }
 
-export async function issueCredential(credential) {
+export async function issueCredential(credential, registry) {
     try {
-        const response = await axios.post(`/api/v1/issue-credential`, { credential });
+        const response = await axios.post(`/api/v1/issue-credential`, { credential, registry });
         return response.data;
     }
     catch (error) {

--- a/keymaster-api.js
+++ b/keymaster-api.js
@@ -367,8 +367,8 @@ v1router.post('/bind-credential', async (req, res) => {
 
 v1router.post('/issue-credential', async (req, res) => {
     try {
-        const { credential } = req.body;
-        const response = await keymaster.issueCredential(credential);
+        const { credential, registry } = req.body;
+        const response = await keymaster.issueCredential(credential, registry);
         res.json(response);
     } catch (error) {
         res.status(400).send(error.toString());

--- a/keymaster-api.js
+++ b/keymaster-api.js
@@ -261,8 +261,8 @@ v1router.post('/verify-response', async (req, res) => {
 
 v1router.post('/groups', async (req, res) => {
     try {
-        const { name } = req.body;
-        const response = await keymaster.createGroup(name);
+        const { name, registry } = req.body;
+        const response = await keymaster.createGroup(name, registry);
         res.json(response);
     } catch (error) {
         res.status(400).send(error.toString());
@@ -310,8 +310,8 @@ v1router.post('/groups/:name/test', async (req, res) => {
 
 v1router.post('/schemas', async (req, res) => {
     try {
-        const { schema } = req.body;
-        const response = await keymaster.createSchema(schema);
+        const { schema, registry } = req.body;
+        const response = await keymaster.createSchema(schema, registry);
         res.json(response);
     } catch (error) {
         res.status(400).send(error.toString());

--- a/keymaster-app/src/KeymasterUI.js
+++ b/keymaster-app/src/KeymasterUI.js
@@ -435,7 +435,7 @@ function KeymasterUI({ keymaster, title }) {
 
     async function issueCredential() {
         try {
-            const did = await keymaster.issueCredential(JSON.parse(credentialString));
+            const did = await keymaster.issueCredential(JSON.parse(credentialString), registry);
             setCredentialDID(did);
             // Add did to issuedList
             setIssuedList(prevIssuedList => [...prevIssuedList, did]);
@@ -1261,14 +1261,28 @@ function KeymasterUI({ keymaster, title }) {
                                                             Issue Credential
                                                         </Button>
                                                     </Grid>
-                                                    {credentialDID &&
-                                                        <Grid item>
-                                                            <Typography style={{ fontSize: '1em', fontFamily: 'Courier' }}>
-                                                                {credentialDID}
-                                                            </Typography>
-                                                        </Grid>
-                                                    }
+                                                    <Grid item>on registry:
+                                                        <Select
+                                                            style={{ width: '300px' }}
+                                                            value={registry}
+                                                            fullWidth
+                                                            onChange={(event) => setRegistry(event.target.value)}
+                                                        >
+                                                            {registries.map((registry, index) => (
+                                                                <MenuItem value={registry} key={index}>
+                                                                    {registry}
+                                                                </MenuItem>
+                                                            ))}
+                                                        </Select>
+                                                    </Grid>
                                                 </Grid>
+                                                {credentialDID &&
+                                                    <Grid item>
+                                                        <Typography style={{ fontSize: '1em', fontFamily: 'Courier' }}>
+                                                            {credentialDID}
+                                                        </Typography>
+                                                    </Grid>
+                                                }
                                             </Grid>
                                         </Box>
                                     }

--- a/keymaster-app/src/KeymasterUI.js
+++ b/keymaster-app/src/KeymasterUI.js
@@ -332,7 +332,7 @@ function KeymasterUI({ keymaster, title }) {
                 return;
             }
 
-            const groupDID = await keymaster.createGroup(groupName);
+            const groupDID = await keymaster.createGroup(groupName, registry);
             await keymaster.addName(groupName, groupDID);
 
             setGroupName('');
@@ -391,7 +391,7 @@ function KeymasterUI({ keymaster, title }) {
                 return;
             }
 
-            const schemaDID = await keymaster.createSchema();
+            const schemaDID = await keymaster.createSchema(null, registry);
             await keymaster.addName(schemaName, schemaDID);
 
             setSchemaName('');
@@ -941,6 +941,20 @@ function KeymasterUI({ keymaster, title }) {
                                         Create Group
                                     </Button>
                                 </Grid>
+                                <Grid item>
+                                    <Select
+                                        style={{ width: '300px' }}
+                                        value={registry}
+                                        fullWidth
+                                        onChange={(event) => setRegistry(event.target.value)}
+                                    >
+                                        {registries.map((registry, index) => (
+                                            <MenuItem value={registry} key={index}>
+                                                {registry}
+                                            </MenuItem>
+                                        ))}
+                                    </Select>
+                                </Grid>
                             </Grid>
                             {groupList &&
                                 <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
@@ -1047,6 +1061,20 @@ function KeymasterUI({ keymaster, title }) {
                                     <Button variant="contained" color="primary" onClick={createSchema} disabled={!schemaName}>
                                         Create Schema
                                     </Button>
+                                </Grid>
+                                <Grid item>
+                                    <Select
+                                        style={{ width: '300px' }}
+                                        value={registry}
+                                        fullWidth
+                                        onChange={(event) => setRegistry(event.target.value)}
+                                    >
+                                        {registries.map((registry, index) => (
+                                            <MenuItem value={registry} key={index}>
+                                                {registry}
+                                            </MenuItem>
+                                        ))}
+                                    </Select>
                                 </Grid>
                             </Grid>
                             {schemaList &&
@@ -1261,7 +1289,7 @@ function KeymasterUI({ keymaster, title }) {
                                                             Issue Credential
                                                         </Button>
                                                     </Grid>
-                                                    <Grid item>on registry:
+                                                    <Grid item>
                                                         <Select
                                                             style={{ width: '300px' }}
                                                             value={registry}

--- a/keymaster-app/src/keymaster-lib.js
+++ b/keymaster-app/src/keymaster-lib.js
@@ -418,9 +418,9 @@ export async function decrypt(did) {
     throw 'Cannot decrypt';
 }
 
-export async function encryptJSON(json, did, registry = defaultRegistry) {
+export async function encryptJSON(json, did, encryptForSender = true, registry = defaultRegistry) {
     const plaintext = JSON.stringify(json);
-    return encrypt(plaintext, did, registry);
+    return encrypt(plaintext, did, encryptForSender, registry);
 }
 
 export async function decryptJSON(did) {
@@ -874,12 +874,12 @@ export async function issueCredential(vc, registry = defaultRegistry) {
     }
 
     // Don't allow credentials that will be garbage-collected
-    if (registry === 'hyperswarm') {
-        throw 'Invalid VC';
-    }
+    // if (registry === 'hyperswarm') {
+    //     throw 'Invalid VC';
+    // }
 
     const signed = await addSignature(vc);
-    const cipherDid = await encryptJSON(signed, vc.credentialSubject.id, registry);
+    const cipherDid = await encryptJSON(signed, vc.credentialSubject.id, true, registry);
     addToOwned(cipherDid);
     return cipherDid;
 }
@@ -1106,8 +1106,7 @@ export async function createResponse(did) {
         match: match,
     };
 
-    const responseDid = await encryptJSON(response, requestor, ephemeralRegistry);
-
+    const responseDid = await encryptJSON(response, requestor, true, ephemeralRegistry);
     return responseDid;
 }
 
@@ -1599,8 +1598,8 @@ export async function votePoll(poll, vote, spoil = false) {
     }
 
     // Encrypt for receiver only
+    // TBD which registry?
     const didBallot = await encryptJSON(ballot, owner, false);
-
     return didBallot;
 }
 

--- a/keymaster-app/src/keymaster-lib.js
+++ b/keymaster-app/src/keymaster-lib.js
@@ -794,7 +794,7 @@ export function lookupDID(name) {
     throw "Unknown DID";
 }
 
-export async function createAsset(data, registry = defaultRegistry, name = null) {
+export async function createAsset(data, registry = defaultRegistry, owner = null) {
 
     function isEmpty(data) {
         if (!data) return true;
@@ -807,7 +807,7 @@ export async function createAsset(data, registry = defaultRegistry, name = null)
         throw 'Invalid input';
     }
 
-    const id = fetchId(name);
+    const id = fetchId(owner);
 
     const operation = {
         type: "create",
@@ -821,7 +821,7 @@ export async function createAsset(data, registry = defaultRegistry, name = null)
         data: data,
     };
 
-    const signed = await addSignature(operation, name);
+    const signed = await addSignature(operation, owner);
     const did = await gatekeeper.createDID(signed);
 
     // Keep assets that will be garbage-collected out of the owned list
@@ -1182,13 +1182,13 @@ export async function importDID(events) {
     return gatekeeper.importBatch(events);
 }
 
-export async function createGroup(name) {
+export async function createGroup(name, registry) {
     const group = {
         name: name,
         members: []
     };
 
-    return createAsset(group);
+    return createAsset(group, registry);
 }
 
 export async function getGroup(id) {
@@ -1359,14 +1359,14 @@ function validateSchema(schema) {
     return true;
 }
 
-export async function createSchema(schema) {
+export async function createSchema(schema, registry) {
     if (!schema) {
         schema = defaultSchema;
     }
 
     validateSchema(schema);
 
-    return createAsset(schema);
+    return createAsset(schema, registry);
 }
 
 export async function getSchema(id) {

--- a/keymaster-lib.js
+++ b/keymaster-lib.js
@@ -418,9 +418,9 @@ export async function decrypt(did) {
     throw 'Cannot decrypt';
 }
 
-export async function encryptJSON(json, did, registry = defaultRegistry) {
+export async function encryptJSON(json, did, encryptForSender = true, registry = defaultRegistry) {
     const plaintext = JSON.stringify(json);
-    return encrypt(plaintext, did, registry);
+    return encrypt(plaintext, did, encryptForSender, registry);
 }
 
 export async function decryptJSON(did) {
@@ -874,12 +874,12 @@ export async function issueCredential(vc, registry = defaultRegistry) {
     }
 
     // Don't allow credentials that will be garbage-collected
-    if (registry === 'hyperswarm') {
-        throw 'Invalid VC';
-    }
+    // if (registry === 'hyperswarm') {
+    //     throw 'Invalid VC';
+    // }
 
     const signed = await addSignature(vc);
-    const cipherDid = await encryptJSON(signed, vc.credentialSubject.id, registry);
+    const cipherDid = await encryptJSON(signed, vc.credentialSubject.id, true, registry);
     addToOwned(cipherDid);
     return cipherDid;
 }
@@ -1106,8 +1106,7 @@ export async function createResponse(did) {
         match: match,
     };
 
-    const responseDid = await encryptJSON(response, requestor, ephemeralRegistry);
-
+    const responseDid = await encryptJSON(response, requestor, true, ephemeralRegistry);
     return responseDid;
 }
 
@@ -1599,8 +1598,8 @@ export async function votePoll(poll, vote, spoil = false) {
     }
 
     // Encrypt for receiver only
+    // TBD which registry?
     const didBallot = await encryptJSON(ballot, owner, false);
-
     return didBallot;
 }
 

--- a/keymaster-lib.js
+++ b/keymaster-lib.js
@@ -794,7 +794,7 @@ export function lookupDID(name) {
     throw "Unknown DID";
 }
 
-export async function createAsset(data, registry = defaultRegistry, name = null) {
+export async function createAsset(data, registry = defaultRegistry, owner = null) {
 
     function isEmpty(data) {
         if (!data) return true;
@@ -807,7 +807,7 @@ export async function createAsset(data, registry = defaultRegistry, name = null)
         throw 'Invalid input';
     }
 
-    const id = fetchId(name);
+    const id = fetchId(owner);
 
     const operation = {
         type: "create",
@@ -821,7 +821,7 @@ export async function createAsset(data, registry = defaultRegistry, name = null)
         data: data,
     };
 
-    const signed = await addSignature(operation, name);
+    const signed = await addSignature(operation, owner);
     const did = await gatekeeper.createDID(signed);
 
     // Keep assets that will be garbage-collected out of the owned list
@@ -1182,13 +1182,13 @@ export async function importDID(events) {
     return gatekeeper.importBatch(events);
 }
 
-export async function createGroup(name) {
+export async function createGroup(name, registry) {
     const group = {
         name: name,
         members: []
     };
 
-    return createAsset(group);
+    return createAsset(group, registry);
 }
 
 export async function getGroup(id) {
@@ -1359,14 +1359,14 @@ function validateSchema(schema) {
     return true;
 }
 
-export async function createSchema(schema) {
+export async function createSchema(schema, registry) {
     if (!schema) {
         schema = defaultSchema;
     }
 
     validateSchema(schema);
 
-    return createAsset(schema);
+    return createAsset(schema, registry);
 }
 
 export async function getSchema(id) {


### PR DESCRIPTION
Previously when creating an asset through the web app (group, schema, or credential) it was always registered on the default registry (TESS). Now a dropdown is provided next to the create button to select which registry to use for the asset.

![image](https://github.com/user-attachments/assets/f085db72-ecf0-4872-9a99-7c8833399b09)

![image](https://github.com/user-attachments/assets/a821cf44-a4fb-4b4c-9056-59eaf1fd3362)

![image](https://github.com/user-attachments/assets/6a2fcc11-ab64-42a5-89e3-cff1021aeb23)

