### PR TITLE
fix: response DIDs should be ephemeral

### DIFF
--- a/doc/openapi.json
+++ b/doc/openapi.json
@@ -491,8 +491,8 @@
                   "name": {
                     "type": "string"
                   },
-                  "registry": {
-                    "type": "string"
+                  "options": {
+                    "type": "object"
                   }
                 }
               }
@@ -1021,11 +1021,16 @@
           "required": true,
           "content": {
             "application/json": {
-              "challenge": {
-                "type": "object"
-              },
-              "options": {
-                "type": "object"
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "challenge": {
+                    "type": "object"
+                  },
+                  "options": {
+                    "type": "object"
+                  }
+                }
               }
             }
           }
@@ -1145,8 +1150,8 @@
                   "name": {
                     "type": "string"
                   },
-                  "registry": {
-                    "type": "string"
+                  "options": {
+                    "type": "object"
                   }
                 }
               }
@@ -1377,6 +1382,9 @@
                 "properties": {
                   "schema": {
                     "type": "object"
+                  },
+                  "options": {
+                    "type": "object"
                   }
                 }
               }
@@ -1417,6 +1425,9 @@
                     "type": "object"
                   },
                   "subject": {
+                    "type": "object"
+                  },
+                  "options": {
                     "type": "object"
                   }
                 }
@@ -1672,44 +1683,44 @@
             "description": "Bad request"
           }
         }
-      }
-    },
-    "post": {
-      "summary": "Issue a credential",
-      "tags": [
-        "Credential"
-      ],
-      "requestBody": {
-        "required": true,
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "credential": {
-                  "type": "object"
-                },
-                "registry": {
-                  "type": "string"
+      },
+      "post": {
+        "summary": "Issue a credential",
+        "tags": [
+          "Credential"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "credential": {
+                    "type": "object"
+                  },
+                  "options": {
+                    "type": "object"
+                  }
                 }
               }
             }
           }
-        }
-      },
-      "responses": {
-        "200": {
-          "description": "Successful response",
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
               }
             }
+          },
+          "400": {
+            "description": "Bad request"
           }
-        },
-        "400": {
-          "description": "Bad request"
         }
       }
     },
@@ -1729,24 +1740,6 @@
             }
           }
         ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "credential": {
-                    "type": "object"
-                  },
-                  "registry": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
         "responses": {
           "200": {
             "description": "Successful response",
@@ -1849,7 +1842,7 @@
         }
       }
     },
