### PR TITLE
refactor: Simplify start functions

### DIFF
--- a/packages/gatekeeper/README.md
+++ b/packages/gatekeeper/README.md
@@ -20,10 +20,10 @@ The library must be configured by calling the start function with one of the sup
 
 ```js
 import * as gatekeeper from '@mdip/gatekeeper/lib';
-import * as json_db from '@mdip/gatekeeper/db/json';
+import * as db_json from '@mdip/gatekeeper/db/json';
 
 await json_db.start('mdip-test');
-await gatekeeper.start(json_db);
+await gatekeeper.start({ db: db_json });
 
 const did = 'did:test:did:test:z3v8AuaTV5VKcT9MJoSHkSTRLpXDoqcgqiKkwGBNSV4nVzb6kLk';
 const docs = await gatekeeper.resolveDID(did);

--- a/packages/gatekeeper/README.md
+++ b/packages/gatekeeper/README.md
@@ -37,8 +37,12 @@ The SDK is used to communicate with a Gatekeeper REST API service.
 ```js
 import * as gatekeeper from '@mdip/gatekeeper/sdk';
 
-gatekeeper.setURL('http://gatekeeper-host:4224');
-await gatekeeper.waitUntilReady();
+await gatekeeper.start({
+    url: 'http://gatekeeper-host:4224',
+    waitUntilReady: true,
+    intervalSeconds: 5,
+    chatty: true,
+});
 
 const did = 'did:test:did:test:z3v8AuaTV5VKcT9MJoSHkSTRLpXDoqcgqiKkwGBNSV4nVzb6kLk';
 const docs = await gatekeeper.resolveDID(did);

--- a/packages/gatekeeper/README.md
+++ b/packages/gatekeeper/README.md
@@ -25,7 +25,7 @@ import * as db_json from '@mdip/gatekeeper/db/json';
 await json_db.start('mdip-test');
 await gatekeeper.start({ db: db_json });
 
-const did = 'did:test:did:test:z3v8AuaTV5VKcT9MJoSHkSTRLpXDoqcgqiKkwGBNSV4nVzb6kLk';
+const did = 'did:test:z3v8AuaTV5VKcT9MJoSHkSTRLpXDoqcgqiKkwGBNSV4nVzb6kLk';
 const docs = await gatekeeper.resolveDID(did);
 console.log(JSON.stringify(docs, null, 4));
 ```
@@ -37,14 +37,17 @@ The SDK is used to communicate with a Gatekeeper REST API service.
 ```js
 import * as gatekeeper from '@mdip/gatekeeper/sdk';
 
+// Try connecting to the gatekeeper service every second,
+// and start reporting (chatty) if not connected after 5 attempts
 await gatekeeper.start({
     url: 'http://gatekeeper-host:4224',
     waitUntilReady: true,
-    intervalSeconds: 5,
-    chatty: true,
+    intervalSeconds: 1,
+    chatty: false,
+    becomeChattyAfter: 5
 });
 
