### PR TITLE
fix: docker publish needs a tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -92,3 +92,4 @@ jobs:
           file: ${{ matrix.dockerfile }}
           push: true
           labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ matrix.tags }}


### PR DESCRIPTION
Adds the tags from the matrix when pushing to registry