### PR TITLE
refactor: Improve db sync performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "",
   "main": "gatekeeper-api.js",
   "scripts": {
-    "start": "node gatekeeper-api.js",
+    "gatekeeper": "node src/gatekeeper-api.js",
+    "keymaster": "node src/keymaster-api.js",
     "test": "node --experimental-vm-modules node_modules/.bin/jest --runInBand --verbose --coverage",
     "lint": "eslint ."
   },

--- a/src/admin-cli.js
+++ b/src/admin-cli.js
@@ -107,6 +107,10 @@ program
             await gatekeeper.getDIDs({ dids: batch, confirm: false, resolve: true });
             console.timeEnd('getDIDs({ dids: batch, confirm: false, resolve: true })');
 
+            console.time('exportDIDs');
+            await gatekeeper.exportDIDs(dids);
+            console.timeEnd('exportDIDs');
+
             if (full) {
                 console.time('resolveDID(did, { verify: true })');
                 for (const did of dids) {

--- a/src/gatekeeper-lib.js
+++ b/src/gatekeeper-lib.js
@@ -35,7 +35,6 @@ export async function stop() {
 
 export async function verifyDID(did) {
     await resolveDID(did, { verify: true });
-    await resolveDID(did, { confirm: true });
 }
 
 export async function verifyDb(chatty = true) {

--- a/src/gatekeeper-lib.js
+++ b/src/gatekeeper-lib.js
@@ -186,7 +186,7 @@ export async function createDID(operation) {
     }
 }
 
-async function generateDoc(anchor) {
+export async function generateDoc(anchor) {
     let doc = {};
     try {
         if (!anchor?.mdip) {

--- a/src/keymaster-app/src/keymaster-lib.js
+++ b/src/keymaster-app/src/keymaster-lib.js
@@ -376,7 +376,7 @@ function fetchId(id) {
         idInfo = wallet.ids[wallet.current];
 
         if (!idInfo) {
-            throw new Error(exceptions.UNKNOWN_ID);
+            throw new Error(exceptions.NO_CURRENT_ID);
         }
     }
 


### PR DESCRIPTION
Replaces the two document caches with a single events cache in gatekeeper. An augmented `admin perf-test` measured a 300X performance increase for DID exports (e.g. from 65 seconds to 146ms for 1440 DIDs on one node). This refactor essentially mitigates the load jump seen in #255. 

Even though we are no longer caching documents, and have to reconstruct them from the events cache, no significant change was measured for the resolution benchmarks.

Incidentally it is possible to measure the size of the events cache by noting the number of bytes returned by a call to /export-dids. In this case ~4.6 MB for 1446 DIDs:

```
kc-gatekeeper-1  | POST /api/v1/export-dids 200 90.996 ms - 4585370
```

The response time of 91ms translates to ~63 _microseconds_ per DID.

This PR also adds unit tests for generateDoc in order to pass the coverage check. (It seems that just removing code can have the side effect of reducing coverage% which fails the check).