-const did = 'did:test:did:test:z3v8AuaTV5VKcT9MJoSHkSTRLpXDoqcgqiKkwGBNSV4nVzb6kLk';
+const did = 'did:test:z3v8AuaTV5VKcT9MJoSHkSTRLpXDoqcgqiKkwGBNSV4nVzb6kLk';
 const docs = await gatekeeper.resolveDID(did);
 console.log(JSON.stringify(docs, null, 4));
 ```

--- a/packages/gatekeeper/src/gatekeeper-lib.js
+++ b/packages/gatekeeper/src/gatekeeper-lib.js
@@ -20,18 +20,28 @@ export function copyJSON(json) {
     return JSON.parse(JSON.stringify(json))
 }
 
-export async function start(injectedDb) {
+export async function start(options = {}) {
+    if (options.db) {
+        db = options.db;
+    }
+    else {
+        throw new Error(exceptions.INVALID_PARAMETER);
+    }
+
     if (!ipfs) {
         helia = await createHelia();
         ipfs = json(helia);
     }
-
-    db = injectedDb;
 }
 
 export async function stop() {
-    helia.stop();
-    await db.stop();
+    if (helia) {
+        helia.stop();
+    }
+
+    if (db) {
+        await db.stop();
+    }
 }
 
 export async function verifyDID(did) {

--- a/packages/gatekeeper/src/gatekeeper-lib.js
+++ b/packages/gatekeeper/src/gatekeeper-lib.js
@@ -28,6 +28,10 @@ export async function start(options = {}) {
         throw new Error(exceptions.INVALID_PARAMETER);
     }
 
+    if (options.console) {
+        console = options.console;
+    }
+
     if (!ipfs) {
         helia = await createHelia();
         ipfs = json(helia);
@@ -69,7 +73,7 @@ export async function verifyDID(did) {
     return "OK";
 }
 
-export async function verifyDb(chatty = true) {
+export async function verifyDb(chatty) {
     if (chatty) {
         console.time('verifyDb');
     }

--- a/packages/gatekeeper/src/gatekeeper-lib.js
+++ b/packages/gatekeeper/src/gatekeeper-lib.js
@@ -28,7 +28,9 @@ export async function start(options = {}) {
         throw new Error(exceptions.INVALID_PARAMETER);
     }
 
+    // Only used for unit testing
     if (options.console) {
+        // eslint-disable-next-line
         console = options.console;
     }
 

--- a/packages/gatekeeper/src/gatekeeper-sdk.js
+++ b/packages/gatekeeper/src/gatekeeper-sdk.js
@@ -10,14 +10,50 @@ function throwError(error) {
     throw error.message;
 }
 
-export async function start() {
+export async function start(options = {}) {
+    if (options.url) {
+        URL = options.url;
+    }
+
+    if (options.waitUntilReady) {
+        await waitUntilReady(options);
+    }
+}
+
+async function waitUntilReady(options = {}) {
+    let { intervalSeconds, chatty, becomeChattyAfter } = options;
+    let ready = false;
+    let retries = 0;
+
+    if (chatty) {
+        console.log(`Connecting to gatekeeper at ${URL}`);
+    }
+
+    while (!ready) {
+        ready = await isReady();
+
+        if (!ready) {
+            if (chatty) {
+                console.log('Waiting for Gatekeeper to be ready...');
+            }
+            // wait for 1 second before checking again
+            await new Promise(resolve => setTimeout(resolve, intervalSeconds * 1000));
+        }
+
+        retries += 1;
+
+        if (!chatty && retries > becomeChattyAfter) {
+            console.log(`Connecting to gatekeeper at ${URL}`);
+            chatty = true;
+        }
+    }
+
+    if (chatty) {
+        console.log('Gatekeeper service is ready!');
+    }
 }
 
 export async function stop() {
-}
-
-export function setURL(url) {
-    URL = url;
 }
 
 export async function listRegistries() {
@@ -37,30 +73,6 @@ export async function resetDb() {
     }
     catch (error) {
         return false;
-    }
-}
-
-export async function waitUntilReady(intervalSeconds = 5, chatty = true) {
-    let ready = false;
-
-    if (chatty) {
-        console.log(`Connecting to gatekeeper at ${URL}`);
-    }
-
-    while (!ready) {
-        ready = await isReady();
-
-        if (!ready) {
-            if (chatty) {
-                console.log('Waiting for Gatekeeper to be ready...');
-            }
-            // wait for 1 second before checking again
-            await new Promise(resolve => setTimeout(resolve, intervalSeconds * 1000));
-        }
-    }
-
-    if (chatty) {
-        console.log('Gatekeeper service is ready!');
     }
 }
 

--- a/packages/gatekeeper/src/gatekeeper-sdk.js
+++ b/packages/gatekeeper/src/gatekeeper-sdk.js
@@ -25,6 +25,18 @@ async function waitUntilReady(options = {}) {
     let ready = false;
     let retries = 0;
 
+    if (!intervalSeconds) {
+        intervalSeconds = 5;
+    }
+
+    if (!chatty) {
+        chatty = false;
+    }
+
+    if (!becomeChattyAfter) {
+        becomeChattyAfter = 0;
+    }
+
     if (chatty) {
         console.log(`Connecting to gatekeeper at ${URL}`);
     }
@@ -42,7 +54,7 @@ async function waitUntilReady(options = {}) {
 
         retries += 1;
 
-        if (!chatty && retries > becomeChattyAfter) {
+        if (!chatty && becomeChattyAfter > 0 && retries > becomeChattyAfter) {
             console.log(`Connecting to gatekeeper at ${URL}`);
             chatty = true;
         }

--- a/packages/keymaster/README.md
+++ b/packages/keymaster/README.md
@@ -26,8 +26,12 @@ import * as json_wallet from '@mdip/keymaster/db/json';
 import * as cipher_node from '@mdip/cipher/node';
 import * as keymaster_lib from '@mdip/keymaster/lib';
 
-gatekeeper_sdk.setURL('http://gatekeeper-host:4224');
-await gatekeeper_sdk.waitUntilReady();
+await gatekeeper.start({
+    url: 'http://gatekeeper-host:4224',
+    waitUntilReady: true,
+    intervalSeconds: 5,
+    chatty: true,
+});
 await keymaster_lib.start(gatekeeper_sdk, json_wallet, cipher_node);
 
 const newId = await keymaster_lib.createId('Bob');
@@ -41,8 +45,12 @@ import * as browser_wallet from '@mdip/keymaster/db/web';
 import * as cipher_web from '@mdip/cipher/web';
 import * as keymaster_lib from '@mdip/keymaster/lib';
 
-gatekeeper_sdk.setURL('http://gatekeeper-host:4224');
-await gatekeeper_sdk.waitUntilReady();
+await gatekeeper.start({
+    url: 'http://gatekeeper-host:4224',
+    waitUntilReady: true,
+    intervalSeconds: 5,
+    chatty: true,
+});
 await keymaster_lib.start(gatekeeper_sdk, browser_wallet, cipher_web);
 
 const newId = await keymaster_lib.createId('Bob');

--- a/packages/keymaster/README.md
+++ b/packages/keymaster/README.md
@@ -26,13 +26,17 @@ import * as json_wallet from '@mdip/keymaster/db/json';
 import * as cipher_node from '@mdip/cipher/node';
 import * as keymaster_lib from '@mdip/keymaster/lib';
 
-await gatekeeper.start({
+await gatekeeper_sdk.start({
     url: 'http://gatekeeper-host:4224',
     waitUntilReady: true,
     intervalSeconds: 5,
     chatty: true,
 });
-await keymaster_lib.start(gatekeeper_sdk, json_wallet, cipher_node);
+await keymaster_lib.start({
+    gatekeeper: gatekeeper_sdk,
+    wallet: json_wallet,
+    cipher: cipher_node
+});
 
 const newId = await keymaster_lib.createId('Bob');
 ```
