### PR TITLE
DOC: add experimental warnings

### DIFF
--- a/doc/keychain/clients/cli/03-ids.md
+++ b/doc/keychain/clients/cli/03-ids.md
@@ -1,5 +1,6 @@
 ---
 title: Working with IDs
+experimental: true
 sidebar_label: IDs
 slug: ids
 ---

--- a/doc/keychain/clients/cli/04-dids.md
+++ b/doc/keychain/clients/cli/04-dids.md
@@ -1,5 +1,6 @@
 ---
 title: Working with DIDs
+experimental: true
 sidebar_label: DIDs
 slug: dids
 ---

--- a/doc/keychain/clients/cli/05-credentials.md
+++ b/doc/keychain/clients/cli/05-credentials.md
@@ -1,5 +1,6 @@
 ---
 title: Working with Credentials
+experimental: true
 sidebar_label: Credentials
 slug: credentials
 ---

--- a/doc/keychain/clients/cli/06-manifests.md
+++ b/doc/keychain/clients/cli/06-manifests.md
@@ -1,5 +1,6 @@
 ---
 title: What is the DID Manifest?
+experimental: true
 sidebar_label: DID Manifest
 slug: manifests
 ---

--- a/doc/keychain/clients/cli/07-challenge-responses.md
+++ b/doc/keychain/clients/cli/07-challenge-responses.md
@@ -1,5 +1,6 @@
 ---
 title: Working with Challenges and Responses
+experimental: true
 sidebar_label: Challenges and Responses
 slug: challenge-responses
 ---

--- a/doc/keychain/clients/cli/08-aliased-names.md
+++ b/doc/keychain/clients/cli/08-aliased-names.md
@@ -1,5 +1,6 @@
 ---
 title: Working with Aliased Names
+experimental: true
 sidebar_label: Aliased Names
 slug: aliased-names
 ---

--- a/doc/keychain/clients/cli/09-encryption.md
+++ b/doc/keychain/clients/cli/09-encryption.md
@@ -1,5 +1,6 @@
 ---
 title: Working with Encryption
+experimental: true
 sidebar_label: Encryption
 slug: encryption
 ---

--- a/doc/keychain/clients/cli/10-voting.md
+++ b/doc/keychain/clients/cli/10-voting.md
@@ -1,5 +1,6 @@
 ---
 title: Voting
+experimental: true
 ---
 
 The MDIP protocol allows for near-endless forms of communication. This page covers the "group" and "poll" set of commands provided by the `kc` CLI tool, which demonstrate how MDIP can be used to perform secure voting.

--- a/doc/keychain/clients/cli/README.md
+++ b/doc/keychain/clients/cli/README.md
@@ -1,5 +1,6 @@
 ---
 title: Keychain-MDIP CLI User Manual
+experimental: true
 sidebar_label: CLI
 ---
 

--- a/doc/keychain/clients/webui/02-first-did.md
+++ b/doc/keychain/clients/webui/02-first-did.md
@@ -1,5 +1,6 @@
 ---
 title: Creating your first DID
+experimental: true
 sidebar_label: 'Your First DID'
 author: Christian
 ---

--- a/doc/keychain/clients/webui/03-identities.md
+++ b/doc/keychain/clients/webui/03-identities.md
@@ -1,5 +1,6 @@
 ---
 title: Identities
+experimental: true
 sidebar_label: Identities
 author: Christian
 ---

--- a/doc/keychain/clients/webui/04-dids.md
+++ b/doc/keychain/clients/webui/04-dids.md
@@ -1,5 +1,6 @@
 ---
 title: DIDs
+experimental: true
 author: Christian
 ---
 

--- a/doc/keychain/clients/webui/05-groups.md
+++ b/doc/keychain/clients/webui/05-groups.md
@@ -1,5 +1,6 @@
 ---
 title: Groups
+experimental: true
 author: Christian
 ---
 

--- a/doc/keychain/clients/webui/06-schema.md
+++ b/doc/keychain/clients/webui/06-schema.md
@@ -1,5 +1,6 @@
 ---
 title: Schema
+experimental: true
 author: Christian
 ---
 

--- a/doc/keychain/clients/webui/07-credentials.md
+++ b/doc/keychain/clients/webui/07-credentials.md
@@ -1,5 +1,6 @@
 ---
 title: Credentials
+experimental: true
 author: Christian
 ---
 

--- a/doc/keychain/clients/webui/08-auth.md
+++ b/doc/keychain/clients/webui/08-auth.md
@@ -1,5 +1,6 @@
 ---
 title: Authentication
+experimental: true
 author: Christian
 ---
 

--- a/doc/keychain/clients/webui/09-wallet.md
+++ b/doc/keychain/clients/webui/09-wallet.md
@@ -1,5 +1,6 @@
 ---
 title: Wallet
+experimental: true
 author: Christian
 ---
 

--- a/doc/keychain/clients/webui/README.md
+++ b/doc/keychain/clients/webui/README.md
@@ -1,5 +1,6 @@
 ---
 title: MDIP Keymaster WebUI
+experimental: true
 sidebar_label: Tutorial
 author: Christian
 pagination_prev: null


### PR DESCRIPTION
This adds the frontmatter `experiemental: true` to all docs that don't already have a similar warning. This will display the warning in https://github.com/KeychainMDIP/kc-docs/pull/10 once it is merged.