### PR TITLE
Changed verify semantics in resolveDID

### DIFF
--- a/admin-cli.js
+++ b/admin-cli.js
@@ -60,6 +60,40 @@ program
     });
 
 program
+    .command('perf-test')
+    .description('DID resolution performance test')
+    .action(async () => {
+        try {
+            console.time('getDIDs');
+            const dids = await gatekeeper.getDIDs();
+            console.timeEnd('getDIDs');
+
+            console.log(`${dids.length} DIDs`);
+
+            console.time('resolveDID(did, { confirm: true })');
+            for (const did of dids) {
+                await gatekeeper.resolveDID(did, { confirm: true });
+            }
+            console.timeEnd('resolveDID(did, { confirm: true })');
+
+            console.time('resolveDID(did)');
+            for (const did of dids) {
+                await gatekeeper.resolveDID(did);
+            }
+            console.timeEnd('resolveDID(did)');
+
+            console.time('resolveDID(did, { verify: true })');
+            for (const did of dids) {
+                await gatekeeper.resolveDID(did, { verify: true });
+            }
+            console.timeEnd('resolveDID(did, { verify: true })');
+        }
+        catch (error) {
+            console.error(error);
+        }
+    });
+
+program
     .command('export-dids')
     .description('Export all DIDs')
     .action(async () => {

--- a/gatekeeper-api.js
+++ b/gatekeeper-api.js
@@ -84,6 +84,10 @@ v1router.get('/did/:did', async (req, res) => {
             options.confirm = req.query.confirm === 'true';
         }
 
+        if (req.query.verify) {
+            options.verify = req.query.verify === 'true';
+        }
+
         const doc = await gatekeeper.resolveDID(req.params.did, options);
         res.json(doc);
     } catch (error) {

--- a/gatekeeper-lib.js
+++ b/gatekeeper-lib.js
@@ -342,14 +342,12 @@ export async function resolveDID(did, { atTime, atVersion, confirm, verify } = {
             break;
         }
 
-        const valid = await verifyUpdate(operation, doc);
+        if (verify) {
+            const valid = await verifyUpdate(operation, doc);
 
-        if (!valid) {
-            if (verify) {
+            if (!valid) {
                 throw "Invalid update";
             }
-
-            continue;
         }
 
         if (operation.type === 'update') {

--- a/gatekeeper-lib.js
+++ b/gatekeeper-lib.js
@@ -299,7 +299,7 @@ async function verifyUpdate(operation, doc) {
 export async function resolveDID(did, { atTime, atVersion, confirm, verify } = {}) {
     const cacheable = confirm && !atTime && !atVersion;
 
-    if (cacheable && confirmedCache[did]) {
+    if (cacheable && !verify && confirmedCache[did]) {
         return confirmedCache[did];
     }
 

--- a/gatekeeper-sdk.js
+++ b/gatekeeper-sdk.js
@@ -94,7 +94,7 @@ export async function createDID(operation) {
     }
 }
 
-export async function resolveDID(did, { atTime, atVersion, confirm } = {}) {
+export async function resolveDID(did, { atTime, atVersion, confirm, verify } = {}) {
     try {
         let params = '';
 
@@ -108,6 +108,10 @@ export async function resolveDID(did, { atTime, atVersion, confirm } = {}) {
 
         if (confirm) {
             params += `confirm=${confirm}&`;
+        }
+
+        if (verify) {
+            params += `verify=${verify}&`;
         }
 
         const response = await axios.get(`${URL}/api/v1/did/${did}?${params}`);

--- a/keymaster-app/src/gatekeeper-sdk.js
+++ b/keymaster-app/src/gatekeeper-sdk.js
@@ -94,7 +94,7 @@ export async function createDID(operation) {
     }
 }
 
-export async function resolveDID(did, { atTime, atVersion, confirm } = {}) {
+export async function resolveDID(did, { atTime, atVersion, confirm, verify } = {}) {
     try {
         let params = '';
 
@@ -108,6 +108,10 @@ export async function resolveDID(did, { atTime, atVersion, confirm } = {}) {
 
         if (confirm) {
             params += `confirm=${confirm}&`;
+        }
+
+        if (verify) {
+            params += `verify=${verify}&`;
         }
 
         const response = await axios.get(`${URL}/api/v1/did/${did}?${params}`);


### PR DESCRIPTION
During DID resolution the update operation signatures will only be checked if the verify flag is set to true. This is safe because the signatures are checked when the operations are added to the db, and checked again by verifyDb when gatekeeper starts.

A new `perf-test` command was added to the admin CLI:

```
$ ./admin perf-test
getDIDs: 72.517ms
1210 DIDs
resolveDID(did, { confirm: true }): 1.950s
resolveDID(did): 32.385s
resolveDID(did, { verify: true }): 55.424s
```

This change resulted in a ~75% performance gain on average over 1210 DID resolutions. Most DIDs have no updates so are not affected (db access only, or ~30ms per resolution). Some DIDs have many updates and were taking hundreds of ms to resolve.