### PR TITLE
feat: Added updateCredential

### DIFF
--- a/doc/openapi.json
+++ b/doc/openapi.json
@@ -1435,50 +1435,9 @@
         }
       }
     },
-    "/credentials/issue": {
-      "post": {
-        "summary": "Issue a credential",
-        "tags": [
-          "Credential"
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "credential": {
-                    "type": "object"
-                  },
-                  "registry": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad request"
-          }
-        }
-      }
-    },
     "/credentials/held": {
       "get": {
-        "summary": "List all credentials",
+        "summary": "List all held credentials",
         "tags": [
           "Credential"
         ],
@@ -1709,9 +1668,97 @@
         }
       }
     },
+    "post": {
+      "summary": "Issue a credential",
+      "tags": [
+        "Credential"
+      ],
+      "requestBody": {
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "credential": {
+                  "type": "object"
+                },
+                "registry": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "Successful response",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "400": {
+          "description": "Bad request"
+        }
+      }
+    },
     "/credentials/issued/{did}": {
       "get": {
         "summary": "Get an issued credential",
+        "tags": [
+          "Credential"
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "did",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "credential": {
+                    "type": "object"
+                  },
+                  "registry": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          }
+        }
+      },
+      "post": {
+        "summary": "Update an issued credential",
         "tags": [
           "Credential"
         ],

--- a/src/gatekeeper-lib.js
+++ b/src/gatekeeper-lib.js
@@ -16,7 +16,7 @@ let helia = null;
 let ipfs = null;
 let eventsCache = {};
 
-function copyJSON(json) {
+export function copyJSON(json) {
     return JSON.parse(JSON.stringify(json))
 }
 

--- a/src/kc-app/src/KeymasterUI.js
+++ b/src/kc-app/src/KeymasterUI.js
@@ -1378,7 +1378,7 @@ function KeymasterUI({ keymaster, title }) {
                                                                     </Button>
                                                                 </Grid>
                                                                 <Grid item>
-                                                                    <Button variant="contained" color="primary" onClick={() => updateIssued(did)} disabled={!issuedEdit || issuedString === issuedStringOriginal}>
+                                                                    <Button variant="contained" color="primary" onClick={() => updateIssued(did)} disabled={did !== selectedIssued || !issuedEdit || issuedString === issuedStringOriginal}>
                                                                         Update
                                                                     </Button>
                                                                 </Grid>

--- a/src/kc-app/src/KeymasterUI.js
+++ b/src/kc-app/src/KeymasterUI.js
@@ -47,7 +47,9 @@ function KeymasterUI({ keymaster, title }) {
     const [selectedHeld, setSelectedHeld] = useState('');
     const [issuedList, setIssuedList] = useState(null);
     const [selectedIssued, setSelectedIssued] = useState('');
+    const [issuedStringOriginal, setIssuedStringOriginal] = useState('');
     const [issuedString, setIssuedString] = useState('');
+    const [issuedEdit, setIssuedEdit] = useState(false);
     const [mnemonicString, setMnemonicString] = useState('');
     const [walletString, setWalletString] = useState('');
     const [manifest, setManifest] = useState(null);
@@ -586,6 +588,7 @@ function KeymasterUI({ keymaster, title }) {
             const doc = await keymaster.resolveDID(did);
             setSelectedIssued(did);
             setIssuedString(JSON.stringify(doc, null, 4));
+            setIssuedEdit(false);
         } catch (error) {
             window.alert(error);
         }
@@ -595,7 +598,20 @@ function KeymasterUI({ keymaster, title }) {
         try {
             const doc = await keymaster.getCredential(did);
             setSelectedIssued(did);
-            setIssuedString(JSON.stringify(doc, null, 4));
+            const issued = JSON.stringify(doc, null, 4);
+            setIssuedStringOriginal(issued);
+            setIssuedString(issued);
+            setIssuedEdit(true);
+        } catch (error) {
+            window.alert(error);
+        }
+    }
+
+    async function updateIssued(did) {
+        try {
+            const credential = JSON.parse(issuedString);
+            await keymaster.updateCredential(did, credential);
+            decryptIssued(did);
         } catch (error) {
             window.alert(error);
         }
@@ -1362,6 +1378,11 @@ function KeymasterUI({ keymaster, title }) {
                                                                     </Button>
                                                                 </Grid>
                                                                 <Grid item>
+                                                                    <Button variant="contained" color="primary" onClick={() => updateIssued(did)} disabled={!issuedEdit || issuedString === issuedStringOriginal}>
+                                                                        Update
+                                                                    </Button>
+                                                                </Grid>
+                                                                <Grid item>
                                                                     <Button variant="contained" color="primary" onClick={() => revokeIssued(did)}>
                                                                         Revoke
                                                                     </Button>
@@ -1374,11 +1395,20 @@ function KeymasterUI({ keymaster, title }) {
                                         </Table>
                                     </TableContainer>
                                     <p>{selectedIssued}</p>
-                                    <textarea
-                                        value={issuedString}
-                                        readOnly
-                                        style={{ width: '800px', height: '600px', overflow: 'auto' }}
-                                    />
+                                    {issuedEdit ? (
+                                        <textarea
+                                            value={issuedString}
+                                            onChange={(e) => setIssuedString(e.target.value.trim())}
+                                            style={{ width: '800px', height: '600px', overflow: 'auto' }}
+                                        />
+
+                                    ) : (
+                                        <textarea
+                                            value={issuedString}
+                                            readOnly
+                                            style={{ width: '800px', height: '600px', overflow: 'auto' }}
+                                        />
+                                    )}
                                 </Box>
                             }
                         </Box>

--- a/src/kc-app/src/keymaster-sdk.js
+++ b/src/kc-app/src/keymaster-sdk.js
@@ -400,7 +400,17 @@ export async function bindCredential(schema, subject) {
 
 export async function issueCredential(credential, registry) {
     try {
-        const response = await axios.post(`${URL}/api/v1/credentials/issue`, { credential, registry });
+        const response = await axios.post(`${URL}/api/v1/credentials/issued`, { credential, registry });
+        return response.data;
+    }
+    catch (error) {
+        throwError(error);
+    }
+}
+
+export async function updateCredential(did, credential) {
+    try {
+        const response = await axios.post(`${URL}/api/v1/credentials/issued/${did}`, { credential });
         return response.data;
     }
     catch (error) {

--- a/src/kc-app/src/keymaster-sdk.js
+++ b/src/kc-app/src/keymaster-sdk.js
@@ -430,7 +430,7 @@ export async function listCredentials() {
 
 export async function acceptCredential(did) {
     try {
-        const response = await axios.post(`${URL}/api/v1/credentials/held/${did}`);
+        const response = await axios.post(`${URL}/api/v1/credentials/held/`, { did });
         return response.data;
     }
     catch (error) {

--- a/src/kc-app/src/keymaster-sdk.js
+++ b/src/kc-app/src/keymaster-sdk.js
@@ -3,8 +3,8 @@ import axios from 'axios';
 let URL = '';
 
 function throwError(error) {
-    if (error.response) {
-        throw error.response.data;
+    if (error.response?.data?.error) {
+        throw error.response.data.error;
     }
 
     throw error.message;

--- a/src/keychain-cli.js
+++ b/src/keychain-cli.js
@@ -273,7 +273,7 @@ program
     .description('Encrypt a message for a DID')
     .action(async (msg, did) => {
         try {
-            const cipherDid = await keymaster.encrypt(msg, did);
+            const cipherDid = await keymaster.encryptMessage(msg, did);
             console.log(cipherDid);
         }
         catch (error) {
@@ -287,7 +287,7 @@ program
     .action(async (file, did) => {
         try {
             const contents = fs.readFileSync(file).toString();
-            const cipherDid = await keymaster.encrypt(contents, did);
+            const cipherDid = await keymaster.encryptMessage(contents, did);
             console.log(cipherDid);
         }
         catch (error) {
@@ -300,7 +300,7 @@ program
     .description('Decrypt an encrypted message DID')
     .action(async (did) => {
         try {
-            const plaintext = await keymaster.decrypt(did);
+            const plaintext = await keymaster.decryptMessage(did);
             console.log(plaintext);
         }
         catch (error) {
@@ -313,8 +313,7 @@ program
     .description('Decrypt an encrypted JSON DID')
     .action(async (did) => {
         try {
-            const plaintext = await keymaster.decrypt(did);
-            const json = JSON.parse(plaintext);
+            const json = await keymaster.decryptJSON(did);
             console.log(JSON.stringify(json, null, 4));
         }
         catch (error) {

--- a/src/keymaster-api.js
+++ b/src/keymaster-api.js
@@ -377,16 +377,6 @@ v1router.post('/credentials/bind', async (req, res) => {
     }
 });
 
-v1router.post('/credentials/issued', async (req, res) => {
-    try {
-        const { credential, registry } = req.body;
-        const response = await keymaster.issueCredential(credential, registry);
-        res.json(response);
-    } catch (error) {
-        res.status(400).send({ error: error.toString() });
-    }
-});
-
 v1router.get('/credentials/held', async (req, res) => {
     try {
         const response = await keymaster.listCredentials();
@@ -454,6 +444,17 @@ v1router.get('/credentials/issued', async (req, res) => {
     }
 });
 
+v1router.post('/credentials/issued', async (req, res) => {
+    try {
+        const { credential, registry } = req.body;
+        const response = await keymaster.issueCredential(credential, registry);
+        res.json(response);
+    } catch (error) {
+        res.status(400).send({ error: error.toString() });
+    }
+});
+
+// eslint-disable-next-line
 v1router.get('/credentials/issued/:did', async (req, res) => {
     try {
         const did = req.params.did;

--- a/src/keymaster-api.js
+++ b/src/keymaster-api.js
@@ -377,7 +377,7 @@ v1router.post('/credentials/bind', async (req, res) => {
     }
 });
 
-v1router.post('/credentials/issue', async (req, res) => {
+v1router.post('/credentials/issued', async (req, res) => {
     try {
         const { credential, registry } = req.body;
         const response = await keymaster.issueCredential(credential, registry);
@@ -461,6 +461,17 @@ v1router.get('/credentials/issued/:did', async (req, res) => {
         res.json(response);
     } catch (error) {
         res.status(500).send({ error: error.toString() });
+    }
+});
+
+v1router.post('/credentials/issued/:did', async (req, res) => {
+    try {
+        const did = req.params.did;
+        const { credential } = req.body;
+        const response = await keymaster.updateCredential(did, credential);
+        res.json(response);
+    } catch (error) {
+        res.status(400).send({ error: error.toString() });
     }
 });
 

--- a/src/keymaster-api.js
+++ b/src/keymaster-api.js
@@ -498,7 +498,7 @@ v1router.post('/keys/rotate', async (req, res) => {
 v1router.post('/keys/encrypt', async (req, res) => {
     try {
         const { msg, did } = req.body;
-        const response = await keymaster.encrypt(msg, did);
+        const response = await keymaster.encryptMessage(msg, did);
         res.json(response);
     } catch (error) {
         res.status(500).send({ error: error.toString() });
@@ -507,7 +507,7 @@ v1router.post('/keys/encrypt', async (req, res) => {
 
 v1router.post('/keys/decrypt', async (req, res) => {
     try {
-        const response = await keymaster.decrypt(req.body.did);
+        const response = await keymaster.decryptMessage(req.body.did);
         res.json(response);
     } catch (error) {
         res.status(500).send({ error: error.toString() });

--- a/src/keymaster-app/src/KeymasterUI.js
+++ b/src/keymaster-app/src/KeymasterUI.js
@@ -1378,7 +1378,7 @@ function KeymasterUI({ keymaster, title }) {
                                                                     </Button>
                                                                 </Grid>
                                                                 <Grid item>
-                                                                    <Button variant="contained" color="primary" onClick={() => updateIssued(did)} disabled={!issuedEdit || issuedString === issuedStringOriginal}>
+                                                                    <Button variant="contained" color="primary" onClick={() => updateIssued(did)} disabled={did !== selectedIssued || !issuedEdit || issuedString === issuedStringOriginal}>
                                                                         Update
                                                                     </Button>
                                                                 </Grid>

--- a/src/keymaster-app/src/KeymasterUI.js
+++ b/src/keymaster-app/src/KeymasterUI.js
@@ -47,7 +47,9 @@ function KeymasterUI({ keymaster, title }) {
     const [selectedHeld, setSelectedHeld] = useState('');
     const [issuedList, setIssuedList] = useState(null);
     const [selectedIssued, setSelectedIssued] = useState('');
+    const [issuedStringOriginal, setIssuedStringOriginal] = useState('');
     const [issuedString, setIssuedString] = useState('');
+    const [issuedEdit, setIssuedEdit] = useState(false);
     const [mnemonicString, setMnemonicString] = useState('');
     const [walletString, setWalletString] = useState('');
     const [manifest, setManifest] = useState(null);
@@ -586,6 +588,7 @@ function KeymasterUI({ keymaster, title }) {
             const doc = await keymaster.resolveDID(did);
             setSelectedIssued(did);
             setIssuedString(JSON.stringify(doc, null, 4));
+            setIssuedEdit(false);
         } catch (error) {
             window.alert(error);
         }
@@ -595,7 +598,20 @@ function KeymasterUI({ keymaster, title }) {
         try {
             const doc = await keymaster.getCredential(did);
             setSelectedIssued(did);
-            setIssuedString(JSON.stringify(doc, null, 4));
+            const issued = JSON.stringify(doc, null, 4);
+            setIssuedStringOriginal(issued);
+            setIssuedString(issued);
+            setIssuedEdit(true);
+        } catch (error) {
+            window.alert(error);
+        }
+    }
+
+    async function updateIssued(did) {
+        try {
+            const credential = JSON.parse(issuedString);
+            await keymaster.updateCredential(did, credential);
+            decryptIssued(did);
         } catch (error) {
             window.alert(error);
         }
@@ -1362,6 +1378,11 @@ function KeymasterUI({ keymaster, title }) {
                                                                     </Button>
                                                                 </Grid>
                                                                 <Grid item>
+                                                                    <Button variant="contained" color="primary" onClick={() => updateIssued(did)} disabled={!issuedEdit || issuedString === issuedStringOriginal}>
+                                                                        Update
+                                                                    </Button>
+                                                                </Grid>
+                                                                <Grid item>
                                                                     <Button variant="contained" color="primary" onClick={() => revokeIssued(did)}>
                                                                         Revoke
                                                                     </Button>
@@ -1374,11 +1395,20 @@ function KeymasterUI({ keymaster, title }) {
                                         </Table>
                                     </TableContainer>
                                     <p>{selectedIssued}</p>
-                                    <textarea
-                                        value={issuedString}
-                                        readOnly
-                                        style={{ width: '800px', height: '600px', overflow: 'auto' }}
-                                    />
+                                    {issuedEdit ? (
+                                        <textarea
+                                            value={issuedString}
+                                            onChange={(e) => setIssuedString(e.target.value.trim())}
+                                            style={{ width: '800px', height: '600px', overflow: 'auto' }}
+                                        />
+
+                                    ) : (
+                                        <textarea
+                                            value={issuedString}
+                                            readOnly
+                                            style={{ width: '800px', height: '600px', overflow: 'auto' }}
+                                        />
+                                    )}
                                 </Box>
                             }
                         </Box>

--- a/src/keymaster-lib.js
+++ b/src/keymaster-lib.js
@@ -420,7 +420,7 @@ async function fetchKeyPair(name = null) {
     return null;
 }
 
-export async function encrypt(msg, did, encryptForSender = true, registry = defaultRegistry) {
+export async function encryptMessage(msg, did, encryptForSender = true, registry = defaultRegistry) {
     const id = fetchId();
     const senderKeypair = await fetchKeyPair();
     const doc = await resolveDID(did, { confirm: true });
@@ -438,7 +438,7 @@ export async function encrypt(msg, did, encryptForSender = true, registry = defa
     }, registry);
 }
 
-export async function decrypt(did) {
+export async function decryptMessage(did) {
     const wallet = loadWallet();
     const id = fetchId();
     const crypt = await resolveAsset(did);
@@ -471,11 +471,11 @@ export async function decrypt(did) {
 
 export async function encryptJSON(json, did, encryptForSender = true, registry = defaultRegistry) {
     const plaintext = JSON.stringify(json);
-    return encrypt(plaintext, did, encryptForSender, registry);
+    return encryptMessage(plaintext, did, encryptForSender, registry);
 }
 
 export async function decryptJSON(did) {
-    const plaintext = await decrypt(did);
+    const plaintext = await decryptMessage(did);
 
     try {
         return JSON.parse(plaintext);
@@ -1167,8 +1167,8 @@ export async function createResponse(did, registry = ephemeralRegistry) {
     const pairs = [];
 
     for (let vcDid of matches) {
-        const plaintext = await decrypt(vcDid);
-        const vpDid = await encrypt(plaintext, requestor, true, registry);
+        const plaintext = await decryptMessage(vcDid);
+        const vpDid = await encryptMessage(plaintext, requestor, true, registry);
         pairs.push({ vc: vcDid, vp: vpDid });
     }
 

--- a/src/keymaster-lib.js
+++ b/src/keymaster-lib.js
@@ -926,6 +926,15 @@ export async function issueCredential(vc, registry = defaultRegistry) {
 export async function updateCredential(credential, vc) {
     const did = lookupDID(credential);
     const doc = await resolveDID(did);
+    const originalVC = await decryptJSON(did);
+
+    if (!originalVC.credential) {
+        throw new Error(exceptions.INVALID_PARAMETER);
+    }
+
+    if (!vc?.credential || !vc?.credentialSubject?.id) {
+        throw new Error(exceptions.INVALID_PARAMETER);
+    }
 
     delete vc.signature;
     const signed = await addSignature(vc);

--- a/src/keymaster-lib.js
+++ b/src/keymaster-lib.js
@@ -476,7 +476,13 @@ export async function encryptJSON(json, did, encryptForSender = true, registry =
 
 export async function decryptJSON(did) {
     const plaintext = await decrypt(did);
-    return JSON.parse(plaintext);
+
+    try {
+        return JSON.parse(plaintext);
+    }
+    catch (error) {
+        throw new Error(exceptions.INVALID_PARAMETER);
+    }
 }
 
 export async function addSignature(obj, controller = null) {

--- a/src/keymaster-sdk.js
+++ b/src/keymaster-sdk.js
@@ -400,7 +400,17 @@ export async function bindCredential(schema, subject) {
 
 export async function issueCredential(credential, registry) {
     try {
-        const response = await axios.post(`${URL}/api/v1/credentials/issue`, { credential, registry });
+        const response = await axios.post(`${URL}/api/v1/credentials/issued`, { credential, registry });
+        return response.data;
+    }
+    catch (error) {
+        throwError(error);
+    }
+}
+
+export async function updateCredential(did, credential) {
+    try {
+        const response = await axios.post(`${URL}/api/v1/credentials/issued/${did}`, { credential });
         return response.data;
     }
     catch (error) {

--- a/src/keymaster-sdk.js
+++ b/src/keymaster-sdk.js
@@ -430,7 +430,7 @@ export async function listCredentials() {
 
 export async function acceptCredential(did) {
     try {
-        const response = await axios.post(`${URL}/api/v1/credentials/held/${did}`);
+        const response = await axios.post(`${URL}/api/v1/credentials/held/`, { did });
         return response.data;
     }
     catch (error) {

--- a/src/keymaster-sdk.js
+++ b/src/keymaster-sdk.js
@@ -3,8 +3,8 @@ import axios from 'axios';
 let URL = '';
 
 function throwError(error) {
-    if (error.response) {
-        throw error.response.data;
+    if (error.response?.data?.error) {
+        throw error.response.data.error;
     }
 
     throw error.message;

--- a/src/keymaster.test.js
+++ b/src/keymaster.test.js
@@ -1405,6 +1405,69 @@ describe('updateCredential', () => {
         const doc = await keymaster.resolveDID(did);
         expect(doc.didDocumentMetadata.version).toBe(2);
     });
+
+    it('should throw exception on invalid parameters', async () => {
+        mockFs({});
+
+        const userDid = await keymaster.createId('Bob');
+        const credentialDid = await keymaster.createCredential(mockSchema);
+        const boundCredential = await keymaster.bindCredential(credentialDid, userDid);
+        const did = await keymaster.issueCredential(boundCredential);
+        const vc = await keymaster.getCredential(did);
+
+        try {
+            await keymaster.updateCredential();
+            throw new Error(exceptions.EXPECTED_EXCEPTION);
+        }
+        catch (error) {
+            expect(error.message).toBe(exceptions.INVALID_DID);
+        }
+
+        try {
+            // Pass agent DID instead of credential DID
+            await keymaster.updateCredential(userDid, vc);
+            throw new Error(exceptions.EXPECTED_EXCEPTION);
+        }
+        catch (error) {
+            expect(error.message).toBe(exceptions.INVALID_PARAMETER);
+        }
+
+        try {
+            await keymaster.updateCredential(did);
+            throw new Error(exceptions.EXPECTED_EXCEPTION);
+        }
+        catch (error) {
+            expect(error.message).toBe(exceptions.INVALID_PARAMETER);
+        }
+
+        try {
+            await keymaster.updateCredential(did, {});
+            throw new Error(exceptions.EXPECTED_EXCEPTION);
+        }
+        catch (error) {
+            expect(error.message).toBe(exceptions.INVALID_PARAMETER);
+        }
+
+        try {
+            const vc2 = gatekeeper.copyJSON(vc);
+            delete vc2.credential;
+            await keymaster.updateCredential(did, vc2);
+            throw new Error(exceptions.EXPECTED_EXCEPTION);
+        }
+        catch (error) {
+            expect(error.message).toBe(exceptions.INVALID_PARAMETER);
+        }
+
+        try {
+            const vc2 = gatekeeper.copyJSON(vc);
+            delete vc2.credentialSubject;
+            await keymaster.updateCredential(did, vc2);
+            throw new Error(exceptions.EXPECTED_EXCEPTION);
+        }
+        catch (error) {
+            expect(error.message).toBe(exceptions.INVALID_PARAMETER);
+        }
+    });
 });
 
 describe('revokeCredential', () => {

--- a/src/keymaster.test.js
+++ b/src/keymaster.test.js
@@ -1434,6 +1434,16 @@ describe('updateCredential', () => {
 
         try {
             // Pass cipher DID instead of credential DID
+            const cipherDID = await keymaster.encrypt('mock', bob);
+            await keymaster.updateCredential(cipherDID, vc);
+            throw new Error(exceptions.EXPECTED_EXCEPTION);
+        }
+        catch (error) {
+            expect(error.message).toBe(exceptions.INVALID_PARAMETER);
+        }
+
+        try {
+            // Pass cipher DID instead of credential DID
             const cipherDID = await keymaster.encryptJSON({ bob }, bob);
             await keymaster.updateCredential(cipherDID, vc);
             throw new Error(exceptions.EXPECTED_EXCEPTION);

--- a/src/keymaster.test.js
+++ b/src/keymaster.test.js
@@ -1378,13 +1378,42 @@ describe('listIssued', () => {
     });
 });
 
+describe('updateCredential', () => {
+
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should update a valid verifiable credential', async () => {
+        mockFs({});
+
+        const userDid = await keymaster.createId('Bob');
+        const credentialDid = await keymaster.createCredential(mockSchema);
+        const boundCredential = await keymaster.bindCredential(credentialDid, userDid);
+        const did = await keymaster.issueCredential(boundCredential);
+        const vc = await keymaster.getCredential(did);
+
+        const validUntilDate = new Date();
+        validUntilDate.setHours(validUntilDate.getHours() + 24);
+        vc.validUntil = validUntilDate.toISOString();
+        const ok = await keymaster.updateCredential(did, vc);
+        expect(ok).toBe(true);
+
+        const updated = await keymaster.getCredential(did);
+        expect(updated.validUntil).toBe(vc.validUntil);
+
+        const doc = await keymaster.resolveDID(did);
+        expect(doc.didDocumentMetadata.version).toBe(2);
+    });
+});
+
 describe('revokeCredential', () => {
 
     afterEach(() => {
         mockFs.restore();
     });
 
-    it('should revoke an valid verifiable credential', async () => {
+    it('should revoke a valid verifiable credential', async () => {
         mockFs({});
 
         const userDid = await keymaster.createId('Bob');

--- a/src/keymaster.test.js
+++ b/src/keymaster.test.js
@@ -1409,9 +1409,9 @@ describe('updateCredential', () => {
     it('should throw exception on invalid parameters', async () => {
         mockFs({});
 
-        const userDid = await keymaster.createId('Bob');
+        const bob = await keymaster.createId('Bob');
         const credentialDid = await keymaster.createCredential(mockSchema);
-        const boundCredential = await keymaster.bindCredential(credentialDid, userDid);
+        const boundCredential = await keymaster.bindCredential(credentialDid, bob);
         const did = await keymaster.issueCredential(boundCredential);
         const vc = await keymaster.getCredential(did);
 
@@ -1425,7 +1425,17 @@ describe('updateCredential', () => {
 
         try {
             // Pass agent DID instead of credential DID
-            await keymaster.updateCredential(userDid, vc);
+            await keymaster.updateCredential(bob, vc);
+            throw new Error(exceptions.EXPECTED_EXCEPTION);
+        }
+        catch (error) {
+            expect(error.message).toBe(exceptions.INVALID_PARAMETER);
+        }
+
+        try {
+            // Pass cipher DID instead of credential DID
+            const cipherDID = await keymaster.encryptJSON({ bob }, bob);
+            await keymaster.updateCredential(cipherDID, vc);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {

--- a/src/keymaster.test.js
+++ b/src/keymaster.test.js
@@ -547,7 +547,7 @@ describe('rotateKeys', () => {
         for (let i = 0; i < 3; i++) {
             keymaster.setCurrentId('Alice');
 
-            const did = await keymaster.encrypt(msg, bob, true, 'local');
+            const did = await keymaster.encryptMessage(msg, bob, true, 'local');
             secrets.push(did);
 
             await keymaster.rotateKeys();
@@ -559,12 +559,12 @@ describe('rotateKeys', () => {
         for (let secret of secrets) {
             keymaster.setCurrentId('Alice');
 
-            const decipher1 = await keymaster.decrypt(secret);
+            const decipher1 = await keymaster.decryptMessage(secret);
             expect(decipher1).toBe(msg);
 
             keymaster.setCurrentId('Bob');
 
-            const decipher2 = await keymaster.decrypt(secret);
+            const decipher2 = await keymaster.decryptMessage(secret);
             expect(decipher2).toBe(msg);
         }
     });
@@ -980,7 +980,7 @@ describe('encrypt', () => {
         const did = await keymaster.createId(name);
 
         const msg = 'Hi Bob!';
-        const encryptDid = await keymaster.encrypt(msg, did);
+        const encryptDid = await keymaster.encryptMessage(msg, did);
         const doc = await keymaster.resolveDID(encryptDid);
         const data = doc.didDocumentData;
         const msgHash = cipher.hashMessage(msg);
@@ -996,7 +996,7 @@ describe('encrypt', () => {
         const did = await keymaster.createId(name);
 
         const msg = generateRandomString(1024);
-        const encryptDid = await keymaster.encrypt(msg, did);
+        const encryptDid = await keymaster.encryptMessage(msg, did);
         const doc = await keymaster.resolveDID(encryptDid);
         const data = doc.didDocumentData;
         const msgHash = cipher.hashMessage(msg);
@@ -1018,8 +1018,8 @@ describe('decrypt', () => {
         const did = await keymaster.createId(name);
 
         const msg = 'Hi Bob!';
-        const encryptDid = await keymaster.encrypt(msg, did);
-        const decipher = await keymaster.decrypt(encryptDid);
+        const encryptDid = await keymaster.encryptMessage(msg, did);
+        const decipher = await keymaster.decryptMessage(encryptDid);
 
         expect(decipher).toBe(msg);
     });
@@ -1030,9 +1030,9 @@ describe('decrypt', () => {
         const did = await keymaster.createId('Bob', 'local');
         const msg = 'Hi Bob!';
         await keymaster.rotateKeys();
-        const encryptDid = await keymaster.encrypt(msg, did, true, 'local');
+        const encryptDid = await keymaster.encryptMessage(msg, did, true, 'local');
         await keymaster.rotateKeys();
-        const decipher = await keymaster.decrypt(encryptDid);
+        const decipher = await keymaster.decryptMessage(encryptDid);
 
         expect(decipher).toBe(msg);
     });
@@ -1043,8 +1043,8 @@ describe('decrypt', () => {
         const did = await keymaster.createId('Bob', 'hyperswarm');
         const msg = 'Hi Bob!';
         await keymaster.rotateKeys();
-        const encryptDid = await keymaster.encrypt(msg, did, true, 'hyperswarm');
-        const decipher = await keymaster.decrypt(encryptDid);
+        const encryptDid = await keymaster.encryptMessage(msg, did, true, 'hyperswarm');
+        const decipher = await keymaster.decryptMessage(encryptDid);
 
         expect(decipher).toBe(msg);
     });
@@ -1061,10 +1061,10 @@ describe('decrypt', () => {
         keymaster.setCurrentId(name1);
 
         const msg = 'Hi Bob!';
-        const encryptDid = await keymaster.encrypt(msg, did);
+        const encryptDid = await keymaster.encryptMessage(msg, did);
 
         keymaster.setCurrentId(name2);
-        const decipher = await keymaster.decrypt(encryptDid);
+        const decipher = await keymaster.decryptMessage(encryptDid);
 
         expect(decipher).toBe(msg);
     });
@@ -1081,10 +1081,10 @@ describe('decrypt', () => {
         keymaster.setCurrentId(name1);
 
         const msg = generateRandomString(1024);
-        const encryptDid = await keymaster.encrypt(msg, did);
+        const encryptDid = await keymaster.encryptMessage(msg, did);
 
         keymaster.setCurrentId(name2);
-        const decipher = await keymaster.decrypt(encryptDid);
+        const decipher = await keymaster.decryptMessage(encryptDid);
 
         expect(decipher).toBe(msg);
     });
@@ -1434,7 +1434,7 @@ describe('updateCredential', () => {
 
         try {
             // Pass cipher DID instead of credential DID
-            const cipherDID = await keymaster.encrypt('mock', bob);
+            const cipherDID = await keymaster.encryptMessage('mock', bob);
             await keymaster.updateCredential(cipherDID, vc);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }


### PR DESCRIPTION
Adds new function `updateCredential` to keymaster lib, api, and sdk.

In the web wallet, decrypting an issued credential will allow it to be edited. The Update button will enable if the credential is changed (typically the `validFrom`, `validUntil`, and `credential` fields). Once updated, the holder will automatically see the new version. If the holder has published an older version to their manifest, they should unpublish, then publish or reveal again to get the new version.

![image](https://github.com/user-attachments/assets/993aa30b-eb20-47dc-b7f9-d9e42072a96d)
