### PR TITLE
Added cache for unconfirmed versions

### DIFF
--- a/admin-cli.js
+++ b/admin-cli.js
@@ -76,11 +76,11 @@ program
             }
             console.timeEnd('resolveDID(did, { confirm: true })');
 
-            console.time('resolveDID(did)');
+            console.time('resolveDID(did, { confirm: false })');
             for (const did of dids) {
-                await gatekeeper.resolveDID(did);
+                await gatekeeper.resolveDID(did, { confirm: false });
             }
-            console.timeEnd('resolveDID(did)');
+            console.timeEnd('resolveDID(did, { confirm: false })');
 
             console.time('resolveDID(did, { verify: true })');
             for (const did of dids) {

--- a/gatekeeper.test.js
+++ b/gatekeeper.test.js
@@ -321,6 +321,38 @@ describe('resolveDID', () => {
         expect(initialDoc).toStrictEqual(cachedDoc);
     });
 
+    it('should return copies of cached version (confirmed)', async () => {
+
+        mockFs({});
+
+        const keypair = cipher.generateRandomJwk();
+        const agentOp = await createAgentOp(keypair);
+        const did = await gatekeeper.createDID(agentOp);
+        const initialDoc = await gatekeeper.resolveDID(did, { confirm: true });
+        const cachedDoc1 = await gatekeeper.resolveDID(did, { confirm: true });
+        const cachedDoc2 = await gatekeeper.resolveDID(did, { confirm: true });
+
+        cachedDoc1.didDocumentData = { mock: true };
+
+        expect(cachedDoc2.didDocumentData).toStrictEqual(initialDoc.didDocumentData);
+    });
+
+    it('should return copies of cached version (unconfirmed)', async () => {
+
+        mockFs({});
+
+        const keypair = cipher.generateRandomJwk();
+        const agentOp = await createAgentOp(keypair);
+        const did = await gatekeeper.createDID(agentOp);
+        const initialDoc = await gatekeeper.resolveDID(did, { confirm: false });
+        const cachedDoc1 = await gatekeeper.resolveDID(did, { confirm: false });
+        const cachedDoc2 = await gatekeeper.resolveDID(did, { confirm: false });
+
+        cachedDoc1.didDocumentData = { mock: true };
+
+        expect(cachedDoc2.didDocumentData).toStrictEqual(initialDoc.didDocumentData);
+    });
+
     it('should resolve confirmed version after an update (confirmed cache refresh)', async () => {
 
         mockFs({});

--- a/keymaster.test.js
+++ b/keymaster.test.js
@@ -505,8 +505,6 @@ describe('rotateKeys', () => {
         const secrets = [];
         const msg = "Hi Bob!";
 
-        keymaster.setCurrentId('Alice');
-
         for (let i = 0; i < 3; i++) {
             keymaster.setCurrentId('Alice');
 


### PR DESCRIPTION
Extending the work done in #227 

performance test results:
```
$ ./admin perf-test
getDIDs: 121.958ms
1198 DIDs
resolveDID(did, { confirm: true }): 3.197s
resolveDID(did, { confirm: false }): 1.878s
resolveDID(did, { verify: true }): 58.186s
```
16X faster to resolve ~1200 DIDs with the cache compared to before

This also resolves #232 