### PR TITLE
feat: Adds supported registries configuration

### DIFF
--- a/dc-tess.yml
+++ b/dc-tess.yml
@@ -12,6 +12,7 @@ services:
     image: keychainmdip/gatekeeper
     environment:
       - KC_GATEKEEPER_DB=json
+      - KC_GATEKEEPER_REGISTRIES=hyperswarm,TESS
       - KC_MONGODB_URL=mongodb://mongodb:27017
     volumes:
       - ./data:/app/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     image: keychainmdip/gatekeeper
     environment:
       - KC_GATEKEEPER_DB=${KC_GATEKEEPER_DB}
+      - KC_GATEKEEPER_REGISTRIES=hyperswarm
       - KC_MONGODB_URL=mongodb://mongodb:27017
     volumes:
       - ./data:/app/data

--- a/src/admin-cli.js
+++ b/src/admin-cli.js
@@ -306,6 +306,19 @@ program
         }
     });
 
+program
+    .command('list-registries')
+    .description('List supported registries')
+    .action(async () => {
+        try {
+            const response = await gatekeeper.listRegistries();
+            console.log(JSON.stringify(response, null, 4));
+        }
+        catch (error) {
+            console.error(error);
+        }
+    });
+
 async function run() {
     gatekeeper.setURL(`${config.gatekeeperURL}:${config.gatekeeperPort}`);
     await keymaster.start(gatekeeper, db_wallet);

--- a/src/config.js
+++ b/src/config.js
@@ -8,6 +8,7 @@ const config = {
     gatekeeperPort: process.env.KC_GATEKEEPER_PORT ? parseInt(process.env.KC_GATEKEEPER_PORT) : 4224,
     gatekeeperURL: process.env.KC_GATEKEEPER_URL || 'http://localhost',
     gatekeeperDb: process.env.KC_GATEKEEPER_DB || 'json',
+    gatekeeperRegistries: process.env.KC_GATEKEEPER_REGISTRIES,
     keymasterPort: process.env.KC_KEYMASTER_PORT ? parseInt(process.env.KC_KEYMASTER_PORT) : 4226,
     nodeName: process.env.KC_NODE_NAME || 'anon',
     nodeID: process.env.KC_NODE_ID,

--- a/src/gatekeeper-api.js
+++ b/src/gatekeeper-api.js
@@ -235,6 +235,8 @@ gatekeeper.verifyDb().then((invalid) => {
         console.log(`${invalid} invalid DIDs removed from MDIP db`);
     }
 
+    gatekeeper.initRegistries(config.gatekeeperRegistries);
+
     const port = config.gatekeeperPort;
     const db = config.gatekeeperDb;
 

--- a/src/gatekeeper-lib.js
+++ b/src/gatekeeper-lib.js
@@ -9,15 +9,12 @@ import * as exceptions from './exceptions.js';
 const validVersions = [1];
 const validTypes = ['agent', 'asset'];
 const validRegistries = ['local', 'hyperswarm', 'TESS'];
+let supportedRegistries = null;
 
 let db = null;
 let helia = null;
 let ipfs = null;
 let eventsCache = {};
-
-export async function listRegistries() {
-    return validRegistries;
-}
 
 export async function start(injectedDb) {
     if (!ipfs) {
@@ -70,6 +67,31 @@ export async function verifyDb(chatty = true) {
     }
 
     return invalid;
+}
+
+export async function initRegistries(csvRegistries) {
+    if (!csvRegistries) {
+        supportedRegistries = validRegistries;
+    }
+    else {
+        const registries = csvRegistries.split(',').map(registry => registry.trim());
+        supportedRegistries = [];
+
+        for (const registry of registries) {
+            if (validRegistries.includes(registry)) {
+                supportedRegistries.push(registry);
+            }
+            else {
+                throw new Error(exceptions.INVALID_REGISTRY);
+            }
+        }
+    }
+
+    return supportedRegistries;
+}
+
+export async function listRegistries() {
+    return supportedRegistries || validRegistries;
 }
 
 // For testing purposes

--- a/src/gatekeeper.test.js
+++ b/src/gatekeeper.test.js
@@ -1616,6 +1616,54 @@ describe('getDids', () => {
     });
 });
 
+describe('initRegistries', () => {
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should default to valid registries', async () => {
+        mockFs({});
+
+        const registries = await gatekeeper.initRegistries();
+
+        expect(registries.length).toBe(3);
+        expect(registries.includes('local')).toBe(true);
+        expect(registries.includes('hyperswarm')).toBe(true);
+        expect(registries.includes('TESS')).toBe(true);
+    });
+
+    it('should parse supported registries', async () => {
+        mockFs({});
+
+        const registries = await gatekeeper.initRegistries("local, hyperswarm");
+
+        expect(registries.length).toBe(2);
+        expect(registries.includes('local')).toBe(true);
+        expect(registries.includes('hyperswarm')).toBe(true);
+    });
+
+    it('should parse supported registries with extra whitespace', async () => {
+        mockFs({});
+
+        const registries = await gatekeeper.initRegistries("   local,    hyperswarm    ");
+
+        expect(registries.length).toBe(2);
+        expect(registries.includes('local')).toBe(true);
+        expect(registries.includes('hyperswarm')).toBe(true);
+    });
+
+    it('should throw an exception on invalid registries', async () => {
+        mockFs({});
+
+        try {
+            await gatekeeper.initRegistries("local, hyperswarm, mock");
+            throw new Error(exceptions.EXPECTED_EXCEPTION);
+        } catch (error) {
+            expect(error.message).toBe(exceptions.INVALID_REGISTRY);
+        }
+    });
+});
+
 describe('listRegistries', () => {
     afterEach(() => {
         mockFs.restore();
@@ -1624,9 +1672,22 @@ describe('listRegistries', () => {
     it('should return list of valid registries', async () => {
         mockFs({});
 
+        await gatekeeper.initRegistries();
         const registries = await gatekeeper.listRegistries();
 
+        expect(registries.length).toBe(3);
         expect(registries.includes('local')).toBe(true);
+        expect(registries.includes('hyperswarm')).toBe(true);
+        expect(registries.includes('TESS')).toBe(true);
+    });
+
+    it('should return list of configured registries', async () => {
+        mockFs({});
+
+        await gatekeeper.initRegistries("hyperswarm, TESS");
+        const registries = await gatekeeper.listRegistries();
+
+        expect(registries.length).toBe(2);
         expect(registries.includes('hyperswarm')).toBe(true);
         expect(registries.includes('TESS')).toBe(true);
     });


### PR DESCRIPTION
Supported registries on a per node basis can be specified in a new environment variable:
```
KC_GATEKEEPER_REGISTRIES=hyperswarm,TESS
```

When set as above, the supported list is reflected in the registry dropdown in the web UI:

![image](https://github.com/user-attachments/assets/c342e361-d816-4d25-98e4-9cf6ab38e212)
