### PR TITLE
remove ToC block from API page

### DIFF
--- a/doc/keychain/library/api/index.mdx
+++ b/doc/keychain/library/api/index.mdx
@@ -1,5 +1,7 @@
 ---
 title: Keymaster API
+experimental: true
+hide_table_of_contents: true
 ---
 
 import ApiDocMdx from '@theme/ApiDocMdx';


### PR DESCRIPTION
Removes the unused ToC block from the API page so that the API plugin can expand right. Also adds the experimental warning to the page.