### PR TITLE
ci: pull trivy image from ECR vs github due to rate limiting

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,7 +15,6 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
 
 jobs:
   generate:
@@ -95,3 +94,5 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL'
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,6 +15,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
 
 jobs:
   generate:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,6 +16,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
 
 jobs:
   generate:


### PR DESCRIPTION
This update is to use the ECR AWS registry for the trivy db vs Github due to rate limiting. This may not fix the issue, but will look at caching the db or an alternative replacement. 