-    "/keys/encrypt": {
+    "/keys/encrypt/message": {
       "post": {
         "summary": "Encrypt a message",
         "tags": [
@@ -1865,6 +1858,47 @@
                   "msg": {
                     "type": "string"
                   },
+                  "receiver": {
+                    "type": "string"
+                  },
+                  "options": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/keys/decrypt/message": {
+      "post": {
+        "summary": "Decrypt a message",
+        "tags": [
+          "Wallet"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
                   "did": {
                     "type": "string"
                   }
@@ -1890,9 +1924,53 @@
         }
       }
     },
-    "/keys/decrypt": {
+    "/keys/encrypt/json": {
       "post": {
-        "summary": "Decrypt a message",
+        "summary": "Encrypt JSON",
+        "tags": [
+          "Wallet"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "json": {
+                    "type": "object"
+                  },
+                  "receiver": {
+                    "type": "string"
+                  },
+                  "options": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/keys/decrypt/json": {
+      "post": {
+        "summary": "Decrypt JSON",
         "tags": [
           "Wallet"
         ],
@@ -2057,6 +2135,9 @@
                 "properties": {
                   "poll": {
                     "type": "object"
+                  },
+                  "options": {
+                    "type": "object"
                   }
                 }
               }
@@ -2132,8 +2213,8 @@
                   "vote": {
                     "type": "object"
                   },
-                  "spoil": {
-                    "type": "boolean"
+                  "options": {
+                    "type": "object"
                   }
                 }
               }
@@ -2218,8 +2299,8 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "reveal": {
-                    "type": "boolean"
+                  "options": {
+                    "type": "object"
                   }
                 }
               }
@@ -2338,6 +2419,9 @@
                 "type": "object",
                 "properties": {
                   "schema": {
+                    "type": "object"
+                  },
+                  "options": {
                     "type": "object"
                   }
                 }

--- a/packages/gatekeeper/src/gatekeeper-lib.js
+++ b/packages/gatekeeper/src/gatekeeper-lib.js
@@ -36,7 +36,7 @@ export async function stop() {
 
 export async function verifyDID(did) {
     const doc = await resolveDID(did, { verify: true });
-    const isoDate = doc?.didDocumentData?.ephemeral?.validUntil;
+    const isoDate = doc?.mdip?.validUntil;
 
     if (isoDate) {
         const validUntil = new Date(isoDate);

--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -728,7 +728,7 @@ export async function createId(name, options = {}) {
     if (!registry) {
         registry = defaultRegistry;
     }
-    
+
     const wallet = loadWallet();
     if (wallet.ids && Object.keys(wallet.ids).includes(name)) {
         throw new Error(exceptions.INVALID_PARAMETER);
@@ -943,11 +943,6 @@ export async function testAgent(id) {
     return doc?.mdip?.type === 'agent';
 }
 
-export async function createCredential(schema, registry) {
-    // TBD validate schema
-    return createAsset(schema, { registry });
-}
-
 export async function bindCredential(schemaId, subjectId, validUntil = null) {
     const id = fetchId();
     const type = lookupDID(schemaId);
@@ -970,7 +965,7 @@ export async function bindCredential(schemaId, subjectId, validUntil = null) {
     };
 }
 
-export async function issueCredential(credential, registry = defaultRegistry) {
+export async function issueCredential(credential, options) {
     const id = fetchId();
 
     if (credential.issuer !== id.did) {
@@ -978,7 +973,7 @@ export async function issueCredential(credential, registry = defaultRegistry) {
     }
 
     const signed = await addSignature(credential);
-    const cipherDid = await encryptJSON(signed, credential.credentialSubject.id, { registry });
+    const cipherDid = await encryptJSON(signed, credential.credentialSubject.id, options);
     addToOwned(cipherDid);
     return cipherDid;
 }
@@ -1535,14 +1530,14 @@ function validateSchema(schema) {
     return true;
 }
 
-export async function createSchema(schema, registry) {
+export async function createSchema(schema, options) {
     if (!schema) {
         schema = defaultSchema;
     }
 
     validateSchema(schema);
 
-    return createAsset(schema, { registry });
+    return createAsset(schema, options);
 }
 
 export async function getSchema(id) {

--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -722,7 +722,13 @@ export async function resolveAsset(did) {
     return null;
 }
 
-export async function createId(name, registry = defaultRegistry) {
+export async function createId(name, options = {}) {
+    let { registry } = options;
+
+    if (!registry) {
+        registry = defaultRegistry;
+    }
+    
     const wallet = loadWallet();
     if (wallet.ids && Object.keys(wallet.ids).includes(name)) {
         throw new Error(exceptions.INVALID_PARAMETER);

--- a/packages/keymaster/src/keymaster-sdk.js
+++ b/packages/keymaster/src/keymaster-sdk.js
@@ -178,9 +178,9 @@ export async function resolveId(id) {
     }
 }
 
-export async function createId(name, registry) {
+export async function createId(name, options) {
     try {
-        const response = await axios.post(`${URL}/api/v1/ids/new`, { name, registry });
+        const response = await axios.post(`${URL}/api/v1/ids/new`, { name, options });
         return response.data;
     }
     catch (error) {

--- a/packages/keymaster/src/keymaster-sdk.js
+++ b/packages/keymaster/src/keymaster-sdk.js
@@ -168,6 +168,46 @@ export async function listIds() {
     }
 }
 
+export async function encryptMessage(msg, receiver, options = {}) {
+    try {
+        const response = await axios.post(`${URL}/api/v1/keys/encrypt/message`, { msg, receiver, options });
+        return response.data;
+    }
+    catch (error) {
+        throwError(error);
+    }
+}
+
+export async function decryptMessage(did) {
+    try {
+        const response = await axios.post(`${URL}/api/v1/keys/decrypt/message`, { did });
+        return response.data;
+    }
+    catch (error) {
+        throwError(error);
+    }
+}
+
+export async function encryptJSON(json, receiver, options = {}) {
+    try {
+        const response = await axios.post(`${URL}/api/v1/keys/encrypt/json`, { json, receiver, options });
+        return response.data;
+    }
+    catch (error) {
+        throwError(error);
+    }
+}
+
+export async function decryptJSON(did) {
+    try {
+        const response = await axios.post(`${URL}/api/v1/keys/decrypt/json`, { did });
+        return response.data;
+    }
+    catch (error) {
+        throwError(error);
+    }
+}
+
 export async function resolveId(id) {
     try {
         const response = await axios.get(`${URL}/api/v1/ids/${id}`);
@@ -258,6 +298,16 @@ export async function resolveDID(name) {
     }
 }
 
+export async function resolveAsset(name) {
+    try {
+        const response = await axios.get(`${URL}/api/v1/assets/${name}`);
+        return response.data;
+    }
+    catch (error) {
+        throwError(error);
+    }
+}
+
 export async function createChallenge(challengeSpec, options) {
     try {
         const response = await axios.post(`${URL}/api/v1/challenge`, { challenge: challengeSpec, options });
@@ -288,9 +338,9 @@ export async function verifyResponse(responseDID, options) {
     }
 }
 
-export async function createGroup(name, registry) {
+export async function createGroup(name, options) {
     try {
-        const response = await axios.post(`${URL}/api/v1/groups`, { name, registry });
+        const response = await axios.post(`${URL}/api/v1/groups`, { name, options });
         return response.data;
     }
     catch (error) {
@@ -338,9 +388,9 @@ export async function groupTest(group, member) {
     }
 }
 
-export async function createSchema(schema, registry) {
+export async function createSchema(schema, options) {
     try {
-        const response = await axios.post(`${URL}/api/v1/schemas`, { schema, registry });
+        const response = await axios.post(`${URL}/api/v1/schemas`, { schema, options });
         return response.data;
     }
     catch (error) {
@@ -388,9 +438,9 @@ export async function testAgent(id) {
     }
 }
 
-export async function bindCredential(schema, subject) {
+export async function bindCredential(schema, subject, options) {
     try {
-        const response = await axios.post(`${URL}/api/v1/credentials/bind`, { schema, subject });
+        const response = await axios.post(`${URL}/api/v1/credentials/bind`, { schema, subject, options });
         return response.data;
     }
     catch (error) {
@@ -398,9 +448,9 @@ export async function bindCredential(schema, subject) {
     }
 }
 
-export async function issueCredential(credential, registry) {
+export async function issueCredential(credential, options) {
     try {
-        const response = await axios.post(`${URL}/api/v1/credentials/issued`, { credential, registry });
+        const response = await axios.post(`${URL}/api/v1/credentials/issued`, { credential, options });
         return response.data;
     }
     catch (error) {
@@ -458,9 +508,9 @@ export async function removeCredential(did) {
     }
 }
 
-export async function publishCredential(did, reveal) {
+export async function publishCredential(did, options) {
     try {
-        const response = await axios.post(`${URL}/api/v1/credentials/held/${did}/publish`, { reveal });
+        const response = await axios.post(`${URL}/api/v1/credentials/held/${did}/publish`, { options });
         return response.data;
     }
     catch (error) {

--- a/scripts/keychain-cli.js
+++ b/scripts/keychain-cli.js
@@ -811,7 +811,7 @@ program
     .description('Publish results to poll, revealing ballots')
     .action(async (poll) => {
         try {
-            const ok = await keymaster.publishPoll(poll, true);
+            const ok = await keymaster.publishPoll(poll, { reveal: true });
             if (ok) {
                 console.log(UPDATE_OK);
             }

--- a/scripts/keychain-cli.js
+++ b/scripts/keychain-cli.js
@@ -138,7 +138,7 @@ program
     .description('Create a new decentralized ID')
     .action(async (name, registry) => {
         try {
-            const did = await keymaster.createId(name, registry);
+            const did = await keymaster.createId(name, { registry });
             console.log(did);
         }
         catch (error) {

--- a/scripts/keychain-cli.js
+++ b/scripts/keychain-cli.js
@@ -359,12 +359,12 @@ program
     });
 
 program
-    .command('create-credential <file> [name]')
-    .description('Create credential from schema file')
+    .command('create-schema <file> [name]')
+    .description('Create schema DID from schema file')
     .action(async (file, name) => {
         try {
             const schema = JSON.parse(fs.readFileSync(file).toString());
-            const did = await keymaster.createCredential(schema);
+            const did = await keymaster.createSchema(schema);
 
             if (name) {
                 keymaster.addName(name, did);

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -145,7 +145,7 @@ function KeymasterUI({ keymaster, title, challengeDID }) {
 
     async function createId() {
         try {
-            await keymaster.createId(newName, registry);
+            await keymaster.createId(newName, { registry });
             refreshAll();
             // TBD this should be done in keymaster?
             // The backup forces a change, triggering registration

--- a/services/gatekeeper/server/src/index.js
+++ b/services/gatekeeper/server/src/index.js
@@ -226,18 +226,35 @@ app.use((req, res) => {
     }
 });
 
-async function main() {
-    if (config.verifyDb) {
+async function verifyLoop() {
+    try {
         const invalid = await gatekeeper.verifyDb();
 
         if (invalid > 0) {
             console.log(`${invalid} invalid DIDs removed from MDIP db`);
         }
+
+        console.log('DID verification loop waiting 60m...');
+    } catch (error) {
+        console.error(`Error in verifyLoop: ${error}`);
     }
-    else {
-        const dids = await gatekeeper.getDIDs();
-        console.log(`Skipping db verification (${dids.length} DIDs)`);
-    }
+    setTimeout(verifyLoop, 60 * 60 * 1000);
+}
+
+async function main() {
+    // if (config.verifyDb) {
+    //     const invalid = await gatekeeper.verifyDb();
+
+    //     if (invalid > 0) {
+    //         console.log(`${invalid} invalid DIDs removed from MDIP db`);
+    //     }
+    // }
+    // else {
+    //     const dids = await gatekeeper.getDIDs();
+    //     console.log(`Skipping db verification (${dids.length} DIDs)`);
+    // }
+
+    await verifyLoop();
 
     const registries = await gatekeeper.initRegistries(config.registries);
 

--- a/services/keymaster/client/src/KeymasterUI.js
+++ b/services/keymaster/client/src/KeymasterUI.js
@@ -145,7 +145,7 @@ function KeymasterUI({ keymaster, title, challengeDID }) {
 
     async function createId() {
         try {
-            await keymaster.createId(newName, registry);
+            await keymaster.createId(newName, { registry });
             refreshAll();
             // TBD this should be done in keymaster?
             // The backup forces a change, triggering registration

--- a/services/keymaster/server/src/index.js
+++ b/services/keymaster/server/src/index.js
@@ -241,8 +241,8 @@ v1router.get('/challenge', async (req, res) => {
 
 v1router.post('/challenge', async (req, res) => {
     try {
-        const { challenge, registry } = req.body;
-        const did = await keymaster.createChallenge(challenge, registry);
+        const { challenge, options } = req.body;
+        const did = await keymaster.createChallenge(challenge, options);
         res.json(did);
     } catch (error) {
         res.status(400).send({ error: error.toString() });

--- a/services/keymaster/server/src/index.js
+++ b/services/keymaster/server/src/index.js
@@ -556,7 +556,8 @@ v1router.post('/schemas/:id/template/new', async (req, res) => {
 
 v1router.post('/asset/create', async (req, res) => {
     try {
-        const response = await keymaster.createAsset(req.body.asset);
+        const options = req.body;
+        const response = await keymaster.createAsset(req.body.asset, options);
         res.json(response);
     } catch (error) {
         res.status(500).send({ error: error.toString() });

--- a/services/keymaster/server/src/index.js
+++ b/services/keymaster/server/src/index.js
@@ -538,7 +538,7 @@ v1router.post('/keys/verify', async (req, res) => {
 
 v1router.post('/credentials/new', async (req, res) => {
     try {
-        const response = await keymaster.createCredential(req.body.schema);
+        const response = await keymaster.createSchema(req.body.schema);
         res.json(response);
     } catch (error) {
         res.status(500).send({ error: error.toString() });

--- a/services/keymaster/server/src/index.js
+++ b/services/keymaster/server/src/index.js
@@ -261,8 +261,8 @@ v1router.post('/response', async (req, res) => {
 
 v1router.post('/response/verify', async (req, res) => {
     try {
-        const { response, retries } = req.body;
-        const verify = await keymaster.verifyResponse(response, retries);
+        const { response, options } = req.body;
+        const verify = await keymaster.verifyResponse(response, options);
         res.json(verify);
     } catch (error) {
         res.status(400).send({ error: error.toString() });
@@ -271,8 +271,8 @@ v1router.post('/response/verify', async (req, res) => {
 
 v1router.post('/groups', async (req, res) => {
     try {
-        const { name, registry } = req.body;
-        const response = await keymaster.createGroup(name, registry);
+        const { name, options } = req.body;
+        const response = await keymaster.createGroup(name, options);
         res.json(response);
     } catch (error) {
         res.status(500).send({ error: error.toString() });
@@ -323,8 +323,8 @@ v1router.post('/groups/:name/test', async (req, res) => {
 
 v1router.post('/schemas', async (req, res) => {
     try {
-        const { schema, registry } = req.body;
-        const response = await keymaster.createSchema(schema, registry);
+        const { schema, options } = req.body;
+        const response = await keymaster.createSchema(schema, options);
         res.json(response);
     } catch (error) {
         res.status(500).send({ error: error.toString() });
@@ -373,8 +373,8 @@ v1router.post('/agents/:id/test', async (req, res) => {
 
 v1router.post('/credentials/bind', async (req, res) => {
     try {
-        const { schema, subject } = req.body;
-        const response = await keymaster.bindCredential(schema, subject);
+        const { schema, subject, options } = req.body;
+        const response = await keymaster.bindCredential(schema, subject, options);
         res.json(response);
     } catch (error) {
         res.status(400).send({ error: error.toString() });
@@ -421,8 +421,8 @@ v1router.delete('/credentials/held/:did', async (req, res) => {
 v1router.post('/credentials/held/:did/publish', async (req, res) => {
     try {
         const did = req.params.did;
-        const { reveal } = req.body;
-        const response = await keymaster.publishCredential(did, reveal);
+        const { options } = req.body;
+        const response = await keymaster.publishCredential(did, options);
         res.json(response);
     } catch (error) {
         res.status(400).send({ error: error.toString() });
@@ -450,8 +450,8 @@ v1router.get('/credentials/issued', async (req, res) => {
 
 v1router.post('/credentials/issued', async (req, res) => {
     try {
-        const { credential, registry } = req.body;
-        const response = await keymaster.issueCredential(credential, registry);
+        const { credential, options } = req.body;
+        const response = await keymaster.issueCredential(credential, options);
         res.json(response);
     } catch (error) {
         res.status(400).send({ error: error.toString() });
@@ -499,7 +499,7 @@ v1router.post('/keys/rotate', async (req, res) => {
     }
 });
 
-v1router.post('/keys/encrypt', async (req, res) => {
+v1router.post('/keys/encrypt/message', async (req, res) => {
     try {
         const { msg, receiver, options } = req.body;
         const response = await keymaster.encryptMessage(msg, receiver, options);
@@ -509,9 +509,28 @@ v1router.post('/keys/encrypt', async (req, res) => {
     }
 });
 
-v1router.post('/keys/decrypt', async (req, res) => {
+v1router.post('/keys/decrypt/message', async (req, res) => {
     try {
         const response = await keymaster.decryptMessage(req.body.did);
+        res.json(response);
+    } catch (error) {
+        res.status(500).send({ error: error.toString() });
+    }
+});
+
+v1router.post('/keys/encrypt/json', async (req, res) => {
+    try {
+        const { json, receiver, options } = req.body;
+        const response = await keymaster.encryptJSON(json, receiver, options);
+        res.json(response);
+    } catch (error) {
+        res.status(500).send({ error: error.toString() });
+    }
+});
+
+v1router.post('/keys/decrypt/json', async (req, res) => {
+    try {
+        const response = await keymaster.decryptJSON(req.body.did);
         res.json(response);
     } catch (error) {
         res.status(500).send({ error: error.toString() });
@@ -538,7 +557,8 @@ v1router.post('/keys/verify', async (req, res) => {
 
 v1router.post('/credentials/new', async (req, res) => {
     try {
-        const response = await keymaster.createSchema(req.body.schema);
+        const { schema, options } = req.body;
+        const response = await keymaster.createSchema(schema, options);
         res.json(response);
     } catch (error) {
         res.status(500).send({ error: error.toString() });
@@ -547,18 +567,31 @@ v1router.post('/credentials/new', async (req, res) => {
 
 v1router.post('/schemas/:id/template/new', async (req, res) => {
     try {
-        const response = await keymaster.createTemplate(req.body.schema);
+        const { schema } = req.body;
+        const response = await keymaster.createTemplate(schema);
         res.json(response);
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
 });
 
-v1router.post('/asset/create', async (req, res) => {
+v1router.post('/assets/new', async (req, res) => {
     try {
-        const options = req.body;
-        const response = await keymaster.createAsset(req.body.asset, options);
+        const { asset, options } = req.body;
+        const response = await keymaster.createAsset(asset, options);
         res.json(response);
+    } catch (error) {
+        res.status(500).send({ error: error.toString() });
+    }
+});
+
+v1router.get('/assets/:id', async (req, res) => {
+    try {
+        const asset = await keymaster.resolveAsset(req.params.id);
+        if (!asset) {
+            return res.status(404).send({ error: 'Asset not found' });
+        }
+        res.json(asset);
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -575,7 +608,8 @@ v1router.get('/templates/poll', async (req, res) => {
 
 v1router.post('/poll/new', async (req, res) => {
     try {
-        const response = await keymaster.createPoll(req.body.poll);
+        const { poll, options } = req.body;
+        const response = await keymaster.createPoll(poll, options);
         res.json(response);
     } catch (error) {
         res.status(500).send({ error: error.toString() });
@@ -593,8 +627,8 @@ v1router.get('/poll/:poll/view', async (req, res) => {
 
 v1router.post('/poll/vote', async (req, res) => {
     try {
-        const { poll, vote, spoil } = req.body;
-        const response = await keymaster.votePoll(poll, vote, spoil);
+        const { poll, vote, options } = req.body;
+        const response = await keymaster.votePoll(poll, vote, options);
         res.json(response);
     } catch (error) {
         res.status(500).send({ error: error.toString() });
@@ -603,7 +637,8 @@ v1router.post('/poll/vote', async (req, res) => {
 
 v1router.put('/poll/update', async (req, res) => {
     try {
-        const response = await keymaster.updatePoll(req.body.ballot);
+        const { ballot } = req.body;
+        const response = await keymaster.updatePoll(ballot);
         res.json(response);
     } catch (error) {
         res.status(500).send({ error: error.toString() });
@@ -612,8 +647,8 @@ v1router.put('/poll/update', async (req, res) => {
 
 v1router.post('/poll/:poll/publish', async (req, res) => {
     try {
-        const reveal = req.body.reveal || false;
-        const response = await keymaster.publishPoll(req.params.poll, reveal);
+        const { poll, options } = req.body;
+        const response = await keymaster.publishPoll(poll, options);
         res.json(response);
     } catch (error) {
         res.status(500).send({ error: error.toString() });
@@ -622,7 +657,8 @@ v1router.post('/poll/:poll/publish', async (req, res) => {
 
 v1router.delete('/poll/:poll/unpublish', async (req, res) => {
     try {
-        const response = await keymaster.unpublishPoll(req.params.poll);
+        const { poll } = req.params;
+        const response = await keymaster.unpublishPoll(poll);
         res.json(response);
     } catch (error) {
         res.status(500).send({ error: error.toString() });

--- a/services/keymaster/server/src/index.js
+++ b/services/keymaster/server/src/index.js
@@ -142,8 +142,8 @@ v1router.get('/ids', async (req, res) => {
 
 v1router.post('/ids/new', async (req, res) => {
     try {
-        const { name, registry } = req.body;
-        const did = await keymaster.createId(name, registry);
+        const { name, options } = req.body;
+        const did = await keymaster.createId(name, options);
         res.json(did);
     } catch (error) {
         res.status(500).send({ error: error.toString() });

--- a/services/keymaster/server/src/index.js
+++ b/services/keymaster/server/src/index.js
@@ -501,8 +501,8 @@ v1router.post('/keys/rotate', async (req, res) => {
 
 v1router.post('/keys/encrypt', async (req, res) => {
     try {
-        const { msg, did } = req.body;
-        const response = await keymaster.encryptMessage(msg, did);
+        const { msg, receiver, options } = req.body;
+        const response = await keymaster.encryptMessage(msg, receiver, options);
         res.json(response);
     } catch (error) {
         res.status(500).send({ error: error.toString() });

--- a/services/mediators/hyperswarm/src/index.js
+++ b/services/mediators/hyperswarm/src/index.js
@@ -471,7 +471,7 @@ async function main() {
     gatekeeper.setURL(`${config.gatekeeperURL}`);
     await gatekeeper.waitUntilReady();
     await initializeBatchesSeen();
-    await gcLoop();
+    //await gcLoop();
     await connectionLoop();
     await exportLoop();
 }

--- a/services/mediators/satoshi/src/index.js
+++ b/services/mediators/satoshi/src/index.js
@@ -307,7 +307,7 @@ async function anchorBatch() {
     console.log(JSON.stringify(batch, null, 4));
 
     if (batch.length > 0) {
-        const did = await keymaster.createAsset(batch, REGISTRY, config.nodeID);
+        const did = await keymaster.createAsset(batch, { registry: REGISTRY, controller: config.nodeID });
         const txid = await createOpReturnTxn(did);
 
         if (txid) {

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -792,7 +792,7 @@ describe('createAsset', () => {
 
         await keymaster.createId('Alice');
 
-        const dataDid = await keymaster.createAsset(mockAnchor, 'hyperswarm', 'Bob');
+        const dataDid = await keymaster.createAsset(mockAnchor, { registry: 'hyperswarm', controller: 'Bob' });
         const doc = await keymaster.resolveDID(dataDid);
 
         expect(doc.didDocument.id).toBe(dataDid);

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -519,7 +519,7 @@ describe('rotateKeys', () => {
     it('should update DID doc with new keys', async () => {
         mockFs({});
 
-        const alice = await keymaster.createId('Alice', 'local');
+        const alice = await keymaster.createId('Alice', { registry: 'local' });
         let doc = await keymaster.resolveDID(alice);
         let vm = doc.didDocument.verificationMethod[0];
         let pubkey = vm.publicKeyJwk;
@@ -540,8 +540,8 @@ describe('rotateKeys', () => {
     it('should decrypt messages encrypted with rotating keys', async () => {
         mockFs({});
 
-        await keymaster.createId('Alice', 'local');
-        const bob = await keymaster.createId('Bob', 'local');
+        await keymaster.createId('Alice', { registry: 'local' });
+        const bob = await keymaster.createId('Bob', { registry: 'local' });
         const secrets = [];
         const msg = "Hi Bob!";
 
@@ -1028,7 +1028,7 @@ describe('decrypt', () => {
     it('should decrypt a short message after rotating keys (confirmed)', async () => {
         mockFs({});
 
-        const did = await keymaster.createId('Bob', 'local');
+        const did = await keymaster.createId('Bob', { registry: 'local' });
         const msg = 'Hi Bob!';
         await keymaster.rotateKeys();
         const encryptDid = await keymaster.encryptMessage(msg, did, { encryptForSender: true, registry: 'local' });
@@ -1041,7 +1041,7 @@ describe('decrypt', () => {
     it('should decrypt a short message after rotating keys (unconfirmed)', async () => {
         mockFs({});
 
-        const did = await keymaster.createId('Bob', 'hyperswarm');
+        const did = await keymaster.createId('Bob', { registry: 'hyperswarm' });
         const msg = 'Hi Bob!';
         await keymaster.rotateKeys();
         const encryptDid = await keymaster.encryptMessage(msg, did, { encryptForSender: true, registry: 'hyperswarm' });
@@ -1920,9 +1920,9 @@ describe('verifyResponse', () => {
     it('should demonstrate full workflow with credential revocations', async () => {
         mockFs({});
 
-        const alice = await keymaster.createId('Alice', 'local');
-        const bob = await keymaster.createId('Bob', 'local');
-        const carol = await keymaster.createId('Carol', 'local');
+        const alice = await keymaster.createId('Alice', { registry: 'local' });
+        const bob = await keymaster.createId('Bob', { registry: 'local' });
+        const carol = await keymaster.createId('Carol', { registry: 'local' });
         await keymaster.createId('Victor', 'local');
 
         keymaster.setCurrentId('Alice');

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -2125,7 +2125,7 @@ describe('publishCredential', () => {
         const boundCredential = await keymaster.bindCredential(credentialDid, bob);
         const did = await keymaster.issueCredential(boundCredential);
 
-        await keymaster.publishCredential(did, true);
+        await keymaster.publishCredential(did, { reveal: true });
 
         const doc = await keymaster.resolveDID(bob);
         const vc = await keymaster.decryptJSON(did);
@@ -2142,7 +2142,7 @@ describe('publishCredential', () => {
         const boundCredential = await keymaster.bindCredential(credentialDid, bob);
         const did = await keymaster.issueCredential(boundCredential);
 
-        await keymaster.publishCredential(did, false);
+        await keymaster.publishCredential(did, { reveal: false });
 
         const doc = await keymaster.resolveDID(bob);
         const vc = await keymaster.decryptJSON(did);
@@ -3259,7 +3259,7 @@ describe('publishPoll', () => {
         const pollDid = await keymaster.createPoll(template);
         const ballotDid = await keymaster.votePoll(pollDid, 1);
         await keymaster.updatePoll(ballotDid);
-        const ok = await keymaster.publishPoll(pollDid, true);
+        const ok = await keymaster.publishPoll(pollDid, { reveal: true });
         const pollData = await keymaster.resolveAsset(pollDid);
 
         expect(ok).toBe(true);

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -1246,7 +1246,7 @@ const mockSchema = {
     "type": "object"
 };
 
-describe('createCredential', () => {
+describe('createSchema', () => {
 
     afterEach(() => {
         mockFs.restore();
@@ -1257,7 +1257,7 @@ describe('createCredential', () => {
 
         await keymaster.createId('Bob');
 
-        const did = await keymaster.createCredential(mockSchema);
+        const did = await keymaster.createSchema(mockSchema);
         const doc = await keymaster.resolveDID(did);
 
         expect(doc.didDocument.id).toBe(did);
@@ -1275,7 +1275,7 @@ describe('bindCredential', () => {
         mockFs({});
 
         const userDid = await keymaster.createId('Bob');
-        const credentialDid = await keymaster.createCredential(mockSchema);
+        const credentialDid = await keymaster.createSchema(mockSchema);
 
         const vc = await keymaster.bindCredential(credentialDid, userDid);
 
@@ -1289,7 +1289,7 @@ describe('bindCredential', () => {
 
         const alice = await keymaster.createId('Alice');
         const bob = await keymaster.createId('Bob');
-        const credentialDid = await keymaster.createCredential(mockSchema);
+        const credentialDid = await keymaster.createSchema(mockSchema);
 
         keymaster.setCurrentId('Alice')
         const vc = await keymaster.bindCredential(credentialDid, bob);
@@ -1310,7 +1310,7 @@ describe('issueCredential', () => {
         mockFs({});
 
         const userDid = await keymaster.createId('Bob');
-        const credentialDid = await keymaster.createCredential(mockSchema);
+        const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, userDid);
 
         const did = await keymaster.issueCredential(boundCredential);
@@ -1335,7 +1335,7 @@ describe('issueCredential', () => {
 
         keymaster.setCurrentId('Alice');
 
-        const credentialDid = await keymaster.createCredential(mockSchema);
+        const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, bob);
 
         keymaster.setCurrentId('Bob');
@@ -1369,7 +1369,7 @@ describe('listIssued', () => {
         mockFs({});
 
         const userDid = await keymaster.createId('Bob');
-        const credentialDid = await keymaster.createCredential(mockSchema);
+        const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, userDid);
         const did = await keymaster.issueCredential(boundCredential);
 
@@ -1389,7 +1389,7 @@ describe('updateCredential', () => {
         mockFs({});
 
         const userDid = await keymaster.createId('Bob');
-        const credentialDid = await keymaster.createCredential(mockSchema);
+        const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, userDid);
         const did = await keymaster.issueCredential(boundCredential);
         const vc = await keymaster.getCredential(did);
@@ -1411,7 +1411,7 @@ describe('updateCredential', () => {
         mockFs({});
 
         const bob = await keymaster.createId('Bob');
-        const credentialDid = await keymaster.createCredential(mockSchema);
+        const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, bob);
         const did = await keymaster.issueCredential(boundCredential);
         const vc = await keymaster.getCredential(did);
@@ -1501,7 +1501,7 @@ describe('revokeCredential', () => {
         mockFs({});
 
         const userDid = await keymaster.createId('Bob');
-        const credentialDid = await keymaster.createCredential(mockSchema);
+        const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, userDid);
         const did = await keymaster.issueCredential(boundCredential);
 
@@ -1517,7 +1517,7 @@ describe('revokeCredential', () => {
         mockFs({});
 
         const userDid = await keymaster.createId('Bob');
-        const credentialDid = await keymaster.createCredential(mockSchema);
+        const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, userDid);
         const did = await keymaster.issueCredential(boundCredential);
 
@@ -1540,7 +1540,7 @@ describe('revokeCredential', () => {
 
         keymaster.setCurrentId('Alice');
 
-        const credentialDid = await keymaster.createCredential(mockSchema);
+        const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, bob);
         const did = await keymaster.issueCredential(boundCredential);
 
@@ -1572,7 +1572,7 @@ describe('acceptCredential', () => {
 
         keymaster.setCurrentId('Alice');
 
-        const credentialDid = await keymaster.createCredential(mockSchema);
+        const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, bob);
         const did = await keymaster.issueCredential(boundCredential);
 
@@ -1595,7 +1595,7 @@ describe('acceptCredential', () => {
 
         keymaster.setCurrentId('Alice');
 
-        const credentialDid = await keymaster.createCredential(mockSchema);
+        const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, bob);
         const did = await keymaster.issueCredential(boundCredential);
 
@@ -1613,7 +1613,7 @@ describe('acceptCredential', () => {
 
         keymaster.setCurrentId('Alice');
 
-        const credentialDid = await keymaster.createCredential(mockSchema);
+        const credentialDid = await keymaster.createSchema(mockSchema);
 
         keymaster.setCurrentId('Bob');
 
@@ -1656,7 +1656,7 @@ describe('createChallenge', () => {
 
         keymaster.setCurrentId('Alice');
 
-        const credentialDid = await keymaster.createCredential(mockSchema);
+        const credentialDid = await keymaster.createSchema(mockSchema);
         const challenge = {
             challenge: {
                 credentials: [
@@ -1717,7 +1717,7 @@ describe('createResponse', () => {
 
         keymaster.setCurrentId('Alice');
 
-        const credentialDid = await keymaster.createCredential(mockSchema);
+        const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, bob);
         const vcDid = await keymaster.issueCredential(boundCredential);
 
@@ -1844,7 +1844,7 @@ describe('verifyResponse', () => {
 
         keymaster.setCurrentId('Alice');
 
-        const credential1 = await keymaster.createCredential(mockSchema);
+        const credential1 = await keymaster.createSchema(mockSchema);
         const bc1 = await keymaster.bindCredential(credential1, carol);
         const vc1 = await keymaster.issueCredential(bc1);
 
@@ -1888,7 +1888,7 @@ describe('verifyResponse', () => {
 
         keymaster.setCurrentId('Alice');
 
-        const credential1 = await keymaster.createCredential(mockSchema);
+        const credential1 = await keymaster.createSchema(mockSchema);
 
         keymaster.setCurrentId('Victor');
 
@@ -1927,25 +1927,25 @@ describe('verifyResponse', () => {
 
         keymaster.setCurrentId('Alice');
 
-        const credential1 = await keymaster.createCredential(mockSchema, 'local');
-        const credential2 = await keymaster.createCredential(mockSchema, 'local');
+        const schema1 = await keymaster.createSchema(mockSchema, { registry: 'local' });
+        const schema2 = await keymaster.createSchema(mockSchema, { registry: 'local' });
 
-        const bc1 = await keymaster.bindCredential(credential1, carol);
-        const bc2 = await keymaster.bindCredential(credential2, carol);
+        const bc1 = await keymaster.bindCredential(schema1, carol);
+        const bc2 = await keymaster.bindCredential(schema2, carol);
 
-        const vc1 = await keymaster.issueCredential(bc1, 'local');
-        const vc2 = await keymaster.issueCredential(bc2, 'local');
+        const vc1 = await keymaster.issueCredential(bc1, { registry: 'local' });
+        const vc2 = await keymaster.issueCredential(bc2, { registry: 'local' });
 
         keymaster.setCurrentId('Bob');
 
-        const credential3 = await keymaster.createCredential(mockSchema, 'local');
-        const credential4 = await keymaster.createCredential(mockSchema, 'local');
+        const schema3 = await keymaster.createSchema(mockSchema, { registry: 'local' });
+        const schema4 = await keymaster.createSchema(mockSchema, { registry: 'local' });
 
-        const bc3 = await keymaster.bindCredential(credential3, carol);
-        const bc4 = await keymaster.bindCredential(credential4, carol);
+        const bc3 = await keymaster.bindCredential(schema3, carol);
+        const bc4 = await keymaster.bindCredential(schema4, carol);
 
-        const vc3 = await keymaster.issueCredential(bc3, 'local');
-        const vc4 = await keymaster.issueCredential(bc4, 'local');
+        const vc3 = await keymaster.issueCredential(bc3, { registry: 'local' });
+        const vc4 = await keymaster.issueCredential(bc4, { registry: 'local' });
 
         keymaster.setCurrentId('Carol');
 
@@ -1960,19 +1960,19 @@ describe('verifyResponse', () => {
             challenge: {
                 credentials: [
                     {
-                        schema: credential1,
+                        schema: schema1,
                         issuers: [alice]
                     },
                     {
-                        schema: credential2,
+                        schema: schema2,
                         issuers: [alice]
                     },
                     {
-                        schema: credential3,
+                        schema: schema3,
                         issuers: [bob]
                     },
                     {
-                        schema: credential4,
+                        schema: schema4,
                         issuers: [bob]
                     },
                 ]
@@ -2084,7 +2084,7 @@ describe('publishCredential', () => {
         mockFs({});
 
         const bob = await keymaster.createId('Bob');
-        const credentialDid = await keymaster.createCredential(mockSchema);
+        const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, bob);
         const did = await keymaster.issueCredential(boundCredential);
 
@@ -2101,7 +2101,7 @@ describe('publishCredential', () => {
         mockFs({});
 
         const bob = await keymaster.createId('Bob');
-        const credentialDid = await keymaster.createCredential(mockSchema);
+        const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, bob);
         const did = await keymaster.issueCredential(boundCredential);
 
@@ -2127,7 +2127,7 @@ describe('unpublishCredential', () => {
         mockFs({});
 
         const bob = await keymaster.createId('Bob');
-        const credentialDid = await keymaster.createCredential(mockSchema);
+        const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, bob);
         const did = await keymaster.issueCredential(boundCredential);
         await keymaster.publishCredential(did, true);
@@ -2170,7 +2170,7 @@ describe('unpublishCredential', () => {
         mockFs({});
 
         const bob = await keymaster.createId('Bob');
-        const credentialDid = await keymaster.createCredential(mockSchema);
+        const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, bob);
         const did = await keymaster.issueCredential(boundCredential);
 
@@ -3465,8 +3465,8 @@ async function setupCredentials() {
 
     keymaster.setCurrentId('Alice');
 
-    const credential1 = await keymaster.createCredential(mockSchema);
-    const credential2 = await keymaster.createCredential(mockSchema);
+    const credential1 = await keymaster.createSchema(mockSchema);
+    const credential2 = await keymaster.createSchema(mockSchema);
 
     const bc1 = await keymaster.bindCredential(credential1, carol);
     const bc2 = await keymaster.bindCredential(credential2, carol);
@@ -3476,8 +3476,8 @@ async function setupCredentials() {
 
     keymaster.setCurrentId('Bob');
 
-    const credential3 = await keymaster.createCredential(mockSchema);
-    const credential4 = await keymaster.createCredential(mockSchema);
+    const credential3 = await keymaster.createSchema(mockSchema);
+    const credential4 = await keymaster.createSchema(mockSchema);
 
     const bc3 = await keymaster.bindCredential(credential3, carol);
     const bc4 = await keymaster.bindCredential(credential4, carol);

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -548,7 +548,7 @@ describe('rotateKeys', () => {
         for (let i = 0; i < 3; i++) {
             keymaster.setCurrentId('Alice');
 
-            const did = await keymaster.encryptMessage(msg, bob, true, 'local');
+            const did = await keymaster.encryptMessage(msg, bob, { registry: 'local' });
             secrets.push(did);
 
             await keymaster.rotateKeys();
@@ -986,7 +986,7 @@ describe('encrypt', () => {
         const data = doc.didDocumentData;
         const msgHash = cipher.hashMessage(msg);
 
-        expect(data.cipher_hash).toBe(msgHash);
+        expect(data.encrypted.cipher_hash).toBe(msgHash);
     });
 
     it('should encrypt a long message', async () => {
@@ -1002,7 +1002,7 @@ describe('encrypt', () => {
         const data = doc.didDocumentData;
         const msgHash = cipher.hashMessage(msg);
 
-        expect(data.cipher_hash).toBe(msgHash);
+        expect(data.encrypted.cipher_hash).toBe(msgHash);
     });
 });
 
@@ -1031,7 +1031,7 @@ describe('decrypt', () => {
         const did = await keymaster.createId('Bob', 'local');
         const msg = 'Hi Bob!';
         await keymaster.rotateKeys();
-        const encryptDid = await keymaster.encryptMessage(msg, did, true, 'local');
+        const encryptDid = await keymaster.encryptMessage(msg, did, { encryptForSender: true, registry: 'local' });
         await keymaster.rotateKeys();
         const decipher = await keymaster.decryptMessage(encryptDid);
 
@@ -1044,7 +1044,7 @@ describe('decrypt', () => {
         const did = await keymaster.createId('Bob', 'hyperswarm');
         const msg = 'Hi Bob!';
         await keymaster.rotateKeys();
-        const encryptDid = await keymaster.encryptMessage(msg, did, true, 'hyperswarm');
+        const encryptDid = await keymaster.encryptMessage(msg, did, { encryptForSender: true, registry: 'hyperswarm' });
         const decipher = await keymaster.decryptMessage(encryptDid);
 
         expect(decipher).toBe(msg);
@@ -1112,7 +1112,7 @@ describe('encryptJSON', () => {
         const did = await keymaster.encryptJSON(mockJson, bob);
         const data = await keymaster.resolveAsset(did);
 
-        expect(data.sender).toStrictEqual(bob);
+        expect(data.encrypted.sender).toStrictEqual(bob);
     });
 });
 

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -1639,14 +1639,16 @@ describe('createChallenge', () => {
                 credentials: []
             }
         };
-        const expectedEphemeral = {
-            validUntil: expect.any(String)
-        };
 
         expect(doc.didDocument.id).toBe(did);
         expect(doc.didDocument.controller).toBe(alice);
         expect(doc.didDocumentData).toStrictEqual(expectedChallenge);
-        expect(doc.mdip.ephemeral).toStrictEqual(expectedEphemeral);
+
+        const now = new Date();
+        const validUntil = new Date(doc.mdip.validUntil);
+        const ttl = validUntil - now;
+
+        expect(ttl < 60 * 60 * 1000).toBe(true);
     });
 
     it('should create an empty challenge with specified expiry', async () => {
@@ -1661,14 +1663,11 @@ describe('createChallenge', () => {
                 credentials: []
             }
         };
-        const expectedEphemeral = {
-            validUntil
-        };
 
         expect(doc.didDocument.id).toBe(did);
         expect(doc.didDocument.controller).toBe(alice);
         expect(doc.didDocumentData).toStrictEqual(expectedChallenge);
-        expect(doc.mdip.ephemeral).toStrictEqual(expectedEphemeral);
+        expect(doc.mdip.validUntil).toBe(validUntil);
     });
 
     it('should create a valid challenge', async () => {

--- a/tests/workflow.js
+++ b/tests/workflow.js
@@ -20,10 +20,10 @@ const mockSchema = {
 
 async function runWorkflow() {
 
-    const alice = await keymaster.createId('Alice', 'local');
-    const bob = await keymaster.createId('Bob', 'local');
-    const carol = await keymaster.createId('Carol', 'local');
-    const victor = await keymaster.createId('Victor', 'local');
+    const alice = await keymaster.createId('Alice', { registry: 'local' });
+    const bob = await keymaster.createId('Bob', { registry: 'local' });
+    const carol = await keymaster.createId('Carol', { registry: 'local' });
+    const victor = await keymaster.createId('Victor', { registry: 'local' });
 
     console.log(`Created Alice  ${alice}`);
     console.log(`Created Bob    ${bob}`);
@@ -32,34 +32,34 @@ async function runWorkflow() {
 
     keymaster.setCurrentId('Alice');
 
-    const credential1 = await keymaster.createCredential(mockSchema, 'local');
-    const credential2 = await keymaster.createCredential(mockSchema, 'local');
+    const schema1 = await keymaster.createSchema(mockSchema, { registry: 'local' });
+    const schema2 = await keymaster.createSchema(mockSchema, { registry: 'local' });
 
-    console.log(`Alice created credential1  ${credential1}`);
-    console.log(`Alice created credential2  ${credential2}`);
+    console.log(`Alice created schema1 ${schema1}`);
+    console.log(`Alice created schema2 ${schema2}`);
 
-    const bc1 = await keymaster.bindCredential(credential1, carol);
-    const bc2 = await keymaster.bindCredential(credential2, carol);
+    const bc1 = await keymaster.bindCredential(schema1, carol);
+    const bc2 = await keymaster.bindCredential(schema2, carol);
 
-    const vc1 = await keymaster.issueCredential(bc1, 'local');
-    const vc2 = await keymaster.issueCredential(bc2, 'local');
+    const vc1 = await keymaster.issueCredential(bc1, { registry: 'local' });
+    const vc2 = await keymaster.issueCredential(bc2, { registry: 'local' });
 
     console.log(`Alice issued vc1 for Carol ${vc1}`);
     console.log(`Alice issued vc2 for Carol ${vc2}`);
 
     keymaster.setCurrentId('Bob');
 
-    const credential3 = await keymaster.createCredential(mockSchema, 'local');
-    const credential4 = await keymaster.createCredential(mockSchema, 'local');
+    const schema3 = await keymaster.createSchema(mockSchema, { registry: 'local' });
+    const schema4 = await keymaster.createSchema(mockSchema, { registry: 'local' });
 
-    console.log(`Bob created credential3  ${credential3}`);
-    console.log(`Bob created credential4  ${credential4}`);
+    console.log(`Bob created schema3 ${schema3}`);
+    console.log(`Bob created schema4 ${schema4}`);
 
-    const bc3 = await keymaster.bindCredential(credential3, carol);
-    const bc4 = await keymaster.bindCredential(credential4, carol);
+    const bc3 = await keymaster.bindCredential(schema3, carol);
+    const bc4 = await keymaster.bindCredential(schema4, carol);
 
-    const vc3 = await keymaster.issueCredential(bc3, 'local');
-    const vc4 = await keymaster.issueCredential(bc4, 'local');
+    const vc3 = await keymaster.issueCredential(bc3, { registry: 'local' });
+    const vc4 = await keymaster.issueCredential(bc4, { registry: 'local' });
 
     console.log(`Bob issued vc3 for Carol ${vc3}`);
     console.log(`Bob issued vc4 for Carol ${vc4}`);
@@ -79,19 +79,19 @@ async function runWorkflow() {
         challenge: {
             credentials: [
                 {
-                    schema: credential1,
+                    schema: schema1,
                     issuers: [alice]
                 },
                 {
-                    schema: credential2,
+                    schema: schema2,
                     issuers: [alice]
                 },
                 {
-                    schema: credential3,
+                    schema: schema3,
                     issuers: [bob]
                 },
                 {
-                    schema: credential4,
+                    schema: schema4,
                     issuers: [bob]
                 },
             ]


### PR DESCRIPTION
The response DIDs were not garbage-collected because the validUntil time was stored in the `didDocumentData` which is encrypted for responses.

This fix moves the validUntil time into the mdip section of the DID documents, which makes more sense since the gatekeeper now has responsibility for garbage collection including expired DIDs, and the gatekeeper does not look inside the didDocumentData on principle (so far). As far as the gatekeeper is concerned there are only agents and assets.

Also resolves: Move DID garbage collection into gatekeeper #303 

Also resolves: Use options pattern #338 

The options pattern has a several advantages. By moving optional parameters into a dictionary, it makes the code more readable with named parameters, e.g.

```
const ok = await keymaster.publishPoll(poll, { reveal: true });
const did = await keymaster.createAsset(batch, { registry: REGISTRY, controller: config.nodeID });
```

Additionally more parameters can be added without changing the function signature (future-proofing). And it makes it much easier to pass the parameters over http in the  SDK.

This change is not backwards compatible, in the sense that the 0.3-beta keymaster SDK will not work with later keymaster servers. When we get out of beta the SDK may support different API versions, but not yet.

For this reason, we've bumped the hyperswarm protocol version to create a different MDIP network to be on the safe side. This doesn't eliminate the compatibility issue, but makes it easier to upgrade servers in unison.

