### PR TITLE
refactor: improve consistency of Keymaster API

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,10 @@ Commands:
   create-asset <file>                        Create an asset from a JSON file
   create-challenge [file] [name]             Create challenge (optionally from a file)
   create-challenge-cc <did> [name]           Create challenge from a credential DID
-  create-credential <file> [name]            Create credential from schema file
+  create-group <name>                        Create a new group
   create-id <name> [registry]                Create a new decentralized ID
   create-response <challenge>                Create a response to a challenge
+  create-schema <file> [name]                Create schema DID from schema file
   create-schema <file> [name]                Create schema from a file
   create-template <schema>                   Create a template from a schema
   create-wallet                              Create new wallet (or show existing wallet)
@@ -79,16 +80,22 @@ Commands:
   encrypt-file <file> <did>                  Encrypt a file for a DID
   encrypt-msg <msg> <did>                    Encrypt a message for a DID
   fix-wallet                                 Remove invalid DIDs from the wallet
+  get-asset <did>                            Get asset by DID
+  get-credential <did>                       Get credential by DID
+  get-group <did>                            Get group by DID
+  get-schema <did>                           Get schema by DID
   group-add <group> <member>                 Add a member to a group
-  group-create <name>                        Create a new group
   group-remove <group> <member>              Remove a member from a group
   group-test <group> [member]                Determine if a member is in a group
   help [command]                             display help for command
   import-wallet <recovery-phrase>            Create new wallet from a recovery phrase
   issue-credential <file> [registry] [name]  Sign and encrypt a bound credential file
+  list-credentials                           List credentials by current ID
+  list-groups                                List groups owned by current ID
   list-ids                                   List IDs and show current ID
   list-issued                                List issued credentials
   list-names                                 Lists names of DIDs
+  list-schemas                               List schemas owned by current ID
   poll-create <file> [name]                  Create poll
   poll-publish <poll>                        Publish results to poll, hiding ballots
   poll-reveal <poll>                         Publish results to poll, revealing ballots

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Options:
 
 Commands:
   accept-credential <did> [name]             Save verifiable credential for current ID
+  add-group-member <group> <member>          Add a member to a group
   add-name <name> <did>                      Adds a name for a DID
   backup-id                                  Backup the current ID to its registry
   backup-wallet                              Backup wallet to encrypted DID and seed bank
@@ -70,23 +71,22 @@ Commands:
   create-challenge-cc <did> [name]           Create challenge from a credential DID
   create-group <name>                        Create a new group
   create-id <name> [registry]                Create a new decentralized ID
+  create-poll <file> [name]                  Create poll
+  create-poll-template                       Generate a poll template
   create-response <challenge>                Create a response to a challenge
   create-schema <file> [name]                Create schema DID from schema file
   create-schema <file> [name]                Create schema from a file
-  create-template <schema>                   Create a template from a schema
+  create-schema-template <schema>            Create a template from a schema
   create-wallet                              Create new wallet (or show existing wallet)
   decrypt-did <did>                          Decrypt an encrypted message DID
   decrypt-json <did>                         Decrypt an encrypted JSON DID
   encrypt-file <file> <did>                  Encrypt a file for a DID
-  encrypt-msg <msg> <did>                    Encrypt a message for a DID
+  encrypt-message <message> <did>            Encrypt a message for a DID
   fix-wallet                                 Remove invalid DIDs from the wallet
   get-asset <did>                            Get asset by DID
   get-credential <did>                       Get credential by DID
   get-group <did>                            Get group by DID
   get-schema <did>                           Get schema by DID
-  group-add <group> <member>                 Add a member to a group
-  group-remove <group> <member>              Remove a member from a group
-  group-test <group> [member]                Determine if a member is in a group
   help [command]                             display help for command
   import-wallet <recovery-phrase>            Create new wallet from a recovery phrase
   issue-credential <file> [registry] [name]  Sign and encrypt a bound credential file
@@ -96,32 +96,32 @@ Commands:
   list-issued                                List issued credentials
   list-names                                 Lists names of DIDs
   list-schemas                               List schemas owned by current ID
-  poll-create <file> [name]                  Create poll
-  poll-publish <poll>                        Publish results to poll, hiding ballots
-  poll-reveal <poll>                         Publish results to poll, revealing ballots
-  poll-template                              Generate a poll template
-  poll-unpublish <poll>                      Remove results from poll
-  poll-update <ballot>                       Add a ballot to the poll
-  poll-view <poll>                           View poll details
-  poll-vote <poll> <vote> [spoil]            Vote in a poll
   publish-credential <did>                   Publish the existence of a credential to the current user manifest
+  publish-poll <poll>                        Publish results to poll, hiding ballots
   recover-id <did>                           Recovers the ID from the DID
   recover-wallet [did]                       Recover wallet from seed bank or encrypted DID
+  remove-group-member <group> <member>       Remove a member from a group
   remove-id <name>                           Deletes named ID
   remove-name <name>                         Removes a name for a DID
   resolve-did <did> [confirm]                Return document associated with DID
   resolve-did-version <did> <version>        Return specified version of document associated with DID
   resolve-id                                 Resolves the current ID
   reveal-credential <did>                    Reveal a credential to the current user manifest
+  reveal-poll <poll>                         Publish results to poll, revealing ballots
   revoke-credential <did>                    Revokes a verifiable credential
-  rotate-keys                                Rotates keys for current user
+  rotate-keys                                Generates new set of keys for current ID
   show-mnemonic                              Show recovery phrase for wallet
   show-wallet                                Show wallet
   sign-file <file>                           Sign a JSON file
+  test-group <group> [member]                Determine if a member is in a group
   unpublish-credential <did>                 Remove a credential from the current user manifest
+  unpublish-poll <poll>                      Remove results from poll
+  update-poll <ballot>                       Add a ballot to the poll
   use-id <name>                              Set the current ID
   verify-file <file>                         Verify the signature in a JSON file
   verify-response <response>                 Decrypt and validate a response to a challenge