@@ -45,13 +49,17 @@ import * as browser_wallet from '@mdip/keymaster/db/web';
 import * as cipher_web from '@mdip/cipher/web';
 import * as keymaster_lib from '@mdip/keymaster/lib';
 
-await gatekeeper.start({
+await gatekeeper_sdk.start({
     url: 'http://gatekeeper-host:4224',
     waitUntilReady: true,
     intervalSeconds: 5,
-    chatty: true,
+    chatty: true
 });
-await keymaster_lib.start(gatekeeper_sdk, browser_wallet, cipher_web);
+await keymaster_lib.start({
+    gatekeeper: gatekeeper_sdk,
+    wallet: browser_wallet,
+    cipher: cipher_web
+});
 
 const newId = await keymaster_lib.createId('Bob');
 ```
@@ -63,8 +71,12 @@ The SDK is used to communicate with a keymaster REST API service.
 ```js
 import * as keymaster_sdk from '@mdip/keymaster/sdk';
 
-keymaster_sdk.setURL('http://keymaster-host:4226');
-await keymaster_sdk.waitUntilReady();
+await keymaster_sdk.start({
+    url: 'http://keymaster-host:4226',
+    waitUntilReady: true,
+    intervalSeconds: 5,
+    chatty: true
+});
 
 const newId = await keymaster_sdk.createId('Bob');
 ```

--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -8,18 +8,43 @@ let cipher = null;
 const defaultRegistry = 'TESS';
 const ephemeralRegistry = 'hyperswarm';
 
-export async function start(gatekeeperDep, dbDep, cipherDep) {
-    if (!gatekeeperDep?.createDID || !dbDep?.loadWallet || !cipherDep?.verifySig) {
+export async function start(options = {}) {
+    if (options.gatekeeper) {
+        gatekeeper = options.gatekeeper;
+
+        if (!gatekeeper.createDID) {
+            throw new Error(exceptions.INVALID_PARAMETER);
+        }
+    }
+    else {
         throw new Error(exceptions.INVALID_PARAMETER);
     }
 
-    gatekeeper = gatekeeperDep;
-    db = dbDep;
-    cipher = cipherDep;
+    if (options.wallet) {
+        db = options.wallet;
+
+        if (!db.loadWallet) {
+            throw new Error(exceptions.INVALID_PARAMETER);
+        }
+    }
+    else {
+        throw new Error(exceptions.INVALID_PARAMETER);
+    }
+
+    if (options.cipher) {
+        cipher = options.cipher;
+
+        if (!cipher.verifySig) {
+            throw new Error(exceptions.INVALID_PARAMETER);
+        }
+    }
+    else {
+        throw new Error(exceptions.INVALID_PARAMETER);
+    }
 }
 
 export async function stop() {
-    await gatekeeper.stop();
+    return gatekeeper.stop();
 }
 
 export async function listRegistries() {

--- a/packages/keymaster/src/keymaster-sdk.js
+++ b/packages/keymaster/src/keymaster-sdk.js
@@ -10,12 +10,32 @@ function throwError(error) {
     throw error.message;
 }
 
-export function setURL(url) {
-    URL = url;
+export async function start(options = {}) {
+    if (options.url) {
+        URL = options.url;
+    }
+
+    if (options.waitUntilReady) {
+        await waitUntilReady(options);
+    }
 }
 
-export async function waitUntilReady(intervalSeconds = 1, chatty = true) {
+async function waitUntilReady(options) {
+    let { intervalSeconds, chatty, becomeChattyAfter } = options;
     let ready = false;
+    let retries = 0;
+
+    if (!intervalSeconds) {
+        intervalSeconds = 5;
+    }
+
+    if (!chatty) {
+        chatty = false;
+    }
+
+    if (!becomeChattyAfter) {
+        becomeChattyAfter = 0;
+    }
 
     if (chatty) {
         console.log(`Connecting to Keymaster at ${URL}`);
@@ -31,11 +51,21 @@ export async function waitUntilReady(intervalSeconds = 1, chatty = true) {
             // wait for 1 second before checking again
             await new Promise(resolve => setTimeout(resolve, intervalSeconds * 1000));
         }
+
+        retries += 1;
+
+        if (!chatty && becomeChattyAfter > 0 && retries > becomeChattyAfter) {
+            console.log(`Connecting to Keymaster at ${URL}`);
+            chatty = true;
+        }
     }
 
     if (chatty) {
         console.log('Keymaster service is ready!');
     }
+}
+
+export async function stop() {
 }
 
 export async function isReady() {

--- a/sample.env
+++ b/sample.env
@@ -9,8 +9,11 @@ KC_DEBUG=false
 KC_GATEKEEPER_DB=json
 KC_GATEKEEPER_REGISTRIES=hyperswarm,TESS,TBTC,TFTC
 KC_GATEKEEPER_PORT=4224
-KC_GATEKEEPER_URL=http://localhost:4224
 KC_GATEKEEPER_VERIFY_DB=true
+
+# CLI
+KC_GATEKEEPER_URL=http://localhost:4224
+# KC_KEYMASTER_URL=http://localhost:4226
 
 # Tesseract mainnet mediator
 KC_TESS_HOST=localhost

--- a/scripts/admin-cli.js
+++ b/scripts/admin-cli.js
@@ -4,7 +4,7 @@ import dotenv from 'dotenv';
 
 import * as gatekeeper from '@mdip/gatekeeper/sdk';
 import * as keymaster from '@mdip/keymaster/lib';
-import * as db_wallet from '@mdip/keymaster/db/json';
+import * as wallet from '@mdip/keymaster/db/json';
 import * as cipher from '@mdip/cipher/node';
 
 dotenv.config();
@@ -383,8 +383,8 @@ program
     });
 
 async function run() {
-    gatekeeper.setURL(gatekeeperURL);
-    await keymaster.start(gatekeeper, db_wallet, cipher);
+    gatekeeper.start({ url: gatekeeperURL });
+    await keymaster.start({ gatekeeper, wallet, cipher });
     program.parse(process.argv);
     await keymaster.stop();
 }

--- a/scripts/keychain-cli.js
+++ b/scripts/keychain-cli.js
@@ -851,8 +851,13 @@ async function run() {
     }
     else {
         keymaster = keymaster_lib;
-        gatekeeper_sdk.setURL(gatekeeperURL);
-        await gatekeeper_sdk.waitUntilReady(1, false);
+        await gatekeeper_sdk.start({
+            url: gatekeeperURL,
+            waitUntilReady: true,
+            intervalSeconds: 1,
+            chatty: false,
+            becomeChattyAfter: 5
+        });
         await keymaster.start(gatekeeper_sdk, db_wallet, cipher);
         program.parse(process.argv);
         await keymaster.stop();

--- a/services/gatekeeper/client/src/App.js
+++ b/services/gatekeeper/client/src/App.js
@@ -3,7 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import * as gatekeeper from '@mdip/gatekeeper/sdk';
 import * as cipher from '@mdip/cipher/web';
 import * as keymaster from '@mdip/keymaster/lib';
-import * as db_wallet from "@mdip/keymaster/db/web";
+import * as wallet from "@mdip/keymaster/db/web";
 import KeymasterUI from './KeymasterUI.js';
 import './App.css';
 
@@ -13,7 +13,7 @@ function App() {
     const [searchParams] = useSearchParams();
     const challengeDID = searchParams.get('challenge');
 
-    keymaster.start(gatekeeper, db_wallet, cipher);
+    keymaster.start({ gatekeeper, wallet, cipher });
 
     return (
         <KeymasterUI keymaster={keymaster} title={'Keymaster Browser Wallet Demo'} challengeDID={challengeDID} />

--- a/services/gatekeeper/server/src/gatekeeper-api.js
+++ b/services/gatekeeper/server/src/gatekeeper-api.js
@@ -16,7 +16,7 @@ const db = (config.db === 'sqlite') ? db_sqlite
         : db_json;
 
 await db.start();
-await gatekeeper.start(db);
+await gatekeeper.start({ db });
 
 const app = express();
 const v1router = express.Router();

--- a/services/keymaster/server/src/keymaster-api.js
+++ b/services/keymaster/server/src/keymaster-api.js
@@ -689,8 +689,12 @@ process.on('unhandledRejection', (reason, promise) => {
 const port = config.keymasterPort;
 
 app.listen(port, async () => {
-    gatekeeper.setURL(`${config.gatekeeperURL}`);
-    await gatekeeper.waitUntilReady();
+    await gatekeeper.start({
+        url: config.gatekeeperURL,
+        waitUntilReady: true,
+        intervalSeconds: 5,
+        chatty: true,
+    });
     await keymaster.start(gatekeeper, db_wallet, cipher);
     console.log(`keymaster server running on port ${port}`);
 

--- a/services/keymaster/server/src/keymaster-api.js
+++ b/services/keymaster/server/src/keymaster-api.js
@@ -4,7 +4,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import * as gatekeeper from '@mdip/gatekeeper/sdk';
 import * as keymaster from '@mdip/keymaster/lib';
-import * as db_wallet from '@mdip/keymaster/db/json';
+import * as wallet from '@mdip/keymaster/db/json';
 import * as cipher from '@mdip/cipher/node';
 import config from './config.js';
 const app = express();
@@ -695,7 +695,7 @@ app.listen(port, async () => {
         intervalSeconds: 5,
         chatty: true,
     });
-    await keymaster.start(gatekeeper, db_wallet, cipher);
+    await keymaster.start({ gatekeeper, wallet, cipher });
     console.log(`keymaster server running on port ${port}`);
 
     try {

--- a/services/mediators/hyperswarm/src/hyperswarm-mediator.js
+++ b/services/mediators/hyperswarm/src/hyperswarm-mediator.js
@@ -418,8 +418,12 @@ const networkID = Buffer.from(hash).toString('hex');
 const topic = b4a.from(networkID, 'hex');
 
 async function main() {
-    gatekeeper.setURL(`${config.gatekeeperURL}`);
-    await gatekeeper.waitUntilReady();
+    await gatekeeper.start({
+        url: config.gatekeeperURL,
+        waitUntilReady: true,
+        intervalSeconds: 5,
+        chatty: true,
+    });
     await initializeBatchesSeen();
     await connectionLoop();
     await exportLoop();

--- a/services/mediators/satoshi/src/satoshi-mediator.js
+++ b/services/mediators/satoshi/src/satoshi-mediator.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import BtcClient from 'bitcoin-core';
 import * as gatekeeper from '@mdip/gatekeeper/sdk';
 import * as keymaster from '@mdip/keymaster/lib';
-import * as db_wallet from '@mdip/keymaster/db/json';
+import * as wallet from '@mdip/keymaster/db/json';
 import * as cipher from '@mdip/cipher/node';
 import config from './config.js';
 
@@ -397,7 +397,7 @@ async function main() {
         intervalSeconds: 5,
         chatty: true,
     });
-    await keymaster.start(gatekeeper, db_wallet, cipher);
+    await keymaster.start({ gatekeeper, wallet, cipher });
 
     try {
         await keymaster.resolveDID(config.nodeID);

--- a/services/mediators/satoshi/src/satoshi-mediator.js
+++ b/services/mediators/satoshi/src/satoshi-mediator.js
@@ -391,9 +391,12 @@ async function main() {
 
     await waitForChain();
 
-    gatekeeper.setURL(`${config.gatekeeperURL}`);
-
-    await gatekeeper.waitUntilReady();
+    await gatekeeper.start({
+        url: config.gatekeeperURL,
+        waitUntilReady: true,
+        intervalSeconds: 5,
+        chatty: true,
+    });
     await keymaster.start(gatekeeper, db_wallet, cipher);
 
     try {

--- a/tests/gatekeeper.test.js
+++ b/tests/gatekeeper.test.js
@@ -13,6 +13,25 @@ afterEach(async () => {
     await gatekeeper.stop();
 });
 
+describe('start', () => {
+
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should throw exception on invalid parameters', async () => {
+        mockFs({});
+
+        try {
+            await gatekeeper.start();
+            throw new Error(exceptions.EXPECTED_EXCEPTION);
+        }
+        catch (error) {
+            expect(error.message).toBe(exceptions.INVALID_PARAMETER);
+        }
+    });
+});
+
 describe('anchorSeed', () => {
 
     afterEach(() => {

--- a/tests/gatekeeper.test.js
+++ b/tests/gatekeeper.test.js
@@ -4,9 +4,16 @@ import * as gatekeeper from '@mdip/gatekeeper/lib';
 import * as db_json from '@mdip/gatekeeper/db/json';
 import * as exceptions from '@mdip/exceptions';
 
+const mockConsole = {
+    log: () => {},
+    error: () => {},
+    time: () => {},
+    timeEnd: () => {},
+}
+
 beforeEach(async () => {
     db_json.start();
-    await gatekeeper.start({ db: db_json });
+    await gatekeeper.start({ db: db_json, console: mockConsole });
 });
 
 afterEach(async () => {
@@ -1901,6 +1908,20 @@ describe('verifyDb', () => {
         await gatekeeper.createDID(assetOp);
 
         const invalid = await gatekeeper.verifyDb(false);
+
+        expect(invalid).toBe(0);
+    });
+
+    it('should verify all DIDs in db with chatty enabled', async () => {
+        mockFs({});
+
+        const keypair = cipher.generateRandomJwk();
+        const agentOp = await createAgentOp(keypair);
+        const agentDID = await gatekeeper.createDID(agentOp);
+        const assetOp = await createAssetOp(agentDID, keypair);
+        await gatekeeper.createDID(assetOp);
+
+        const invalid = await gatekeeper.verifyDb(true);
 
         expect(invalid).toBe(0);
     });

--- a/tests/gatekeeper.test.js
+++ b/tests/gatekeeper.test.js
@@ -6,7 +6,7 @@ import * as exceptions from '@mdip/exceptions';
 
 beforeEach(async () => {
     db_json.start();
-    await gatekeeper.start(db_json);
+    await gatekeeper.start({ db: db_json });
 });
 
 afterEach(async () => {

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -10,12 +10,79 @@ import * as exceptions from '@mdip/exceptions';
 
 beforeEach(async () => {
     db_json.start('mdip');
-    await gatekeeper.start(db_json);
+    await gatekeeper.start({ db: db_json });
     await keymaster.start({ gatekeeper, wallet, cipher });
 });
 
 afterEach(async () => {
     await keymaster.stop();
+});
+
+describe('start', () => {
+
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should throw exception on invalid parameters', async () => {
+        mockFs({});
+
+        try {
+            await keymaster.start();
+            throw new Error(exceptions.EXPECTED_EXCEPTION);
+        }
+        catch (error) {
+            expect(error.message).toBe(exceptions.INVALID_PARAMETER);
+        }
+
+        try {
+            await keymaster.start({ wallet, cipher });
+            throw new Error(exceptions.EXPECTED_EXCEPTION);
+        }
+        catch (error) {
+            expect(error.message).toBe(exceptions.INVALID_PARAMETER);
+        }
+
+        try {
+            await keymaster.start({ gatekeeper, cipher });
+            throw new Error(exceptions.EXPECTED_EXCEPTION);
+        }
+        catch (error) {
+            expect(error.message).toBe(exceptions.INVALID_PARAMETER);
+        }
+
+        try {
+            await keymaster.start({ gatekeeper, wallet });
+            throw new Error(exceptions.EXPECTED_EXCEPTION);
+        }
+        catch (error) {
+            expect(error.message).toBe(exceptions.INVALID_PARAMETER);
+        }
+
+        try {
+            await keymaster.start({ gatekeeper: {}, wallet, cipher });
+            throw new Error(exceptions.EXPECTED_EXCEPTION);
+        }
+        catch (error) {
+            expect(error.message).toBe(exceptions.INVALID_PARAMETER);
+        }
+
+        try {
+            await keymaster.start({ gatekeeper, wallet: {}, cipher });
+            throw new Error(exceptions.EXPECTED_EXCEPTION);
+        }
+        catch (error) {
+            expect(error.message).toBe(exceptions.INVALID_PARAMETER);
+        }
+
+        try {
+            await keymaster.start({ gatekeeper, wallet, cipher: {} });
+            throw new Error(exceptions.EXPECTED_EXCEPTION);
+        }
+        catch (error) {
+            expect(error.message).toBe(exceptions.INVALID_PARAMETER);
+        }
+    });
 });
 
 describe('loadWallet', () => {

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -5,13 +5,13 @@ import * as keymaster from '@mdip/keymaster/lib';
 import * as gatekeeper from '@mdip/gatekeeper/lib';
 import * as cipher from '@mdip/cipher/node';
 import * as db_json from '@mdip/gatekeeper/db/json';
-import * as db_wallet from '@mdip/keymaster/db/json';
+import * as wallet from '@mdip/keymaster/db/json';
 import * as exceptions from '@mdip/exceptions';
 
 beforeEach(async () => {
     db_json.start('mdip');
     await gatekeeper.start(db_json);
-    await keymaster.start(gatekeeper, db_wallet, cipher);
+    await keymaster.start({ gatekeeper, wallet, cipher });
 });
 
 afterEach(async () => {

--- a/tests/workflow.js
+++ b/tests/workflow.js
@@ -147,7 +147,7 @@ async function runWorkflow() {
 
 async function main() {
     await db_json.start('mdip-workflow');
-    await gatekeeper.start(db_json);
+    await gatekeeper.start({ db: db_json });
     await keymaster.start({ gatekeeper, wallet, cipher });
 
     const backup = await keymaster.loadWallet();

--- a/tests/workflow.js
+++ b/tests/workflow.js
@@ -1,5 +1,5 @@
 import * as keymaster from '@mdip/keymaster/lib';
-import * as db_wallet from '@mdip/keymaster/db/json';
+import * as wallet from '@mdip/keymaster/db/json';
 import * as gatekeeper from '@mdip/gatekeeper/lib';
 import * as db_json from '@mdip/gatekeeper/db/json';
 import * as cipher from '@mdip/cipher/node';
@@ -148,7 +148,7 @@ async function runWorkflow() {
 async function main() {
     await db_json.start('mdip-workflow');
     await gatekeeper.start(db_json);
-    await keymaster.start(gatekeeper, db_wallet, cipher);
+    await keymaster.start({ gatekeeper, wallet, cipher });
 
     const backup = await keymaster.loadWallet();
     await keymaster.newWallet(null, true);


### PR DESCRIPTION
All start functions (gatekeeper and keymaster, lib and sdk) now take single options parameter. The setURL and and waitForReady functions for the sdks have been rolled into the start function, and are therefore deprecated.

The READMEs have been updated with examples:

gatekeeper

```

// Try connecting to the gatekeeper service every second,
// and start reporting (chatty) if not connected after 5 attempts
await gatekeeper.start({
    url: 'http://gatekeeper-host:4224',
    waitUntilReady: true,
    intervalSeconds: 1,
    chatty: false,
    becomeChattyAfter: 5
});
```

keymaster

```
await gatekeeper_sdk.start({
    url: 'http://gatekeeper-host:4224',
    waitUntilReady: true,
    intervalSeconds: 5,
    chatty: true
});
await keymaster_lib.start({
    gatekeeper: gatekeeper_sdk,
    wallet: browser_wallet,
    cipher: cipher_web
});
```