+  view-poll <poll>                           View poll details
+  vote-poll <poll> <vote> [spoil]            Vote in a poll
 ```
 
 ## admin-cli

--- a/doc/openapi.json
+++ b/doc/openapi.json
@@ -475,7 +475,7 @@
         }
       }
     },
-    "/ids/new": {
+    "/ids/": {
       "post": {
         "summary": "Create a new ID",
         "tags": [
@@ -1367,47 +1367,6 @@
         }
       }
     },
-    "/credentials/new": {
-      "post": {
-        "summary": "Create a credential",
-        "tags": [
-          "Credential"
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "schema": {
-                    "type": "object"
-                  },
-                  "options": {
-                    "type": "object"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        }
-      }
-    },
     "/credentials/bind": {
       "post": {
         "summary": "Bind a credential",
@@ -2120,7 +2079,7 @@
         }
       }
     },
-    "/poll/new": {
+    "/polls": {
       "post": {
         "summary": "Create a poll",
         "tags": [
@@ -2161,7 +2120,7 @@
         }
       }
     },
-    "/poll/{poll}/view": {
+    "/polls/{poll}/view": {
       "get": {
         "summary": "View a poll",
         "tags": [
@@ -2194,7 +2153,7 @@
         }
       }
     },
-    "/poll/vote": {
+    "/polls/vote": {
       "post": {
         "summary": "Vote in a poll",
         "tags": [
@@ -2238,7 +2197,7 @@
         }
       }
     },
-    "/poll/update": {
+    "/polls/update": {
       "put": {
         "summary": "Update a poll",
         "tags": [
@@ -2276,7 +2235,7 @@
         }
       }
     },
-    "/poll/{poll}/publish": {
+    "/polls/{poll}/publish": {
       "post": {
         "summary": "Publish a poll",
         "tags": [
@@ -2324,7 +2283,7 @@
         }
       }
     },
-    "/poll/{poll}/unpublish": {
+    "/polls/{poll}/unpublish": {
       "delete": {
         "summary": "Unpublish a poll",
         "tags": [
@@ -2357,7 +2316,7 @@
         }
       }
     },
-    "/schemas/{id}/template/new": {
+    "/schemas/{id}/template": {
       "post": {
         "summary": "Create a template",
         "tags": [
@@ -2405,7 +2364,7 @@
         }
       }
     },
-    "/schemas/new": {
+    "/schemas": {
       "post": {
         "summary": "Create new schema",
         "tags": [
@@ -2444,9 +2403,7 @@
             "description": "Internal server error"
           }
         }
-      }
-    },
-    "/schemas": {
+      },
       "get": {
         "summary": "List schemas",
         "tags": [

--- a/doc/openapi.json
+++ b/doc/openapi.json
@@ -56,11 +56,13 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "type": "object"
                 },
                 "examples": {
                   "example1": {
-                    "value": "ready"
+                    "value": {
+                      "ready": true
+                    }
                   }
                 }
               }
@@ -84,16 +86,23 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
+                  "type": "object",
+                  "properties": {
+                    "registries": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
                   }
                 },
-                "example": [
-                  "local",
-                  "hyperswarm",
-                  "TBTC"
-                ]
+                "example": {
+                  "registries": [
+                    "local",
+                    "hyperswarm",
+                    "TBTC"
+                  ]
+                }
               }
             }
           },
@@ -222,7 +231,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -286,7 +300,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -438,7 +457,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string"
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -461,10 +485,22 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ids": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
                   }
+                },
+                "example": {
+                  "ids": [
+                    "Alice",
+                    "Bob",
+                    "Carol"
+                  ]
                 }
               }
             }
@@ -473,9 +509,7 @@
             "description": "Internal server error"
           }
         }
-      }
-    },
-    "/ids/": {
+      },
       "post": {
         "summary": "Create a new ID",
         "tags": [
@@ -505,7 +539,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "did": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "did": "did:test:z3v8Auaha4rszsBwMyApaY9eUR1pipjGASYvqqfuXiXhxA8DXmo"
                 }
               }
             }
@@ -682,7 +724,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -715,7 +762,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -763,7 +815,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "recovered": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "recovered": "Bob"
                 }
               }
             }
@@ -786,9 +846,22 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "string"
+                  "type": "object",
+                  "properties": {
+                    "names": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "names": {
+                    "Alice": "did:test:z3v8AuajL3eA67e1kbHkRpwPAzBaoNxrWS2T3aM1Q7f96ScetCK",
+                    "Bob": "did:test:z3v8AuajNV8UTtdm2X7PzmXvVrNP5iQTX2ebjsHkcF1NS9BCV7v",
+                    "Carol": "did:test:z3v8AuaaZZqtVPZuHAqFkJhwKrcuAYaud8XA2MjrFYBth7ifELZ",
+                    "Dave": "did:test:z3v8AuaUd8ExyT4ZfvRdPXzUWrsZqLAE9a8aiYUL7Fya4ncrK4p"
                   }
                 }
               }
@@ -828,7 +901,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -978,7 +1056,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -1001,8 +1084,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "string",
-                  "example": "did:string"
+                  "type": "object",
+                  "properties": {
+                    "did": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "did": "did:test:z3v8Auaha4rszsBwMyApaY9eUR1pipjGASYvqqfuXiXhxA8DXmo"
                 }
               }
             }
@@ -1041,7 +1131,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "did": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "did": "did:test:z3v8Auaha4rszsBwMyApaY9eUR1pipjGASYvqqfuXiXhxA8DXmo"
                 }
               }
             }
@@ -1082,7 +1180,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "did": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "did": "did:test:z3v8Auaha4rszsBwMyApaY9eUR1pipjGASYvqqfuXiXhxA8DXmo"
                 }
               }
             }
@@ -1164,7 +1270,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "did": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "did": "did:test:z3v8Auaha4rszsBwMyApaY9eUR1pipjGASYvqqfuXiXhxA8DXmo"
                 }
               }
             }
@@ -1260,7 +1374,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -1308,7 +1427,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -1356,7 +1480,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "boolean"
+                  "type": "object",
+                  "properties": {
+                    "test": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "example": {
+                  "test": true
                 }
               }
             }
@@ -1423,10 +1555,22 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "held": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
                   }
+                },
+                "example": {
+                  "held": [
+                    "did:test:z3v8Auaha4rszsBwMyApaY9eUR1pipjGASYvqqfuXiXhxA8DXmo",
+                    "did:test:z3v8AuajL3eA67e1kbHkRpwPAzBaoNxrWS2T3aM1Q7f96ScetCK",
+                    "did:test:z3v8AuahRF4UhG5pvktQmnafoKa92pH5QUHZFuBp5qPcwj1jdqV"
+                  ]
                 }
               }
             }
@@ -1462,7 +1606,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -1526,7 +1675,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -1560,8 +1714,13 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "reveal": {
-                    "type": "boolean"
+                  "options": {
+                    "type": "object",
+                    "properties": {
+                      "reveal": {
+                        "type": "boolean"
+                      }
+                    }
                   }
                 }
               }
@@ -1574,7 +1733,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -1607,7 +1771,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -1630,10 +1799,22 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "issued": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
                   }
+                },
+                "example": {
+                  "issued": [
+                    "did:test:z3v8Auaha4rszsBwMyApaY9eUR1pipjGASYvqqfuXiXhxA8DXmo",
+                    "did:test:z3v8AuajL3eA67e1kbHkRpwPAzBaoNxrWS2T3aM1Q7f96ScetCK",
+                    "did:test:z3v8AuahRF4UhG5pvktQmnafoKa92pH5QUHZFuBp5qPcwj1jdqV"
+                  ]
                 }
               }
             }
@@ -1672,7 +1853,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "did": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "did": "did:test:z3v8Auaha4rszsBwMyApaY9eUR1pipjGASYvqqfuXiXhxA8DXmo"
                 }
               }
             }
@@ -1736,7 +1925,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -1767,7 +1961,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -1790,7 +1989,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -1834,7 +2038,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "did": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "did": "did:test:z3v8Auaha4rszsBwMyApaY9eUR1pipjGASYvqqfuXiXhxA8DXmo"
                 }
               }
             }
@@ -1872,7 +2084,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "string"
                 }
               }
             }
@@ -1916,7 +2128,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "did": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "did": "did:test:z3v8Auaha4rszsBwMyApaY9eUR1pipjGASYvqqfuXiXhxA8DXmo"
                 }
               }
             }
@@ -2041,7 +2261,7 @@
         }
       }
     },
-    "/asset/create": {
+    "/assets/": {
       "post": {
         "summary": "Create an asset",
         "tags": [
@@ -2068,7 +2288,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "did": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "did": "did:test:z3v8Auaha4rszsBwMyApaY9eUR1pipjGASYvqqfuXiXhxA8DXmo"
                 }
               }
             }
@@ -2109,7 +2337,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "did": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "did": "did:test:z3v8Auaha4rszsBwMyApaY9eUR1pipjGASYvqqfuXiXhxA8DXmo"
                 }
               }
             }
@@ -2186,7 +2422,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "did": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "did": "did:test:z3v8Auaha4rszsBwMyApaY9eUR1pipjGASYvqqfuXiXhxA8DXmo"
                 }
               }
             }
@@ -2224,7 +2468,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -2272,7 +2521,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -2305,7 +2559,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -2353,7 +2612,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "did": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "did": "did:test:z3v8Auaha4rszsBwMyApaY9eUR1pipjGASYvqqfuXiXhxA8DXmo"
                 }
               }
             }
@@ -2394,7 +2661,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "did": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "example": {
+                  "did": "did:test:z3v8Auaha4rszsBwMyApaY9eUR1pipjGASYvqqfuXiXhxA8DXmo"
                 }
               }
             }
@@ -2415,7 +2690,22 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "schemas": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                },
+                "example": {
+                  "schemas": [
+                    "did:test:z3v8Auaha4rszsBwMyApaY9eUR1pipjGASYvqqfuXiXhxA8DXmo",
+                    "did:test:z3v8AuajL3eA67e1kbHkRpwPAzBaoNxrWS2T3aM1Q7f96ScetCK",
+                    "did:test:z3v8AuahRF4UhG5pvktQmnafoKa92pH5QUHZFuBp5qPcwj1jdqV"
+                  ]
                 }
               }
             }
@@ -2479,7 +2769,12 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             }
@@ -2527,7 +2822,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object"
+                  "type": "object",
+                  "properties": {
+                    "test": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "example": {
+                  "test": true
                 }
               }
             }

--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -531,7 +531,7 @@ export async function createAsset(data, options = {}) {
     const did = await gatekeeper.createDID(signed);
 
     // Keep assets that will be garbage-collected out of the owned list
-    if (registry !== 'hyperswarm') {
+    if (!validUntil) {
         await addToOwned(did);
     }
 
@@ -1561,6 +1561,28 @@ export const defaultSchema = {
     ]
 };
 
+export async function listGroups(owner) {
+    const id = await fetchIdInfo(owner);
+    const schemas = [];
+
+    if (id.owned) {
+        for (const did of id.owned) {
+            try {
+                const isGroup = await groupTest(did);
+
+                if (isGroup) {
+                    schemas.push(did);
+                }
+            }
+            catch (error) {
+                continue;
+            }
+        }
+    }
+
+    return schemas;
+}
+
 function validateSchema(schema) {
     try {
         if (!Object.keys(schema).includes('$schema')) {
@@ -1611,6 +1633,28 @@ export async function testSchema(id) {
     }
 
     return validateSchema(schema);
+}
+
+export async function listSchemas(owner) {
+    const id = await fetchIdInfo(owner);
+    const schemas = [];
+
+    if (id.owned) {
+        for (const did of id.owned) {
+            try {
+                const isSchema = await testSchema(did);
+
+                if (isSchema) {
+                    schemas.push(did);
+                }
+            }
+            catch (error) {
+                continue;
+            }
+        }
+    }
+
+    return schemas;
 }
 
 export async function createTemplate(id) {

--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -898,7 +898,7 @@ export async function recoverId(did) {
 
         await saveWallet(wallet);
 
-        return `Recovered ${data.name}!`;
+        return wallet.current;
     }
     catch {
         throw new Error(exceptions.INVALID_PARAMETER);
@@ -959,9 +959,7 @@ export async function addName(name, did) {
     }
 
     wallet.names[name] = did;
-    await saveWallet(wallet);
-
-    return true;
+    return saveWallet(wallet);
 }
 
 export async function removeName(name) {
@@ -1465,7 +1463,7 @@ export async function groupAdd(groupId, memberId) {
         throw new Error(exceptions.UPDATE_FAILED);
     }
 
-    return data;
+    return ok;
 }
 
 export async function groupRemove(groupId, memberId) {
@@ -1921,7 +1919,7 @@ export async function updatePoll(ballot) {
         received: new Date().toISOString(),
     };
 
-    return await updateDID(didPoll, docPoll);
+    return updateDID(didPoll, docPoll);
 }
 
 export async function publishPoll(poll, options = {}) {
@@ -1947,7 +1945,7 @@ export async function publishPoll(poll, options = {}) {
 
     doc.didDocumentData.results = view.results;
 
-    return await updateDID(didPoll, doc);
+    return updateDID(didPoll, doc);
 }
 
 export async function unpublishPoll(poll) {

--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -1408,7 +1408,7 @@ export async function createGroup(name, options = {}) {
 }
 
 export async function getGroup(id) {
-    const isGroup = await groupTest(id);
+    const isGroup = await testGroup(id);
 
     if (!isGroup) {
         throw new Error(exceptions.INVALID_PARAMETER);
@@ -1417,7 +1417,7 @@ export async function getGroup(id) {
     return resolveAsset(id);
 }
 
-export async function groupAdd(groupId, memberId) {
+export async function addGroupMember(groupId, memberId) {
     const groupDID = await lookupDID(groupId);
     const doc = await resolveDID(groupDID);
     const data = doc.didDocumentData;
@@ -1447,7 +1447,7 @@ export async function groupAdd(groupId, memberId) {
     }
 
     // Can't add a mutual membership relation
-    const isMember = await groupTest(memberId, groupId);
+    const isMember = await testGroup(memberId, groupId);
 
     if (isMember) {
         throw new Error(exceptions.INVALID_PARAMETER);
@@ -1466,7 +1466,7 @@ export async function groupAdd(groupId, memberId) {
     return ok;
 }
 
-export async function groupRemove(groupId, memberId) {
+export async function removeGroupMember(groupId, memberId) {
     const groupDID = await lookupDID(groupId);
     const doc = await resolveDID(groupDID);
     const data = doc.didDocumentData;
@@ -1503,7 +1503,7 @@ export async function groupRemove(groupId, memberId) {
     return data;
 }
 
-export async function groupTest(group, member) {
+export async function testGroup(group, member) {
     const didGroup = await lookupDID(group);
 
     if (!didGroup) {
@@ -1535,7 +1535,7 @@ export async function groupTest(group, member) {
 
     if (!isMember) {
         for (const did of data.members) {
-            isMember = await groupTest(did, didMember);
+            isMember = await testGroup(did, didMember);
 
             if (isMember) {
                 break;
@@ -1566,7 +1566,7 @@ export async function listGroups(owner) {
     if (id.owned) {
         for (const did of id.owned) {
             try {
-                const isGroup = await groupTest(did);
+                const isGroup = await testGroup(did);
 
                 if (isGroup) {
                     schemas.push(did);
@@ -1710,7 +1710,7 @@ export async function createPoll(poll, options = {}) {
     }
 
     try {
-        const isValidGroup = await groupTest(poll.roster);
+        const isValidGroup = await testGroup(poll.roster);
 
         if (!isValidGroup) {
             throw new Error(exceptions.INVALID_PARAMETER);
@@ -1754,7 +1754,7 @@ export async function viewPoll(poll) {
     }
 
     const voteExpired = Date(data.deadline) > new Date();
-    const isEligible = await groupTest(data.roster, id.did);
+    const isEligible = await testGroup(data.roster, id.did);
 
     const view = {
         description: data.description,
@@ -1824,7 +1824,7 @@ export async function votePoll(poll, vote, options = {}) {
     const didPoll = await lookupDID(poll);
     const doc = await resolveDID(didPoll);
     const data = doc.didDocumentData;
-    const eligible = await groupTest(data.roster, id.did);
+    const eligible = await testGroup(data.roster, id.did);
     const expired = (Date(data.deadline) > new Date());
     const owner = doc.didDocument.controller;
 
@@ -1891,7 +1891,7 @@ export async function updatePoll(ballot) {
         throw new Error(exceptions.INVALID_PARAMETER);
     }
 
-    const eligible = await groupTest(dataPoll.roster, didVoter);
+    const eligible = await testGroup(dataPoll.roster, didVoter);
 
     if (!eligible) {
         throw new Error(exceptions.INVALID_PARAMETER);

--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -700,7 +700,7 @@ export async function revokeDID(did) {
     return ok;
 }
 
-async function addToOwned(did) {
+export async function addToOwned(did) {
     const wallet = await loadWallet();
     const id = wallet.ids[wallet.current];
     const owned = new Set(id.owned);
@@ -711,7 +711,7 @@ async function addToOwned(did) {
     return saveWallet(wallet);
 }
 
-async function removeFromOwned(did, owner) {
+export async function removeFromOwned(did, owner) {
     const wallet = await loadWallet();
     const id = await fetchIdInfo(owner);
 

--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -711,7 +711,7 @@ export async function addToOwned(did) {
     return saveWallet(wallet);
 }
 
-export async function removeFromOwned(did, owner) {
+async function removeFromOwned(did, owner) {
     const wallet = await loadWallet();
     const id = await fetchIdInfo(owner);
 
@@ -720,7 +720,7 @@ export async function removeFromOwned(did, owner) {
     return saveWallet(wallet);
 }
 
-async function addToHeld(did) {
+export async function addToHeld(did) {
     const wallet = await loadWallet();
     const id = wallet.ids[wallet.current];
     const held = new Set(id.held);

--- a/packages/keymaster/src/keymaster-sdk.js
+++ b/packages/keymaster/src/keymaster-sdk.js
@@ -250,7 +250,7 @@ export async function resolveId(id) {
 
 export async function createId(name, options) {
     try {
-        const response = await axios.post(`${URL}/api/v1/ids/new`, { name, options });
+        const response = await axios.post(`${URL}/api/v1/ids`, { name, options });
         return response.data;
     }
     catch (error) {

--- a/packages/keymaster/src/keymaster-sdk.js
+++ b/packages/keymaster/src/keymaster-sdk.js
@@ -418,6 +418,19 @@ export async function groupTest(group, member) {
     }
 }
 
+export async function listGroups(owner) {
+    try {
+        if (!owner) {
+            owner = '';
+        }
+        const response = await axios.get(`${URL}/api/v1/groups?owner=${owner}`);
+        return response.data;
+    }
+    catch (error) {
+        throwError(error);
+    }
+}
+
 export async function createSchema(schema, options) {
     try {
         const response = await axios.post(`${URL}/api/v1/schemas`, { schema, options });
@@ -451,6 +464,20 @@ export async function setSchema(id, schema) {
 export async function testSchema(id) {
     try {
         const response = await axios.post(`${URL}/api/v1/schemas/${id}/test`);
+        return response.data;
+    }
+    catch (error) {
+        throwError(error);
+    }
+}
+
+export async function listSchemas(owner) {
+    try {
+        if (!owner) {
+            owner = '';
+        }
+
+        const response = await axios.get(`${URL}/api/v1/schemas?owner=${owner}`);
         return response.data;
     }
     catch (error) {

--- a/packages/keymaster/src/keymaster-sdk.js
+++ b/packages/keymaster/src/keymaster-sdk.js
@@ -388,7 +388,7 @@ export async function getGroup(group) {
     }
 }
 
-export async function groupAdd(group, member) {
+export async function addGroupMember(group, member) {
     try {
         const response = await axios.post(`${URL}/api/v1/groups/${group}/add`, { member });
         return response.data.ok;
@@ -398,7 +398,7 @@ export async function groupAdd(group, member) {
     }
 }
 
-export async function groupRemove(group, member) {
+export async function removeGroupMember(group, member) {
     try {
         const response = await axios.post(`${URL}/api/v1/groups/${group}/remove`, { member });
         return response.data.ok;
@@ -408,7 +408,7 @@ export async function groupRemove(group, member) {
     }
 }
 
-export async function groupTest(group, member) {
+export async function testGroup(group, member) {
     try {
         const response = await axios.post(`${URL}/api/v1/groups/${group}/test`, { member });
         return response.data.test;

--- a/packages/keymaster/src/keymaster-sdk.js
+++ b/packages/keymaster/src/keymaster-sdk.js
@@ -71,7 +71,7 @@ export async function stop() {
 export async function isReady() {
     try {
         const response = await axios.get(`${URL}/api/v1/ready`);
-        return response.data;
+        return response.data.ready;
     }
     catch (error) {
         return false;
@@ -81,7 +81,7 @@ export async function isReady() {
 export async function loadWallet() {
     try {
         const response = await axios.get(`${URL}/api/v1/wallet`);
-        return response.data;
+        return response.data.wallet;
     }
     catch (error) {
         throwError(error);
@@ -91,7 +91,7 @@ export async function loadWallet() {
 export async function saveWallet(wallet) {
     try {
         const response = await axios.put(`${URL}/api/v1/wallet`, { wallet });
-        return response.data;
+        return response.data.ok;
     }
     catch (error) {
         throwError(error);
@@ -101,7 +101,7 @@ export async function saveWallet(wallet) {
 export async function newWallet(mnemonic, overwrite = false) {
     try {
         const response = await axios.post(`${URL}/api/v1/wallet/new`, { mnemonic, overwrite });
-        return response.data;
+        return response.data.wallet;
     }
     catch (error) {
         throwError(error);
@@ -111,7 +111,7 @@ export async function newWallet(mnemonic, overwrite = false) {
 export async function backupWallet() {
     try {
         const response = await axios.post(`${URL}/api/v1/wallet/backup`);
-        return response.data;
+        return response.data.ok;
     }
     catch (error) {
         throwError(error);
@@ -121,7 +121,7 @@ export async function backupWallet() {
 export async function recoverWallet() {
     try {
         const response = await axios.post(`${URL}/api/v1/wallet/recover`);
-        return response.data;
+        return response.data.wallet;
     }
     catch (error) {
         throwError(error);
@@ -131,7 +131,7 @@ export async function recoverWallet() {
 export async function checkWallet() {
     try {
         const response = await axios.post(`${URL}/api/v1/wallet/check`);
-        return response.data;
+        return response.data.check;
     }
     catch (error) {
         throwError(error);
@@ -141,7 +141,7 @@ export async function checkWallet() {
 export async function fixWallet() {
     try {
         const response = await axios.post(`${URL}/api/v1/wallet/fix`);
-        return response.data;
+        return response.data.fix;
     }
     catch (error) {
         throwError(error);
@@ -151,7 +151,7 @@ export async function fixWallet() {
 export async function decryptMnemonic() {
     try {
         const response = await axios.get(`${URL}/api/v1/wallet/mnemonic`);
-        return response.data;
+        return response.data.mnemonic;
     }
     catch (error) {
         throwError(error);
@@ -161,7 +161,7 @@ export async function decryptMnemonic() {
 export async function listRegistries() {
     try {
         const response = await axios.get(`${URL}/api/v1/registries`);
-        return response.data;
+        return response.data.registries;
     }
     catch (error) {
         throwError(error);
@@ -171,7 +171,7 @@ export async function listRegistries() {
 export async function getCurrentId() {
     try {
         const response = await axios.get(`${URL}/api/v1/ids/current`);
-        return response.data;
+        return response.data.current;
     }
     catch (error) {
         throwError(error);
@@ -181,7 +181,7 @@ export async function getCurrentId() {
 export async function setCurrentId(name) {
     try {
         const response = await axios.put(`${URL}/api/v1/ids/current`, { name });
-        return response.data;
+        return response.data.ok;
     }
     catch (error) {
         throwError(error);
@@ -191,7 +191,7 @@ export async function setCurrentId(name) {
 export async function listIds() {
     try {
         const response = await axios.get(`${URL}/api/v1/ids`);
-        return response.data;
+        return response.data.ids;
     }
     catch (error) {
         throwError(error);
@@ -201,7 +201,7 @@ export async function listIds() {
 export async function encryptMessage(msg, receiver, options = {}) {
     try {
         const response = await axios.post(`${URL}/api/v1/keys/encrypt/message`, { msg, receiver, options });
-        return response.data;
+        return response.data.did;
     }
     catch (error) {
         throwError(error);
@@ -211,7 +211,7 @@ export async function encryptMessage(msg, receiver, options = {}) {
 export async function decryptMessage(did) {
     try {
         const response = await axios.post(`${URL}/api/v1/keys/decrypt/message`, { did });
-        return response.data;
+        return response.data.message;
     }
     catch (error) {
         throwError(error);
@@ -221,7 +221,7 @@ export async function decryptMessage(did) {
 export async function encryptJSON(json, receiver, options = {}) {
     try {
         const response = await axios.post(`${URL}/api/v1/keys/encrypt/json`, { json, receiver, options });
-        return response.data;
+        return response.data.did;
     }
     catch (error) {
         throwError(error);
@@ -231,7 +231,7 @@ export async function encryptJSON(json, receiver, options = {}) {
 export async function decryptJSON(did) {
     try {
         const response = await axios.post(`${URL}/api/v1/keys/decrypt/json`, { did });
-        return response.data;
+        return response.data.json;
     }
     catch (error) {
         throwError(error);
@@ -241,7 +241,7 @@ export async function decryptJSON(did) {
 export async function resolveId(id) {
     try {
         const response = await axios.get(`${URL}/api/v1/ids/${id}`);
-        return response.data;
+        return response.data.docs;
     }
     catch (error) {
         throwError(error);
@@ -251,7 +251,7 @@ export async function resolveId(id) {
 export async function createId(name, options) {
     try {
         const response = await axios.post(`${URL}/api/v1/ids`, { name, options });
-        return response.data;
+        return response.data.did;
     }
     catch (error) {
         throwError(error);
@@ -261,7 +261,7 @@ export async function createId(name, options) {
 export async function removeId(id) {
     try {
         const response = await axios.delete(`${URL}/api/v1/ids/${id}`);
-        return response.data;
+        return response.data.ok;
     }
     catch (error) {
         throwError(error);
@@ -271,7 +271,7 @@ export async function removeId(id) {
 export async function backupId(id) {
     try {
         const response = await axios.post(`${URL}/api/v1/ids/${id}/backup`);
-        return response.data;
+        return response.data.ok;
     }
     catch (error) {
         throwError(error);
@@ -281,7 +281,7 @@ export async function backupId(id) {
 export async function recoverId(did) {
     try {
         const response = await axios.post(`${URL}/api/v1/ids/${did}/recover`);
-        return response.data;
+        return response.data.recovered;
     }
     catch (error) {
         throwError(error);
@@ -291,7 +291,7 @@ export async function recoverId(did) {
 export async function listNames() {
     try {
         const response = await axios.get(`${URL}/api/v1/names`);
-        return response.data;
+        return response.data.names;
     }
     catch (error) {
         throwError(error);
@@ -301,7 +301,7 @@ export async function listNames() {
 export async function addName(name, did) {
     try {
         const response = await axios.post(`${URL}/api/v1/names`, { name, did });
-        return response.data;
+        return response.data.ok;
     }
     catch (error) {
         throwError(error);
@@ -311,7 +311,7 @@ export async function addName(name, did) {
 export async function removeName(name) {
     try {
         const response = await axios.delete(`${URL}/api/v1/names/${name}`);
-        return response.data;
+        return response.data.ok;
     }
     catch (error) {
         throwError(error);
@@ -321,7 +321,7 @@ export async function removeName(name) {
 export async function resolveDID(name) {
     try {
         const response = await axios.get(`${URL}/api/v1/names/${name}`);
-        return response.data;
+        return response.data.docs;
     }
     catch (error) {
         throwError(error);
@@ -331,7 +331,7 @@ export async function resolveDID(name) {
 export async function resolveAsset(name) {
     try {
         const response = await axios.get(`${URL}/api/v1/assets/${name}`);
-        return response.data;
+        return response.data.asset;
     }
     catch (error) {
         throwError(error);
@@ -341,7 +341,7 @@ export async function resolveAsset(name) {
 export async function createChallenge(challengeSpec, options) {
     try {
         const response = await axios.post(`${URL}/api/v1/challenge`, { challenge: challengeSpec, options });
-        return response.data;
+        return response.data.did;
     }
     catch (error) {
         throwError(error);
@@ -351,7 +351,7 @@ export async function createChallenge(challengeSpec, options) {
 export async function createResponse(challengeDID, options) {
     try {
         const response = await axios.post(`${URL}/api/v1/response`, { challenge: challengeDID, options });
-        return response.data;
+        return response.data.did;
     }
     catch (error) {
         throwError(error);
@@ -361,7 +361,7 @@ export async function createResponse(challengeDID, options) {
 export async function verifyResponse(responseDID, options) {
     try {
         const response = await axios.post(`${URL}/api/v1/response/verify`, { response: responseDID, options });
-        return response.data;
+        return response.data.verify;
     }
     catch (error) {
         throwError(error);
@@ -371,7 +371,7 @@ export async function verifyResponse(responseDID, options) {
 export async function createGroup(name, options) {
     try {
         const response = await axios.post(`${URL}/api/v1/groups`, { name, options });
-        return response.data;
+        return response.data.did;
     }
     catch (error) {
         throwError(error);
@@ -381,7 +381,7 @@ export async function createGroup(name, options) {
 export async function getGroup(group) {
     try {
         const response = await axios.get(`${URL}/api/v1/groups/${group}`);
-        return response.data;
+        return response.data.group;
     }
     catch (error) {
         throwError(error);
@@ -391,7 +391,7 @@ export async function getGroup(group) {
 export async function groupAdd(group, member) {
     try {
         const response = await axios.post(`${URL}/api/v1/groups/${group}/add`, { member });
-        return response.data;
+        return response.data.ok;
     }
     catch (error) {
         throwError(error);
@@ -401,7 +401,7 @@ export async function groupAdd(group, member) {
 export async function groupRemove(group, member) {
     try {
         const response = await axios.post(`${URL}/api/v1/groups/${group}/remove`, { member });
-        return response.data;
+        return response.data.ok;
     }
     catch (error) {
         throwError(error);
@@ -411,7 +411,7 @@ export async function groupRemove(group, member) {
 export async function groupTest(group, member) {
     try {
         const response = await axios.post(`${URL}/api/v1/groups/${group}/test`, { member });
-        return response.data;
+        return response.data.test;
     }
     catch (error) {
         throwError(error);
@@ -424,7 +424,7 @@ export async function listGroups(owner) {
             owner = '';
         }
         const response = await axios.get(`${URL}/api/v1/groups?owner=${owner}`);
-        return response.data;
+        return response.data.groups;
     }
     catch (error) {
         throwError(error);
@@ -434,7 +434,7 @@ export async function listGroups(owner) {
 export async function createSchema(schema, options) {
     try {
         const response = await axios.post(`${URL}/api/v1/schemas`, { schema, options });
-        return response.data;
+        return response.data.did;
     }
     catch (error) {
         throwError(error);
@@ -444,7 +444,7 @@ export async function createSchema(schema, options) {
 export async function getSchema(id) {
     try {
         const response = await axios.get(`${URL}/api/v1/schemas/${id}`);
-        return response.data;
+        return response.data.schema;
     }
     catch (error) {
         throwError(error);
@@ -454,7 +454,7 @@ export async function getSchema(id) {
 export async function setSchema(id, schema) {
     try {
         const response = await axios.put(`${URL}/api/v1/schemas/${id}`, { schema });
-        return response.data;
+        return response.data.ok;
     }
     catch (error) {
         throwError(error);
@@ -464,7 +464,7 @@ export async function setSchema(id, schema) {
 export async function testSchema(id) {
     try {
         const response = await axios.post(`${URL}/api/v1/schemas/${id}/test`);
-        return response.data;
+        return response.data.test;
     }
     catch (error) {
         throwError(error);
@@ -478,7 +478,7 @@ export async function listSchemas(owner) {
         }
 
         const response = await axios.get(`${URL}/api/v1/schemas?owner=${owner}`);
-        return response.data;
+        return response.data.schemas;
     }
     catch (error) {
         throwError(error);
@@ -488,7 +488,7 @@ export async function listSchemas(owner) {
 export async function testAgent(id) {
     try {
         const response = await axios.post(`${URL}/api/v1/agents/${id}/test`);
-        return response.data;
+        return response.data.test;
     }
     catch (error) {
         throwError(error);
@@ -498,7 +498,7 @@ export async function testAgent(id) {
 export async function bindCredential(schema, subject, options) {
     try {
         const response = await axios.post(`${URL}/api/v1/credentials/bind`, { schema, subject, options });
-        return response.data;
+        return response.data.credential;
     }
     catch (error) {
         throwError(error);
@@ -508,7 +508,7 @@ export async function bindCredential(schema, subject, options) {
 export async function issueCredential(credential, options) {
     try {
         const response = await axios.post(`${URL}/api/v1/credentials/issued`, { credential, options });
-        return response.data;
+        return response.data.did;
     }
     catch (error) {
         throwError(error);
@@ -518,7 +518,7 @@ export async function issueCredential(credential, options) {
 export async function updateCredential(did, credential) {
     try {
         const response = await axios.post(`${URL}/api/v1/credentials/issued/${did}`, { credential });
-        return response.data;
+        return response.data.ok;
     }
     catch (error) {
         throwError(error);
@@ -528,7 +528,7 @@ export async function updateCredential(did, credential) {
 export async function listCredentials() {
     try {
         const response = await axios.get(`${URL}/api/v1/credentials/held`);
-        return response.data;
+        return response.data.held;
     }
     catch (error) {
         throwError(error);
@@ -538,7 +538,7 @@ export async function listCredentials() {
 export async function acceptCredential(did) {
     try {
         const response = await axios.post(`${URL}/api/v1/credentials/held/`, { did });
-        return response.data;
+        return response.data.ok;
     }
     catch (error) {
         throwError(error);
@@ -548,7 +548,7 @@ export async function acceptCredential(did) {
 export async function getCredential(did) {
     try {
         const response = await axios.get(`${URL}/api/v1/credentials/held/${did}`);
-        return response.data;
+        return response.data.credential;
     }
     catch (error) {
         throwError(error);
@@ -558,7 +558,7 @@ export async function getCredential(did) {
 export async function removeCredential(did) {
     try {
         const response = await axios.delete(`${URL}/api/v1/credentials/held/${did}`);
-        return response.data;
+        return response.data.ok;
     }
     catch (error) {
         throwError(error);
@@ -568,7 +568,7 @@ export async function removeCredential(did) {
 export async function publishCredential(did, options) {
     try {
         const response = await axios.post(`${URL}/api/v1/credentials/held/${did}/publish`, { options });
-        return response.data;
+        return response.data.ok;
     }
     catch (error) {
         throwError(error);
@@ -578,7 +578,7 @@ export async function publishCredential(did, options) {
 export async function unpublishCredential(did) {
     try {
         const response = await axios.post(`${URL}/api/v1/credentials/held/${did}/unpublish`);
-        return response.data;
+        return response.data.ok;
     }
     catch (error) {
         throwError(error);
@@ -588,7 +588,7 @@ export async function unpublishCredential(did) {
 export async function listIssued() {
     try {
         const response = await axios.get(`${URL}/api/v1/credentials/issued`);
-        return response.data;
+        return response.data.issued;
     }
     catch (error) {
         throwError(error);
@@ -598,7 +598,7 @@ export async function listIssued() {
 export async function revokeCredential(did) {
     try {
         const response = await axios.delete(`${URL}/api/v1/credentials/issued/${did}`);
-        return response.data;
+        return response.data.ok;
     }
     catch (error) {
         throwError(error);

--- a/scripts/keychain-cli.js
+++ b/scripts/keychain-cli.js
@@ -951,10 +951,7 @@ async function run() {
         keymaster = keymaster_lib;
         await gatekeeper_sdk.start({
             url: gatekeeperURL,
-            waitUntilReady: true,
-            intervalSeconds: 1,
-            chatty: false,
-            becomeChattyAfter: 5
+            waitUntilReady: false,
         });
         await keymaster.start({
             gatekeeper: gatekeeper_sdk,

--- a/scripts/keychain-cli.js
+++ b/scripts/keychain-cli.js
@@ -241,7 +241,7 @@ program
 
 program
     .command('rotate-keys')
-    .description('Rotates keys for current user')
+    .description('Generates new set of keys for current ID')
     .action(async () => {
         try {
             const doc = await keymaster.rotateKeys();
@@ -279,7 +279,7 @@ program
     });
 
 program
-    .command('encrypt-msg <msg> <did>')
+    .command('encrypt-message <message> <did>')
     .description('Encrypt a message for a DID')
     .action(async (msg, did) => {
         try {
@@ -681,11 +681,11 @@ program
     });
 
 program
-    .command('group-add <group> <member>')
+    .command('add-group-member <group> <member>')
     .description('Add a member to a group')
     .action(async (group, member) => {
         try {
-            const response = await keymaster.groupAdd(group, member);
+            const response = await keymaster.addGroupMember(group, member);
             console.log(response);
         }
         catch (error) {
@@ -694,11 +694,11 @@ program
     });
 
 program
-    .command('group-remove <group> <member>')
+    .command('remove-group-member <group> <member>')
     .description('Remove a member from a group')
     .action(async (group, member) => {
         try {
-            const response = await keymaster.groupRemove(group, member);
+            const response = await keymaster.removeGroupMember(group, member);
             console.log(response);
         }
         catch (error) {
@@ -707,11 +707,11 @@ program
     });
 
 program
-    .command('group-test <group> [member]')
+    .command('test-group <group> [member]')
     .description('Determine if a member is in a group')
     .action(async (group, member) => {
         try {
-            const response = await keymaster.groupTest(group, member);
+            const response = await keymaster.testGroup(group, member);
             console.log(response);
         }
         catch (error) {
@@ -766,7 +766,7 @@ program
     });
 
 program
-    .command('create-template <schema>')
+    .command('create-schema-template <schema>')
     .description('Create a template from a schema')
     .action(async (schema) => {
         try {
@@ -806,7 +806,7 @@ program
     });
 
 program
-    .command('poll-template')
+    .command('create-poll-template')
     .description('Generate a poll template')
     .action(async () => {
         try {
@@ -819,7 +819,7 @@ program
     });
 
 program
-    .command('poll-create <file> [name]')
+    .command('create-poll <file> [name]')
     .description('Create poll')
     .action(async (file, name) => {
         try {
@@ -838,7 +838,7 @@ program
     });
 
 program
-    .command('poll-view <poll>')
+    .command('view-poll <poll>')
     .description('View poll details')
     .action(async (poll) => {
         try {
@@ -851,7 +851,7 @@ program
     });
 
 program
-    .command('poll-vote <poll> <vote> [spoil]')
+    .command('vote-poll <poll> <vote> [spoil]')
     .description('Vote in a poll')
     .action(async (poll, vote, spoil) => {
         try {
@@ -864,7 +864,7 @@ program
     });
 
 program
-    .command('poll-update <ballot>')
+    .command('update-poll <ballot>')
     .description('Add a ballot to the poll')
     .action(async (ballot) => {
         try {
@@ -882,7 +882,7 @@ program
     });
 
 program
-    .command('poll-publish <poll>')
+    .command('publish-poll <poll>')
     .description('Publish results to poll, hiding ballots')
     .action(async (poll) => {
         try {
@@ -900,7 +900,7 @@ program
     });
 
 program
-    .command('poll-reveal <poll>')
+    .command('reveal-poll <poll>')
     .description('Publish results to poll, revealing ballots')
     .action(async (poll) => {
         try {
@@ -918,7 +918,7 @@ program
     });
 
 program
-    .command('poll-unpublish <poll>')
+    .command('unpublish-poll <poll>')
     .description('Remove results from poll')
     .action(async (poll) => {
         try {

--- a/scripts/keychain-cli.js
+++ b/scripts/keychain-cli.js
@@ -509,7 +509,7 @@ program
     .description('Publish the existence of a credential to the current user manifest')
     .action(async (did) => {
         try {
-            const response = await keymaster.publishCredential(did, false);
+            const response = await keymaster.publishCredential(did, { reveal: false });
             console.log(JSON.stringify(response, null, 4));
         }
         catch (error) {
@@ -522,7 +522,7 @@ program
     .description('Reveal a credential to the current user manifest')
     .action(async (did) => {
         try {
-            const response = await keymaster.publishCredential(did, true);
+            const response = await keymaster.publishCredential(did, { reveal: true });
             console.log(JSON.stringify(response, null, 4));
         }
         catch (error) {

--- a/scripts/keychain-cli.js
+++ b/scripts/keychain-cli.js
@@ -505,6 +505,32 @@ program
     });
 
 program
+    .command('list-credentials')
+    .description('List credentials by current ID')
+    .action(async () => {
+        try {
+            const held = await keymaster.listCredentials();
+            console.log(JSON.stringify(held, null, 4));
+        }
+        catch (error) {
+            console.error(error.message);
+        }
+    });
+
+program
+    .command('get-credential <did>')
+    .description('Get credential by DID')
+    .action(async (did) => {
+        try {
+            const credential = await keymaster.getCredential(did);
+            console.log(JSON.stringify(credential, null, 4));
+        }
+        catch (error) {
+            console.error(error.message);
+        }
+    });
+
+program
     .command('publish-credential <did>')
     .description('Publish the existence of a credential to the current user manifest')
     .action(async (did) => {
@@ -615,13 +641,39 @@ program
     });
 
 program
-    .command('group-create <name>')
+    .command('create-group <name>')
     .description('Create a new group')
     .action(async (name) => {
         try {
             const did = await keymaster.createGroup(name);
             console.log(did);
             keymaster.addName(name, did);
+        }
+        catch (error) {
+            console.error(error.message);
+        }
+    });
+
+program
+    .command('list-groups')
+    .description('List groups owned by current ID')
+    .action(async () => {
+        try {
+            const groups = await keymaster.listGroups();
+            console.log(JSON.stringify(groups, null, 4));
+        }
+        catch (error) {
+            console.error(error.message);
+        }
+    });
+
+program
+    .command('get-group <did>')
+    .description('Get group by DID')
+    .action(async (did) => {
+        try {
+            const group = await keymaster.getGroup(did);
+            console.log(JSON.stringify(group, null, 4));
         }
         catch (error) {
             console.error(error.message);
@@ -687,6 +739,33 @@ program
     });
 
 program
+    .command('list-schemas')
+    .description('List schemas owned by current ID')
+    .action(async (file, name) => {
+        try {
+            const schemas = await keymaster.listSchemas();
+            console.log(JSON.stringify(schemas, null, 4));
+        }
+        catch (error) {
+            console.error(error.message);
+        }
+    });
+
+
+program
+    .command('get-schema <did>')
+    .description('Get schema by DID')
+    .action(async (did) => {
+        try {
+            const schema = await keymaster.getSchema(did);
+            console.log(JSON.stringify(schema, null, 4));
+        }
+        catch (error) {
+            console.error(error.message);
+        }
+    });
+
+program
     .command('create-template <schema>')
     .description('Create a template from a schema')
     .action(async (schema) => {
@@ -707,6 +786,19 @@ program
             const asset = JSON.parse(fs.readFileSync(file).toString());
             const did = await keymaster.createAsset(asset);
             console.log(did);
+        }
+        catch (error) {
+            console.error(error.message);
+        }
+    });
+
+program
+    .command('get-asset <did>')
+    .description('Get asset by DID')
+    .action(async (did) => {
+        try {
+            const asset = await keymaster.resolveAsset(did);
+            console.log(JSON.stringify(asset, null, 4));
         }
         catch (error) {
             console.error(error.message);

--- a/scripts/swagger.sh
+++ b/scripts/swagger.sh
@@ -1,0 +1,1 @@
+docker run -p 8080:8080 swaggerapi/swagger-editor

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -592,7 +592,7 @@ function KeymasterUI({ keymaster, title, challengeDID }) {
 
     async function publishCredential(did) {
         try {
-            await keymaster.publishCredential(did, false);
+            await keymaster.publishCredential(did, { reveal: false });
             resolveId();
             decryptCredential(did);
         } catch (error) {
@@ -602,7 +602,7 @@ function KeymasterUI({ keymaster, title, challengeDID }) {
 
     async function revealCredential(did) {
         try {
-            await keymaster.publishCredential(did, true);
+            await keymaster.publishCredential(did, { reveal: true });
             resolveId();
             decryptCredential(did);
         } catch (error) {
@@ -1541,7 +1541,7 @@ function KeymasterUI({ keymaster, title, challengeDID }) {
                                                 margin="normal"
                                                 inputProps={{ maxLength: 85, style: { fontFamily: 'Courier', fontSize: '0.8em' } }}
                                             />
-                                            <br/>
+                                            <br />
                                             <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
                                                 <Grid item>
                                                     <Button variant="contained" color="primary" onClick={newChallenge}>
@@ -1577,7 +1577,7 @@ function KeymasterUI({ keymaster, title, challengeDID }) {
                                                 margin="normal"
                                                 inputProps={{ maxLength: 85, style: { fontFamily: 'Courier', fontSize: '0.8em' } }}
                                             />
-                                            <br/>
+                                            <br />
                                             <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
                                                 <Grid item>
                                                     <Button variant="contained" color="primary" onClick={() => decryptResponse(response)} disabled={!response || response === authDID}>

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -303,7 +303,7 @@ function KeymasterUI({ keymaster, title, challengeDID }) {
 
         for (const name of names) {
             try {
-                const isGroup = await keymaster.groupTest(name);
+                const isGroup = await keymaster.testGroup(name);
 
                 if (isGroup) {
                     groupList.push(name);
@@ -444,7 +444,7 @@ function KeymasterUI({ keymaster, title, challengeDID }) {
 
     async function addMember(did) {
         try {
-            await keymaster.groupAdd(selectedGroupName, did);
+            await keymaster.addGroupMember(selectedGroupName, did);
             refreshGroup(selectedGroupName);
         } catch (error) {
             window.alert(error);
@@ -454,7 +454,7 @@ function KeymasterUI({ keymaster, title, challengeDID }) {
     async function removeMember(did) {
         try {
             if (window.confirm(`Remove member from ${selectedGroupName}?`)) {
-                await keymaster.groupRemove(selectedGroupName, did);
+                await keymaster.removeGroupMember(selectedGroupName, did);
                 refreshGroup(selectedGroupName);
             }
         } catch (error) {

--- a/services/keymaster/client/src/KeymasterUI.js
+++ b/services/keymaster/client/src/KeymasterUI.js
@@ -303,7 +303,7 @@ function KeymasterUI({ keymaster, title, challengeDID }) {
 
         for (const name of names) {
             try {
-                const isGroup = await keymaster.groupTest(name);
+                const isGroup = await keymaster.testGroup(name);
 
                 if (isGroup) {
                     groupList.push(name);
@@ -444,7 +444,7 @@ function KeymasterUI({ keymaster, title, challengeDID }) {
 
     async function addMember(did) {
         try {
-            await keymaster.groupAdd(selectedGroupName, did);
+            await keymaster.addGroupMember(selectedGroupName, did);
             refreshGroup(selectedGroupName);
         } catch (error) {
             window.alert(error);
@@ -454,7 +454,7 @@ function KeymasterUI({ keymaster, title, challengeDID }) {
     async function removeMember(did) {
         try {
             if (window.confirm(`Remove member from ${selectedGroupName}?`)) {
-                await keymaster.groupRemove(selectedGroupName, did);
+                await keymaster.removeGroupMember(selectedGroupName, did);
                 refreshGroup(selectedGroupName);
             }
         } catch (error) {
@@ -1541,7 +1541,7 @@ function KeymasterUI({ keymaster, title, challengeDID }) {
                                                 margin="normal"
                                                 inputProps={{ maxLength: 85, style: { fontFamily: 'Courier', fontSize: '0.8em' } }}
                                             />
-                                            <br/>
+                                            <br />
                                             <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
                                                 <Grid item>
                                                     <Button variant="contained" color="primary" onClick={newChallenge}>
@@ -1577,7 +1577,7 @@ function KeymasterUI({ keymaster, title, challengeDID }) {
                                                 margin="normal"
                                                 inputProps={{ maxLength: 85, style: { fontFamily: 'Courier', fontSize: '0.8em' } }}
                                             />
-                                            <br/>
+                                            <br />
                                             <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
                                                 <Grid item>
                                                     <Button variant="contained" color="primary" onClick={() => decryptResponse(response)} disabled={!response || response === authDID}>

--- a/services/keymaster/client/src/KeymasterUI.js
+++ b/services/keymaster/client/src/KeymasterUI.js
@@ -592,7 +592,7 @@ function KeymasterUI({ keymaster, title, challengeDID }) {
 
     async function publishCredential(did) {
         try {
-            await keymaster.publishCredential(did, false);
+            await keymaster.publishCredential(did, { reveal: false });
             resolveId();
             decryptCredential(did);
         } catch (error) {
@@ -602,7 +602,7 @@ function KeymasterUI({ keymaster, title, challengeDID }) {
 
     async function revealCredential(did) {
         try {
-            await keymaster.publishCredential(did, true);
+            await keymaster.publishCredential(did, { reveal: true });
             resolveId();
             decryptCredential(did);
         } catch (error) {

--- a/services/keymaster/server/src/keymaster-api.js
+++ b/services/keymaster/server/src/keymaster-api.js
@@ -140,7 +140,7 @@ v1router.get('/ids', async (req, res) => {
     }
 });
 
-v1router.post('/ids/new', async (req, res) => {
+v1router.post('/ids/', async (req, res) => {
     try {
         const { name, options } = req.body;
         const response = await keymaster.createId(name, options);
@@ -555,17 +555,7 @@ v1router.post('/keys/verify', async (req, res) => {
     }
 });
 
-v1router.post('/credentials/new', async (req, res) => {
-    try {
-        const { schema, options } = req.body;
-        const response = await keymaster.createSchema(schema, options);
-        res.json(response);
-    } catch (error) {
-        res.status(500).send({ error: error.toString() });
-    }
-});
-
-v1router.post('/schemas/:id/template/new', async (req, res) => {
+v1router.post('/schemas/:id/template/', async (req, res) => {
     try {
         const { schema } = req.body;
         const response = await keymaster.createTemplate(schema);
@@ -575,7 +565,7 @@ v1router.post('/schemas/:id/template/new', async (req, res) => {
     }
 });
 
-v1router.post('/assets/new', async (req, res) => {
+v1router.post('/assets/', async (req, res) => {
     try {
         const { asset, options } = req.body;
         const response = await keymaster.createAsset(asset, options);
@@ -606,7 +596,7 @@ v1router.get('/templates/poll', async (req, res) => {
     }
 });
 
-v1router.post('/poll/new', async (req, res) => {
+v1router.post('/polls/', async (req, res) => {
     try {
         const { poll, options } = req.body;
         const response = await keymaster.createPoll(poll, options);
@@ -616,7 +606,7 @@ v1router.post('/poll/new', async (req, res) => {
     }
 });
 
-v1router.get('/poll/:poll/view', async (req, res) => {
+v1router.get('/polls/:poll/view', async (req, res) => {
     try {
         const response = await keymaster.viewPoll(req.params.poll);
         res.json(response);
@@ -625,7 +615,7 @@ v1router.get('/poll/:poll/view', async (req, res) => {
     }
 });
 
-v1router.post('/poll/vote', async (req, res) => {
+v1router.post('/polls/vote', async (req, res) => {
     try {
         const { poll, vote, options } = req.body;
         const response = await keymaster.votePoll(poll, vote, options);
@@ -635,7 +625,7 @@ v1router.post('/poll/vote', async (req, res) => {
     }
 });
 
-v1router.put('/poll/update', async (req, res) => {
+v1router.put('/polls/update', async (req, res) => {
     try {
         const { ballot } = req.body;
         const response = await keymaster.updatePoll(ballot);
@@ -645,7 +635,7 @@ v1router.put('/poll/update', async (req, res) => {
     }
 });
 
-v1router.post('/poll/:poll/publish', async (req, res) => {
+v1router.post('/polls/:poll/publish', async (req, res) => {
     try {
         const { poll, options } = req.body;
         const response = await keymaster.publishPoll(poll, options);
@@ -655,7 +645,7 @@ v1router.post('/poll/:poll/publish', async (req, res) => {
     }
 });
 
-v1router.delete('/poll/:poll/unpublish', async (req, res) => {
+v1router.delete('/polls/:poll/unpublish', async (req, res) => {
     try {
         const { poll } = req.params;
         const response = await keymaster.unpublishPoll(poll);

--- a/services/keymaster/server/src/keymaster-api.js
+++ b/services/keymaster/server/src/keymaster-api.js
@@ -303,7 +303,7 @@ v1router.get('/groups/:name', async (req, res) => {
 v1router.post('/groups/:name/add', async (req, res) => {
     try {
         const { member } = req.body;
-        const ok = await keymaster.groupAdd(req.params.name, member);
+        const ok = await keymaster.addGroupMember(req.params.name, member);
         res.json({ ok });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
@@ -313,7 +313,7 @@ v1router.post('/groups/:name/add', async (req, res) => {
 v1router.post('/groups/:name/remove', async (req, res) => {
     try {
         const { member } = req.body;
-        const ok = await keymaster.groupRemove(req.params.name, member);
+        const ok = await keymaster.removeGroupMember(req.params.name, member);
         res.json({ ok });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
@@ -323,7 +323,7 @@ v1router.post('/groups/:name/remove', async (req, res) => {
 v1router.post('/groups/:name/test', async (req, res) => {
     try {
         const { member } = req.body;
-        const test = await keymaster.groupTest(req.params.name, member);
+        const test = await keymaster.testGroup(req.params.name, member);
         res.json({ test });
     } catch (error) {
         res.status(400).send({ error: error.toString() });

--- a/services/keymaster/server/src/keymaster-api.js
+++ b/services/keymaster/server/src/keymaster-api.js
@@ -23,7 +23,7 @@ let serverReady = false;
 
 v1router.get('/ready', async (req, res) => {
     try {
-        res.json(serverReady);
+        res.json({ ready: serverReady });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -32,7 +32,7 @@ v1router.get('/ready', async (req, res) => {
 v1router.get('/registries', async (req, res) => {
     try {
         const registries = await keymaster.listRegistries();
-        res.json(registries);
+        res.json({ registries });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -41,7 +41,7 @@ v1router.get('/registries', async (req, res) => {
 v1router.get('/wallet', async (req, res) => {
     try {
         const wallet = await keymaster.loadWallet();
-        res.json(wallet);
+        res.json({ wallet });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -50,8 +50,8 @@ v1router.get('/wallet', async (req, res) => {
 v1router.put('/wallet', async (req, res) => {
     try {
         const { wallet } = req.body;
-        const response = await keymaster.saveWallet(wallet);
-        res.json(response);
+        const ok = await keymaster.saveWallet(wallet);
+        res.json({ ok });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -61,7 +61,7 @@ v1router.post('/wallet/new', async (req, res) => {
     try {
         const { mnemonic, overwrite } = req.body;
         const wallet = await keymaster.newWallet(mnemonic, overwrite);
-        res.json(wallet);
+        res.json({ wallet });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -69,8 +69,8 @@ v1router.post('/wallet/new', async (req, res) => {
 
 v1router.post('/wallet/backup', async (req, res) => {
     try {
-        const response = await keymaster.backupWallet();
-        res.json(response);
+        const ok = await keymaster.backupWallet();
+        res.json({ ok });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -78,8 +78,8 @@ v1router.post('/wallet/backup', async (req, res) => {
 
 v1router.post('/wallet/recover', async (req, res) => {
     try {
-        const response = await keymaster.recoverWallet();
-        res.json(response);
+        const wallet = await keymaster.recoverWallet();
+        res.json({ wallet });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -87,8 +87,8 @@ v1router.post('/wallet/recover', async (req, res) => {
 
 v1router.post('/wallet/check', async (req, res) => {
     try {
-        const response = await keymaster.checkWallet();
-        res.json(response);
+        const check = await keymaster.checkWallet();
+        res.json({ check });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -96,8 +96,8 @@ v1router.post('/wallet/check', async (req, res) => {
 
 v1router.post('/wallet/fix', async (req, res) => {
     try {
-        const response = await keymaster.fixWallet();
-        res.json(response);
+        const fix = await keymaster.fixWallet();
+        res.json({ fix });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -105,8 +105,8 @@ v1router.post('/wallet/fix', async (req, res) => {
 
 v1router.get('/wallet/mnemonic', async (req, res) => {
     try {
-        const response = await keymaster.decryptMnemonic();
-        res.json(response);
+        const mnemonic = await keymaster.decryptMnemonic();
+        res.json({ mnemonic });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -114,8 +114,8 @@ v1router.get('/wallet/mnemonic', async (req, res) => {
 
 v1router.get('/ids/current', async (req, res) => {
     try {
-        const response = await keymaster.getCurrentId();
-        res.json(response);
+        const current = await keymaster.getCurrentId();
+        res.json({ current });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -124,8 +124,8 @@ v1router.get('/ids/current', async (req, res) => {
 v1router.put('/ids/current', async (req, res) => {
     try {
         const { name } = req.body;
-        const response = await keymaster.setCurrentId(name);
-        res.json(response);
+        const ok = await keymaster.setCurrentId(name);
+        res.json({ ok });
     } catch (error) {
         res.status(400).send({ error: error.toString() });
     }
@@ -133,8 +133,8 @@ v1router.put('/ids/current', async (req, res) => {
 
 v1router.get('/ids', async (req, res) => {
     try {
-        const response = await keymaster.listIds();
-        res.json(response);
+        const ids = await keymaster.listIds();
+        res.json({ ids });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -143,8 +143,8 @@ v1router.get('/ids', async (req, res) => {
 v1router.post('/ids/', async (req, res) => {
     try {
         const { name, options } = req.body;
-        const response = await keymaster.createId(name, options);
-        res.json(response);
+        const did = await keymaster.createId(name, options);
+        res.json({ did });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -152,11 +152,11 @@ v1router.post('/ids/', async (req, res) => {
 
 v1router.get('/ids/:id', async (req, res) => {
     try {
-        const doc = await keymaster.resolveId(req.params.id);
-        if (!doc) {
+        const docs = await keymaster.resolveId(req.params.id);
+        if (!docs) {
             return res.status(404).send({ error: 'ID not found' });
         }
-        res.json(doc);
+        res.json({ docs });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -164,8 +164,8 @@ v1router.get('/ids/:id', async (req, res) => {
 
 v1router.delete('/ids/:id', async (req, res) => {
     try {
-        const response = await keymaster.removeId(req.params.id);
-        res.json(response);
+        const ok = await keymaster.removeId(req.params.id);
+        res.json({ ok });
     } catch (error) {
         res.status(400).send({ error: error.toString() });
     }
@@ -173,8 +173,8 @@ v1router.delete('/ids/:id', async (req, res) => {
 
 v1router.post('/ids/:id/backup', async (req, res) => {
     try {
-        const response = await keymaster.backupId(req.params.id);
-        res.json(response);
+        const ok = await keymaster.backupId(req.params.id);
+        res.json({ ok });
     } catch (error) {
         res.status(400).send({ error: error.toString() });
     }
@@ -183,8 +183,8 @@ v1router.post('/ids/:id/backup', async (req, res) => {
 v1router.post('/ids/:id/recover', async (req, res) => {
     try {
         const { did } = req.body;
-        const response = await keymaster.recoverId(did);
-        res.json(response);
+        const current = await keymaster.recoverId(did);
+        res.json({ recovered: current });
     } catch (error) {
         res.status(400).send({ error: error.toString() });
     }
@@ -192,8 +192,8 @@ v1router.post('/ids/:id/recover', async (req, res) => {
 
 v1router.get('/names', async (req, res) => {
     try {
-        const response = await keymaster.listNames();
-        res.json(response);
+        const names = await keymaster.listNames();
+        res.json({ names });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -202,8 +202,8 @@ v1router.get('/names', async (req, res) => {
 v1router.post('/names', async (req, res) => {
     try {
         const { name, did } = req.body;
-        const response = await keymaster.addName(name, did);
-        res.json(response);
+        const ok = await keymaster.addName(name, did);
+        res.json({ ok });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -211,11 +211,11 @@ v1router.post('/names', async (req, res) => {
 
 v1router.get('/names/:name', async (req, res) => {
     try {
-        const doc = await keymaster.resolveDID(req.params.name);
-        if (!doc) {
+        const docs = await keymaster.resolveDID(req.params.name);
+        if (!docs) {
             return res.status(404).send({ error: 'Name not found' });
         }
-        res.json(doc);
+        res.json({ docs });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -223,8 +223,8 @@ v1router.get('/names/:name', async (req, res) => {
 
 v1router.delete('/names/:name', async (req, res) => {
     try {
-        const response = await keymaster.removeName(req.params.name);
-        res.json(response);
+        const ok = await keymaster.removeName(req.params.name);
+        res.json({ ok });
     } catch (error) {
         res.status(400).send({ error: error.toString() });
     }
@@ -232,8 +232,8 @@ v1router.delete('/names/:name', async (req, res) => {
 
 v1router.get('/challenge', async (req, res) => {
     try {
-        const response = await keymaster.createChallenge();
-        res.json(response);
+        const did = await keymaster.createChallenge();
+        res.json({ did });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -242,8 +242,8 @@ v1router.get('/challenge', async (req, res) => {
 v1router.post('/challenge', async (req, res) => {
     try {
         const { challenge, options } = req.body;
-        const response = await keymaster.createChallenge(challenge, options);
-        res.json(response);
+        const did = await keymaster.createChallenge(challenge, options);
+        res.json({ did });
     } catch (error) {
         res.status(400).send({ error: error.toString() });
     }
@@ -252,8 +252,8 @@ v1router.post('/challenge', async (req, res) => {
 v1router.post('/response', async (req, res) => {
     try {
         const { challenge, options } = req.body;
-        const response = await keymaster.createResponse(challenge, options);
-        res.json(response);
+        const did = await keymaster.createResponse(challenge, options);
+        res.json({ did });
     } catch (error) {
         res.status(400).send({ error: error.toString() });
     }
@@ -263,7 +263,7 @@ v1router.post('/response/verify', async (req, res) => {
     try {
         const { response, options } = req.body;
         const verify = await keymaster.verifyResponse(response, options);
-        res.json(verify);
+        res.json({ verify });
     } catch (error) {
         res.status(400).send({ error: error.toString() });
     }
@@ -271,8 +271,8 @@ v1router.post('/response/verify', async (req, res) => {
 
 v1router.get('/groups', async (req, res) => {
     try {
-        const response = await keymaster.listGroups(req.query.owner);
-        res.json(response);
+        const groups = await keymaster.listGroups(req.query.owner);
+        res.json({ groups });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -281,8 +281,8 @@ v1router.get('/groups', async (req, res) => {
 v1router.post('/groups', async (req, res) => {
     try {
         const { name, options } = req.body;
-        const response = await keymaster.createGroup(name, options);
-        res.json(response);
+        const did = await keymaster.createGroup(name, options);
+        res.json({ did });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -294,7 +294,7 @@ v1router.get('/groups/:name', async (req, res) => {
         if (!group) {
             return res.status(404).send({ error: 'Group not found' });
         }
-        res.json(group);
+        res.json({ group });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -303,8 +303,8 @@ v1router.get('/groups/:name', async (req, res) => {
 v1router.post('/groups/:name/add', async (req, res) => {
     try {
         const { member } = req.body;
-        const response = await keymaster.groupAdd(req.params.name, member);
-        res.json(response);
+        const ok = await keymaster.groupAdd(req.params.name, member);
+        res.json({ ok });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -313,8 +313,8 @@ v1router.post('/groups/:name/add', async (req, res) => {
 v1router.post('/groups/:name/remove', async (req, res) => {
     try {
         const { member } = req.body;
-        const response = await keymaster.groupRemove(req.params.name, member);
-        res.json(response);
+        const ok = await keymaster.groupRemove(req.params.name, member);
+        res.json({ ok });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -323,8 +323,8 @@ v1router.post('/groups/:name/remove', async (req, res) => {
 v1router.post('/groups/:name/test', async (req, res) => {
     try {
         const { member } = req.body;
-        const response = await keymaster.groupTest(req.params.name, member);
-        res.json(response);
+        const test = await keymaster.groupTest(req.params.name, member);
+        res.json({ test });
     } catch (error) {
         res.status(400).send({ error: error.toString() });
     }
@@ -332,8 +332,8 @@ v1router.post('/groups/:name/test', async (req, res) => {
 
 v1router.get('/schemas', async (req, res) => {
     try {
-        const response = await keymaster.listSchemas(req.query.owner);
-        res.json(response);
+        const schemas = await keymaster.listSchemas(req.query.owner);
+        res.json({ schemas });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -342,8 +342,8 @@ v1router.get('/schemas', async (req, res) => {
 v1router.post('/schemas', async (req, res) => {
     try {
         const { schema, options } = req.body;
-        const response = await keymaster.createSchema(schema, options);
-        res.json(response);
+        const did = await keymaster.createSchema(schema, options);
+        res.json({ did });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -355,7 +355,7 @@ v1router.get('/schemas/:id', async (req, res) => {
         if (!schema) {
             return res.status(404).send({ error: 'Schema not found' });
         }
-        res.json(schema);
+        res.json({ schema });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -364,8 +364,8 @@ v1router.get('/schemas/:id', async (req, res) => {
 v1router.put('/schemas/:id', async (req, res) => {
     try {
         const { schema } = req.body;
-        const response = await keymaster.setSchema(req.params.id, schema);
-        res.json(response.data);
+        const ok = await keymaster.setSchema(req.params.id, schema);
+        res.json({ ok });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -373,8 +373,8 @@ v1router.put('/schemas/:id', async (req, res) => {
 
 v1router.post('/schemas/:id/test', async (req, res) => {
     try {
-        const response = await keymaster.testSchema(req.params.id);
-        res.json(response);
+        const test = await keymaster.testSchema(req.params.id);
+        res.json({ test });
     } catch (error) {
         res.status(400).send({ error: error.toString() });
     }
@@ -382,8 +382,8 @@ v1router.post('/schemas/:id/test', async (req, res) => {
 
 v1router.post('/agents/:id/test', async (req, res) => {
     try {
-        const response = await keymaster.testAgent(req.params.id);
-        res.json(response);
+        const test = await keymaster.testAgent(req.params.id);
+        res.json({ test });
     } catch (error) {
         res.status(400).send({ error: error.toString() });
     }
@@ -392,8 +392,8 @@ v1router.post('/agents/:id/test', async (req, res) => {
 v1router.post('/credentials/bind', async (req, res) => {
     try {
         const { schema, subject, options } = req.body;
-        const response = await keymaster.bindCredential(schema, subject, options);
-        res.json(response);
+        const credential = await keymaster.bindCredential(schema, subject, options);
+        res.json({ credential });
     } catch (error) {
         res.status(400).send({ error: error.toString() });
     }
@@ -401,8 +401,8 @@ v1router.post('/credentials/bind', async (req, res) => {
 
 v1router.get('/credentials/held', async (req, res) => {
     try {
-        const response = await keymaster.listCredentials();
-        res.json(response);
+        const held = await keymaster.listCredentials();
+        res.json({ held });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -411,8 +411,8 @@ v1router.get('/credentials/held', async (req, res) => {
 v1router.post('/credentials/held', async (req, res) => {
     try {
         const { did } = req.body;
-        const response = await keymaster.acceptCredential(did);
-        res.json(response);
+        const ok = await keymaster.acceptCredential(did);
+        res.json({ ok });
     } catch (error) {
         res.status(400).send({ error: error.toString() });
     }
@@ -420,8 +420,8 @@ v1router.post('/credentials/held', async (req, res) => {
 
 v1router.get('/credentials/held/:did', async (req, res) => {
     try {
-        const response = await keymaster.getCredential(req.params.did);
-        res.json(response);
+        const credential = await keymaster.getCredential(req.params.did);
+        res.json({ credential });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -429,8 +429,8 @@ v1router.get('/credentials/held/:did', async (req, res) => {
 
 v1router.delete('/credentials/held/:did', async (req, res) => {
     try {
-        const response = await keymaster.removeCredential(req.params.did);
-        res.json(response);
+        const ok = await keymaster.removeCredential(req.params.did);
+        res.json({ ok });
     } catch (error) {
         res.status(400).send({ error: error.toString() });
     }
@@ -440,8 +440,8 @@ v1router.post('/credentials/held/:did/publish', async (req, res) => {
     try {
         const did = req.params.did;
         const { options } = req.body;
-        const response = await keymaster.publishCredential(did, options);
-        res.json(response);
+        const ok = await keymaster.publishCredential(did, options);
+        res.json({ ok });
     } catch (error) {
         res.status(400).send({ error: error.toString() });
     }
@@ -450,8 +450,8 @@ v1router.post('/credentials/held/:did/publish', async (req, res) => {
 v1router.post('/credentials/held/:did/unpublish', async (req, res) => {
     try {
         const did = req.params.did;
-        const response = await keymaster.unpublishCredential(did);
-        res.json(response);
+        const ok = await keymaster.unpublishCredential(did);
+        res.json({ ok });
     } catch (error) {
         res.status(400).send({ error: error.toString() });
     }
@@ -459,8 +459,8 @@ v1router.post('/credentials/held/:did/unpublish', async (req, res) => {
 
 v1router.get('/credentials/issued', async (req, res) => {
     try {
-        const response = await keymaster.listIssued();
-        res.json(response);
+        const issued = await keymaster.listIssued();
+        res.json({ issued });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -469,8 +469,8 @@ v1router.get('/credentials/issued', async (req, res) => {
 v1router.post('/credentials/issued', async (req, res) => {
     try {
         const { credential, options } = req.body;
-        const response = await keymaster.issueCredential(credential, options);
-        res.json(response);
+        const did = await keymaster.issueCredential(credential, options);
+        res.json({ did });
     } catch (error) {
         res.status(400).send({ error: error.toString() });
     }
@@ -480,8 +480,8 @@ v1router.post('/credentials/issued', async (req, res) => {
 v1router.get('/credentials/issued/:did', async (req, res) => {
     try {
         const did = req.params.did;
-        const response = await keymaster.getCredential(did);
-        res.json(response);
+        const credential = await keymaster.getCredential(did);
+        res.json({ credential });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -491,8 +491,8 @@ v1router.post('/credentials/issued/:did', async (req, res) => {
     try {
         const did = req.params.did;
         const { credential } = req.body;
-        const response = await keymaster.updateCredential(did, credential);
-        res.json(response);
+        const ok = await keymaster.updateCredential(did, credential);
+        res.json({ ok });
     } catch (error) {
         res.status(400).send({ error: error.toString() });
     }
@@ -501,8 +501,8 @@ v1router.post('/credentials/issued/:did', async (req, res) => {
 v1router.delete('/credentials/issued/:did', async (req, res) => {
     try {
         const did = req.params.did;
-        const response = await keymaster.revokeCredential(did);
-        res.json(response);
+        const ok = await keymaster.revokeCredential(did);
+        res.json({ ok });
     } catch (error) {
         res.status(400).send({ error: error.toString() });
     }
@@ -510,8 +510,8 @@ v1router.delete('/credentials/issued/:did', async (req, res) => {
 
 v1router.post('/keys/rotate', async (req, res) => {
     try {
-        const response = await keymaster.rotateKeys();
-        res.json(response);
+        const ok = await keymaster.rotateKeys();
+        res.json({ ok });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -520,8 +520,8 @@ v1router.post('/keys/rotate', async (req, res) => {
 v1router.post('/keys/encrypt/message', async (req, res) => {
     try {
         const { msg, receiver, options } = req.body;
-        const response = await keymaster.encryptMessage(msg, receiver, options);
-        res.json(response);
+        const did = await keymaster.encryptMessage(msg, receiver, options);
+        res.json({ did });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -529,8 +529,8 @@ v1router.post('/keys/encrypt/message', async (req, res) => {
 
 v1router.post('/keys/decrypt/message', async (req, res) => {
     try {
-        const response = await keymaster.decryptMessage(req.body.did);
-        res.json(response);
+        const message = await keymaster.decryptMessage(req.body.did);
+        res.json({ message });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -539,8 +539,8 @@ v1router.post('/keys/decrypt/message', async (req, res) => {
 v1router.post('/keys/encrypt/json', async (req, res) => {
     try {
         const { json, receiver, options } = req.body;
-        const response = await keymaster.encryptJSON(json, receiver, options);
-        res.json(response);
+        const did = await keymaster.encryptJSON(json, receiver, options);
+        res.json({ did });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -548,8 +548,8 @@ v1router.post('/keys/encrypt/json', async (req, res) => {
 
 v1router.post('/keys/decrypt/json', async (req, res) => {
     try {
-        const response = await keymaster.decryptJSON(req.body.did);
-        res.json(response);
+        const json = await keymaster.decryptJSON(req.body.did);
+        res.json({ json });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -557,8 +557,8 @@ v1router.post('/keys/decrypt/json', async (req, res) => {
 
 v1router.post('/keys/sign', async (req, res) => {
     try {
-        const response = await keymaster.addSignature(JSON.parse(req.body.contents));
-        res.json(response);
+        const signed = await keymaster.addSignature(JSON.parse(req.body.contents));
+        res.json({ signed });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -566,8 +566,8 @@ v1router.post('/keys/sign', async (req, res) => {
 
 v1router.post('/keys/verify', async (req, res) => {
     try {
-        const response = await keymaster.verifySignature(req.body.json);
-        res.json(response);
+        const ok = await keymaster.verifySignature(req.body.json);
+        res.json({ ok });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -576,8 +576,8 @@ v1router.post('/keys/verify', async (req, res) => {
 v1router.post('/schemas/:id/template/', async (req, res) => {
     try {
         const { schema } = req.body;
-        const response = await keymaster.createTemplate(schema);
-        res.json(response);
+        const template = await keymaster.createTemplate(schema);
+        res.json({ template });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -586,8 +586,8 @@ v1router.post('/schemas/:id/template/', async (req, res) => {
 v1router.post('/assets/', async (req, res) => {
     try {
         const { asset, options } = req.body;
-        const response = await keymaster.createAsset(asset, options);
-        res.json(response);
+        const did = await keymaster.createAsset(asset, options);
+        res.json({ did });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -599,7 +599,7 @@ v1router.get('/assets/:id', async (req, res) => {
         if (!asset) {
             return res.status(404).send({ error: 'Asset not found' });
         }
-        res.json(asset);
+        res.json({ asset });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -607,8 +607,8 @@ v1router.get('/assets/:id', async (req, res) => {
 
 v1router.get('/templates/poll', async (req, res) => {
     try {
-        const response = await keymaster.pollTemplate();
-        res.json(response);
+        const template = await keymaster.pollTemplate();
+        res.json({ template });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -617,8 +617,8 @@ v1router.get('/templates/poll', async (req, res) => {
 v1router.post('/polls/', async (req, res) => {
     try {
         const { poll, options } = req.body;
-        const response = await keymaster.createPoll(poll, options);
-        res.json(response);
+        const did = await keymaster.createPoll(poll, options);
+        res.json({ did });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -626,8 +626,8 @@ v1router.post('/polls/', async (req, res) => {
 
 v1router.get('/polls/:poll/view', async (req, res) => {
     try {
-        const response = await keymaster.viewPoll(req.params.poll);
-        res.json(response);
+        const poll = await keymaster.viewPoll(req.params.poll);
+        res.json({ poll });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -636,8 +636,8 @@ v1router.get('/polls/:poll/view', async (req, res) => {
 v1router.post('/polls/vote', async (req, res) => {
     try {
         const { poll, vote, options } = req.body;
-        const response = await keymaster.votePoll(poll, vote, options);
-        res.json(response);
+        const did = await keymaster.votePoll(poll, vote, options);
+        res.json({ did });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -646,8 +646,8 @@ v1router.post('/polls/vote', async (req, res) => {
 v1router.put('/polls/update', async (req, res) => {
     try {
         const { ballot } = req.body;
-        const response = await keymaster.updatePoll(ballot);
-        res.json(response);
+        const ok = await keymaster.updatePoll(ballot);
+        res.json({ ok });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -656,8 +656,8 @@ v1router.put('/polls/update', async (req, res) => {
 v1router.post('/polls/:poll/publish', async (req, res) => {
     try {
         const { poll, options } = req.body;
-        const response = await keymaster.publishPoll(poll, options);
-        res.json(response);
+        const ok = await keymaster.publishPoll(poll, options);
+        res.json({ ok });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }
@@ -666,8 +666,8 @@ v1router.post('/polls/:poll/publish', async (req, res) => {
 v1router.delete('/polls/:poll/unpublish', async (req, res) => {
     try {
         const { poll } = req.params;
-        const response = await keymaster.unpublishPoll(poll);
-        res.json(response);
+        const ok = await keymaster.unpublishPoll(poll);
+        res.json({ ok });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }

--- a/services/keymaster/server/src/keymaster-api.js
+++ b/services/keymaster/server/src/keymaster-api.js
@@ -269,6 +269,15 @@ v1router.post('/response/verify', async (req, res) => {
     }
 });
 
+v1router.get('/groups', async (req, res) => {
+    try {
+        const response = await keymaster.listGroups(req.query.owner);
+        res.json(response);
+    } catch (error) {
+        res.status(500).send({ error: error.toString() });
+    }
+});
+
 v1router.post('/groups', async (req, res) => {
     try {
         const { name, options } = req.body;
@@ -318,6 +327,15 @@ v1router.post('/groups/:name/test', async (req, res) => {
         res.json(response);
     } catch (error) {
         res.status(400).send({ error: error.toString() });
+    }
+});
+
+v1router.get('/schemas', async (req, res) => {
+    try {
+        const response = await keymaster.listSchemas(req.query.owner);
+        res.json(response);
+    } catch (error) {
+        res.status(500).send({ error: error.toString() });
     }
 });
 

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -3803,8 +3803,8 @@ describe('checkWallet', () => {
         mockFs({});
 
         await keymaster.createId('Alice');
-        await keymaster.addToOwned('did:test:mock');
-        await keymaster.addToHeld('did:test:mock');
+        await keymaster.addToOwned('did:test:mock1');
+        await keymaster.addToHeld('did:test:mock2');
 
         const { checked, invalid, deleted } = await keymaster.checkWallet();
 

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -3072,6 +3072,8 @@ describe('listGroups', () => {
         const group2 = await keymaster.createGroup('mock-2');
         const group3 = await keymaster.createGroup('mock-3');
         const schema1 = await keymaster.createSchema();
+        // add a bogus DID to trigger the exception case
+        await keymaster.addToOwned('did:test:mock');
 
         const groups = await keymaster.listGroups();
 

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -3784,7 +3784,7 @@ describe('checkWallet', () => {
         expect(deleted).toBe(1);
     });
 
-    it('should detect invalid DIDs', async () => {
+    it('should detect removed DIDs', async () => {
         mockFs({});
 
         const agentDID = await keymaster.createId('Alice');
@@ -3796,6 +3796,20 @@ describe('checkWallet', () => {
 
         expect(checked).toBe(3);
         expect(invalid).toBe(3);
+        expect(deleted).toBe(0);
+    });
+
+    it('should detect invalid DIDs', async () => {
+        mockFs({});
+
+        await keymaster.createId('Alice');
+        await keymaster.addToOwned('did:test:mock');
+        await keymaster.addToHeld('did:test:mock');
+
+        const { checked, invalid, deleted } = await keymaster.checkWallet();
+
+        expect(checked).toBe(3);
+        expect(invalid).toBe(2);
         expect(deleted).toBe(0);
     });
 

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -2424,7 +2424,7 @@ describe('createGroup', () => {
     });
 });
 
-describe('groupAdd', () => {
+describe('addGroupMember', () => {
 
     afterEach(() => {
         mockFs.restore();
@@ -2439,7 +2439,7 @@ describe('groupAdd', () => {
         const mockAnchor = { name: 'mockData' };
         const dataDid = await keymaster.createAsset(mockAnchor);
 
-        const ok = await keymaster.groupAdd(groupDid, dataDid);
+        const ok = await keymaster.addGroupMember(groupDid, dataDid);
         expect(ok).toBe(true);
 
         const data = await keymaster.getGroup(groupDid);
@@ -2462,7 +2462,7 @@ describe('groupAdd', () => {
 
         const alias = 'mockAlias';
         await keymaster.addName(alias, dataDid);
-        const ok = await keymaster.groupAdd(groupDid, alias);
+        const ok = await keymaster.addGroupMember(groupDid, alias);
         expect(ok).toBe(true);
 
         const data = await keymaster.getGroup(groupDid);
@@ -2482,7 +2482,7 @@ describe('groupAdd', () => {
         const groupDid = await keymaster.createGroup(groupName);
 
         try {
-            await keymaster.groupAdd(groupDid, 'mockAlias');
+            await keymaster.addGroupMember(groupDid, 'mockAlias');
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2501,7 +2501,7 @@ describe('groupAdd', () => {
 
         const alias = 'mockAlias';
         await keymaster.addName(alias, groupDid);
-        const ok = await keymaster.groupAdd(alias, dataDid);
+        const ok = await keymaster.addGroupMember(alias, dataDid);
         expect(ok).toBe(true);
 
         const data = await keymaster.getGroup(groupDid);
@@ -2521,7 +2521,7 @@ describe('groupAdd', () => {
         const dataDid = await keymaster.createAsset(mockAnchor);
 
         try {
-            await keymaster.groupAdd('mockAlias', dataDid);
+            await keymaster.addGroupMember('mockAlias', dataDid);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2538,11 +2538,11 @@ describe('groupAdd', () => {
         const mockAnchor = { name: 'mockData' };
         const dataDid = await keymaster.createAsset(mockAnchor);
 
-        await keymaster.groupAdd(groupDid, dataDid);
-        await keymaster.groupAdd(groupDid, dataDid);
-        await keymaster.groupAdd(groupDid, dataDid);
+        await keymaster.addGroupMember(groupDid, dataDid);
+        await keymaster.addGroupMember(groupDid, dataDid);
+        await keymaster.addGroupMember(groupDid, dataDid);
 
-        const data = await keymaster.groupAdd(groupDid, dataDid);
+        const data = await keymaster.addGroupMember(groupDid, dataDid);
 
         const expectedGroup = {
             name: groupName,
@@ -2561,11 +2561,11 @@ describe('groupAdd', () => {
         const mockAnchor = { name: 'mockData' };
         const dataDid = await keymaster.createAsset(mockAnchor);
 
-        await keymaster.groupAdd(groupDid, dataDid);
+        await keymaster.addGroupMember(groupDid, dataDid);
         const dox1 = await keymaster.resolveDID(groupDid);
         const version1 = dox1.didDocumentMetadata.version;
 
-        await keymaster.groupAdd(groupDid, dataDid);
+        await keymaster.addGroupMember(groupDid, dataDid);
         const dox2 = await keymaster.resolveDID(groupDid);
         const version2 = dox2.didDocumentMetadata.version;
 
@@ -2583,7 +2583,7 @@ describe('groupAdd', () => {
         for (let i = 0; i < memberCount; i++) {
             const mockAnchor = { name: `mock-${i}` };
             const dataDid = await keymaster.createAsset(mockAnchor);
-            await keymaster.groupAdd(groupDid, dataDid);
+            await keymaster.addGroupMember(groupDid, dataDid);
         }
 
         const data = await keymaster.resolveAsset(groupDid);
@@ -2599,7 +2599,7 @@ describe('groupAdd', () => {
         const groupDid = await keymaster.createGroup(groupName);
 
         try {
-            await keymaster.groupAdd(groupDid);
+            await keymaster.addGroupMember(groupDid);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2607,7 +2607,7 @@ describe('groupAdd', () => {
         }
 
         try {
-            await keymaster.groupAdd(groupDid, 100);
+            await keymaster.addGroupMember(groupDid, 100);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2615,7 +2615,7 @@ describe('groupAdd', () => {
         }
 
         try {
-            await keymaster.groupAdd(groupDid, [1, 2, 3]);
+            await keymaster.addGroupMember(groupDid, [1, 2, 3]);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2623,7 +2623,7 @@ describe('groupAdd', () => {
         }
 
         try {
-            await keymaster.groupAdd(groupDid, { name: 'mock' });
+            await keymaster.addGroupMember(groupDid, { name: 'mock' });
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2631,7 +2631,7 @@ describe('groupAdd', () => {
         }
 
         try {
-            await keymaster.groupAdd(groupDid, 'did:mock');
+            await keymaster.addGroupMember(groupDid, 'did:mock');
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2647,7 +2647,7 @@ describe('groupAdd', () => {
         const dataDid = await keymaster.createAsset(mockAnchor);
 
         try {
-            await keymaster.groupAdd(null, dataDid);
+            await keymaster.addGroupMember(null, dataDid);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2655,7 +2655,7 @@ describe('groupAdd', () => {
         }
 
         try {
-            await keymaster.groupAdd(100, dataDid);
+            await keymaster.addGroupMember(100, dataDid);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2663,7 +2663,7 @@ describe('groupAdd', () => {
         }
 
         try {
-            await keymaster.groupAdd([1, 2, 3], dataDid);
+            await keymaster.addGroupMember([1, 2, 3], dataDid);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2671,7 +2671,7 @@ describe('groupAdd', () => {
         }
 
         try {
-            await keymaster.groupAdd({ name: 'mock' }, dataDid);
+            await keymaster.addGroupMember({ name: 'mock' }, dataDid);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2679,7 +2679,7 @@ describe('groupAdd', () => {
         }
 
         try {
-            await keymaster.groupAdd(agentDid, dataDid);
+            await keymaster.addGroupMember(agentDid, dataDid);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2687,7 +2687,7 @@ describe('groupAdd', () => {
         }
 
         try {
-            await keymaster.groupAdd(dataDid, agentDid);
+            await keymaster.addGroupMember(dataDid, agentDid);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2702,7 +2702,7 @@ describe('groupAdd', () => {
         const groupDid = await keymaster.createGroup('group');
 
         try {
-            await keymaster.groupAdd(groupDid, groupDid);
+            await keymaster.addGroupMember(groupDid, groupDid);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2718,11 +2718,11 @@ describe('groupAdd', () => {
         const group2Did = await keymaster.createGroup('group-2');
         const group3Did = await keymaster.createGroup('group-3');
 
-        await keymaster.groupAdd(group1Did, group2Did);
-        await keymaster.groupAdd(group2Did, group3Did);
+        await keymaster.addGroupMember(group1Did, group2Did);
+        await keymaster.addGroupMember(group2Did, group3Did);
 
         try {
-            await keymaster.groupAdd(group3Did, group1Did);
+            await keymaster.addGroupMember(group3Did, group1Did);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2731,7 +2731,7 @@ describe('groupAdd', () => {
     });
 });
 
-describe('groupRemove', () => {
+describe('removeGroupMember', () => {
 
     afterEach(() => {
         mockFs.restore();
@@ -2745,9 +2745,9 @@ describe('groupRemove', () => {
         const groupDid = await keymaster.createGroup(groupName);
         const mockAnchor = { name: 'mockData' };
         const dataDid = await keymaster.createAsset(mockAnchor);
-        await keymaster.groupAdd(groupDid, dataDid);
+        await keymaster.addGroupMember(groupDid, dataDid);
 
-        const data = await keymaster.groupRemove(groupDid, dataDid);
+        const data = await keymaster.removeGroupMember(groupDid, dataDid);
 
         const expectedGroup = {
             name: groupName,
@@ -2765,12 +2765,12 @@ describe('groupRemove', () => {
         const groupDid = await keymaster.createGroup(groupName);
         const mockAnchor = { name: 'mockData' };
         const dataDid = await keymaster.createAsset(mockAnchor);
-        await keymaster.groupAdd(groupDid, dataDid);
+        await keymaster.addGroupMember(groupDid, dataDid);
 
         const alias = 'mockAlias';
         await keymaster.addName(alias, dataDid);
 
-        const data = await keymaster.groupRemove(groupDid, alias);
+        const data = await keymaster.removeGroupMember(groupDid, alias);
 
         const expectedGroup = {
             name: groupName,
@@ -2789,7 +2789,7 @@ describe('groupRemove', () => {
         const mockAnchor = { name: 'mockData' };
         const dataDid = await keymaster.createAsset(mockAnchor);
 
-        const data = await keymaster.groupRemove(groupDid, dataDid);
+        const data = await keymaster.removeGroupMember(groupDid, dataDid);
 
         const expectedGroup = {
             name: groupName,
@@ -2810,7 +2810,7 @@ describe('groupRemove', () => {
         const version1 = dox1.didDocumentMetadata.version;
 
         const dataDid = await keymaster.createAsset(mockAnchor);
-        await keymaster.groupRemove(groupDid, dataDid);
+        await keymaster.removeGroupMember(groupDid, dataDid);
         const dox2 = await keymaster.resolveDID(groupDid);
         const version2 = dox2.didDocumentMetadata.version;
 
@@ -2825,7 +2825,7 @@ describe('groupRemove', () => {
         const groupDid = await keymaster.createGroup(groupName);
 
         try {
-            await keymaster.groupRemove(groupDid);
+            await keymaster.removeGroupMember(groupDid);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2833,7 +2833,7 @@ describe('groupRemove', () => {
         }
 
         try {
-            await keymaster.groupRemove(groupDid, 100);
+            await keymaster.removeGroupMember(groupDid, 100);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2841,7 +2841,7 @@ describe('groupRemove', () => {
         }
 
         try {
-            await keymaster.groupRemove(groupDid, [1, 2, 3]);
+            await keymaster.removeGroupMember(groupDid, [1, 2, 3]);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2849,7 +2849,7 @@ describe('groupRemove', () => {
         }
 
         try {
-            await keymaster.groupRemove(groupDid, { name: 'mock' });
+            await keymaster.removeGroupMember(groupDid, { name: 'mock' });
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2857,7 +2857,7 @@ describe('groupRemove', () => {
         }
 
         try {
-            await keymaster.groupRemove(groupDid, 'did:mock');
+            await keymaster.removeGroupMember(groupDid, 'did:mock');
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2873,7 +2873,7 @@ describe('groupRemove', () => {
         const dataDid = await keymaster.createAsset(mockAnchor);
 
         try {
-            await keymaster.groupRemove();
+            await keymaster.removeGroupMember();
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2881,7 +2881,7 @@ describe('groupRemove', () => {
         }
 
         try {
-            await keymaster.groupRemove(null, dataDid);
+            await keymaster.removeGroupMember(null, dataDid);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2889,7 +2889,7 @@ describe('groupRemove', () => {
         }
 
         try {
-            await keymaster.groupRemove(100, dataDid);
+            await keymaster.removeGroupMember(100, dataDid);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2897,7 +2897,7 @@ describe('groupRemove', () => {
         }
 
         try {
-            await keymaster.groupRemove([1, 2, 3], dataDid);
+            await keymaster.removeGroupMember([1, 2, 3], dataDid);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2905,7 +2905,7 @@ describe('groupRemove', () => {
         }
 
         try {
-            await keymaster.groupRemove({ name: 'mock' }, dataDid);
+            await keymaster.removeGroupMember({ name: 'mock' }, dataDid);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2913,7 +2913,7 @@ describe('groupRemove', () => {
         }
 
         try {
-            await keymaster.groupRemove(agentDid, dataDid);
+            await keymaster.removeGroupMember(agentDid, dataDid);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2921,7 +2921,7 @@ describe('groupRemove', () => {
         }
 
         try {
-            await keymaster.groupRemove(dataDid, agentDid);
+            await keymaster.removeGroupMember(dataDid, agentDid);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {
@@ -2930,7 +2930,7 @@ describe('groupRemove', () => {
     });
 });
 
-describe('groupTest', () => {
+describe('testGroup', () => {
 
     afterEach(() => {
         mockFs.restore();
@@ -2944,9 +2944,9 @@ describe('groupTest', () => {
         const groupDid = await keymaster.createGroup(groupName);
         const mockAnchor = { name: 'mockData' };
         const dataDid = await keymaster.createAsset(mockAnchor);
-        await keymaster.groupAdd(groupDid, dataDid);
+        await keymaster.addGroupMember(groupDid, dataDid);
 
-        const test = await keymaster.groupTest(groupDid, dataDid);
+        const test = await keymaster.testGroup(groupDid, dataDid);
 
         expect(test).toBe(true);
     });
@@ -2960,7 +2960,7 @@ describe('groupTest', () => {
         const mockAnchor = { name: 'mockData' };
         const dataDid = await keymaster.createAsset(mockAnchor);
 
-        const test = await keymaster.groupTest(groupDid, dataDid);
+        const test = await keymaster.testGroup(groupDid, dataDid);
 
         expect(test).toBe(false);
     });
@@ -2972,7 +2972,7 @@ describe('groupTest', () => {
         const groupName = 'mockGroup';
         const groupDid = await keymaster.createGroup(groupName);
 
-        const test = await keymaster.groupTest(groupDid);
+        const test = await keymaster.testGroup(groupDid);
 
         expect(test).toBe(true);
     });
@@ -2984,7 +2984,7 @@ describe('groupTest', () => {
         const mockAnchor = { name: 'mockData' };
         const dataDid = await keymaster.createAsset(mockAnchor);
 
-        const test = await keymaster.groupTest(dataDid);
+        const test = await keymaster.testGroup(dataDid);
 
         expect(test).toBe(false);
     });
@@ -2999,21 +2999,21 @@ describe('groupTest', () => {
         const group4Did = await keymaster.createGroup('level-4');
         const group5Did = await keymaster.createGroup('level-5');
 
-        await keymaster.groupAdd(group1Did, group2Did);
-        await keymaster.groupAdd(group2Did, group3Did);
-        await keymaster.groupAdd(group3Did, group4Did);
-        await keymaster.groupAdd(group4Did, group5Did);
+        await keymaster.addGroupMember(group1Did, group2Did);
+        await keymaster.addGroupMember(group2Did, group3Did);
+        await keymaster.addGroupMember(group3Did, group4Did);
+        await keymaster.addGroupMember(group4Did, group5Did);
 
-        const test1 = await keymaster.groupTest(group1Did, group2Did);
+        const test1 = await keymaster.testGroup(group1Did, group2Did);
         expect(test1).toBe(true);
 
-        const test2 = await keymaster.groupTest(group1Did, group3Did);
+        const test2 = await keymaster.testGroup(group1Did, group3Did);
         expect(test2).toBe(true);
 
-        const test3 = await keymaster.groupTest(group1Did, group4Did);
+        const test3 = await keymaster.testGroup(group1Did, group4Did);
         expect(test3).toBe(true);
 
-        const test4 = await keymaster.groupTest(group1Did, group5Did);
+        const test4 = await keymaster.testGroup(group1Did, group5Did);
         expect(test4).toBe(true);
     });
 });
@@ -3273,7 +3273,7 @@ describe('viewPoll', () => {
 
         const bobDid = await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
-        await keymaster.groupAdd(rosterDid, bobDid);
+        await keymaster.addGroupMember(rosterDid, bobDid);
         const template = await keymaster.pollTemplate();
 
         template.roster = rosterDid;
@@ -3308,7 +3308,7 @@ describe('votePoll', () => {
 
         const bobDid = await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
-        await keymaster.groupAdd(rosterDid, bobDid);
+        await keymaster.addGroupMember(rosterDid, bobDid);
         const template = await keymaster.pollTemplate();
 
         template.roster = rosterDid;
@@ -3330,7 +3330,7 @@ describe('votePoll', () => {
 
         const bobDid = await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
-        await keymaster.groupAdd(rosterDid, bobDid);
+        await keymaster.addGroupMember(rosterDid, bobDid);
         const template = await keymaster.pollTemplate();
 
         template.roster = rosterDid;
@@ -3378,7 +3378,7 @@ describe('updatePoll', () => {
 
         const bobDid = await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
-        await keymaster.groupAdd(rosterDid, bobDid);
+        await keymaster.addGroupMember(rosterDid, bobDid);
         const template = await keymaster.pollTemplate();
         template.roster = rosterDid;
         const pollDid = await keymaster.createPoll(template);
@@ -3396,7 +3396,7 @@ describe('updatePoll', () => {
 
         const bobDid = await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
-        await keymaster.groupAdd(rosterDid, bobDid);
+        await keymaster.addGroupMember(rosterDid, bobDid);
         const template = await keymaster.pollTemplate();
         template.roster = rosterDid;
         const pollDid = await keymaster.createPoll(template);
@@ -3422,7 +3422,7 @@ describe('publishPoll', () => {
 
         const bobDid = await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
-        await keymaster.groupAdd(rosterDid, bobDid);
+        await keymaster.addGroupMember(rosterDid, bobDid);
         const template = await keymaster.pollTemplate();
         template.roster = rosterDid;
         const pollDid = await keymaster.createPoll(template);
@@ -3465,7 +3465,7 @@ describe('publishPoll', () => {
 
         const bobDid = await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
-        await keymaster.groupAdd(rosterDid, bobDid);
+        await keymaster.addGroupMember(rosterDid, bobDid);
         const template = await keymaster.pollTemplate();
         template.roster = rosterDid;
         const pollDid = await keymaster.createPoll(template);
@@ -3497,7 +3497,7 @@ describe('unpublishPoll', () => {
 
         const bobDid = await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
-        await keymaster.groupAdd(rosterDid, bobDid);
+        await keymaster.addGroupMember(rosterDid, bobDid);
         const template = await keymaster.pollTemplate();
         template.roster = rosterDid;
         const pollDid = await keymaster.createPoll(template);

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -3872,7 +3872,7 @@ describe('fixWallet', () => {
         expect(namesRemoved).toBe(0);
     });
 
-    it('should remove invalid DIDs', async () => {
+    it('should remove deleted DIDs', async () => {
         mockFs({});
 
         const agentDID = await keymaster.createId('Alice');
@@ -3886,6 +3886,21 @@ describe('fixWallet', () => {
         expect(ownedRemoved).toBe(0);
         expect(heldRemoved).toBe(0);
         expect(namesRemoved).toBe(1);
+    });
+
+    it('should remove invalid DIDs', async () => {
+        mockFs({});
+
+        await keymaster.createId('Alice');
+        await keymaster.addToOwned('did:test:mock1');
+        await keymaster.addToHeld('did:test:mock2');
+
+        const { idsRemoved, ownedRemoved, heldRemoved, namesRemoved } = await keymaster.fixWallet();
+
+        expect(idsRemoved).toBe(0);
+        expect(ownedRemoved).toBe(1);
+        expect(heldRemoved).toBe(1);
+        expect(namesRemoved).toBe(0);
     });
 
     it('should remove revoked credentials', async () => {

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -614,8 +614,8 @@ describe('testAgent', () => {
         mockFs({});
 
         await keymaster.createId('Bob');
-        const dataDID = await keymaster.createAsset({ name: 'mockAnchor' });
-        const isAgent = await keymaster.testAgent(dataDID);
+        const dataDid = await keymaster.createAsset({ name: 'mockAnchor' });
+        const isAgent = await keymaster.testAgent(dataDid);
 
         expect(isAgent).toBe(false);
     });
@@ -2344,7 +2344,7 @@ describe('unpublishCredential', () => {
         const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, bob);
         const did = await keymaster.issueCredential(boundCredential);
-        await keymaster.publishCredential(did, true);
+        await keymaster.publishCredential(did, { reveal: true });
 
         await keymaster.unpublishCredential(did);
 
@@ -2438,8 +2438,11 @@ describe('groupAdd', () => {
         const groupDid = await keymaster.createGroup(groupName);
         const mockAnchor = { name: 'mockData' };
         const dataDid = await keymaster.createAsset(mockAnchor);
-        const data = await keymaster.groupAdd(groupDid, dataDid);
 
+        const ok = await keymaster.groupAdd(groupDid, dataDid);
+        expect(ok).toBe(true);
+
+        const data = await keymaster.getGroup(groupDid);
         const expectedGroup = {
             name: groupName,
             members: [dataDid],
@@ -2459,8 +2462,10 @@ describe('groupAdd', () => {
 
         const alias = 'mockAlias';
         await keymaster.addName(alias, dataDid);
-        const data = await keymaster.groupAdd(groupDid, alias);
+        const ok = await keymaster.groupAdd(groupDid, alias);
+        expect(ok).toBe(true);
 
+        const data = await keymaster.getGroup(groupDid);
         const expectedGroup = {
             name: groupName,
             members: [dataDid],
@@ -2496,8 +2501,10 @@ describe('groupAdd', () => {
 
         const alias = 'mockAlias';
         await keymaster.addName(alias, groupDid);
-        const data = await keymaster.groupAdd(alias, dataDid);
+        const ok = await keymaster.groupAdd(alias, dataDid);
+        expect(ok).toBe(true);
 
+        const data = await keymaster.getGroup(groupDid);
         const expectedGroup = {
             name: groupName,
             members: [dataDid],
@@ -3022,9 +3029,9 @@ describe('getGroup', () => {
 
         await keymaster.createId('Bob');
         const groupName = 'mock';
-        const groupDID = await keymaster.createGroup(groupName);
+        const groupDid = await keymaster.createGroup(groupName);
 
-        const group = await keymaster.getGroup(groupDID);
+        const group = await keymaster.getGroup(groupDid);
 
         expect(group.name).toBe(groupName);
         expect(group.members).toStrictEqual([]);

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -1417,6 +1417,31 @@ describe('createSchema', () => {
     });
 });
 
+describe('listSchemas', () => {
+
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should return list of schemas', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+
+        const schema1 = await keymaster.createSchema();
+        const schema2 = await keymaster.createSchema();
+        const schema3 = await keymaster.createSchema();
+        const group1 = await keymaster.createGroup('mockGroup');
+
+        const schemas = await keymaster.listSchemas();
+
+        expect(schemas.includes(schema1)).toBe(true);
+        expect(schemas.includes(schema2)).toBe(true);
+        expect(schemas.includes(schema3)).toBe(true);
+        expect(schemas.includes(group1)).toBe(false);
+    });
+});
+
 describe('bindCredential', () => {
 
     afterEach(() => {
@@ -3028,6 +3053,32 @@ describe('getGroup', () => {
         catch (error) {
             expect(error.message).toBe(exceptions.INVALID_PARAMETER);
         }
+    });
+});
+
+
+describe('listGroups', () => {
+
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should return list of schemas', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+
+        const group1 = await keymaster.createGroup('mock-1');
+        const group2 = await keymaster.createGroup('mock-2');
+        const group3 = await keymaster.createGroup('mock-3');
+        const schema1 = await keymaster.createSchema();
+
+        const groups = await keymaster.listGroups();
+
+        expect(groups.includes(group1)).toBe(true);
+        expect(groups.includes(group2)).toBe(true);
+        expect(groups.includes(group3)).toBe(true);
+        expect(groups.includes(schema1)).toBe(false);
     });
 });
 


### PR DESCRIPTION
Adds new API endpoints:
- `GET /groups`
- `GET /schemas`

Removes deprecated endpoint:
- `POST /credentials/new`

Renames all `/poll/` endpoints to `/polls/`

Changes all endpoints to return JSON with named return values.

Adds new CLI commands:
- `get-asset`
- `list-groups`
- `get-group`
- `list-schemas`
- `get-schema`
- `list-credentials`
- `get-credential`

Changed all commands to follow `verb-subject` pattern which mostly affected the group commands:
- `group-create` -> `create-group`
- `group-add` -> `add-group-member`
- `group-remove` -> `remove-group-member`
- `group-test` -> `test-group`

The associated keymaster lib function names were changed to follow suit.

Also fixed an issue with reveal credential in the web wallet and CLI.

Also adds a script to start a swagger editor in a docker container (useful for editing the openapi spec)

