### PR TITLE
refactor: processEvents

### DIFF
--- a/scripts/admin-cli.js
+++ b/scripts/admin-cli.js
@@ -112,6 +112,7 @@ program
             }
             console.timeEnd('resolveDID(did, { confirm: false })');
 
+            batch = [];
             console.time('getDIDs({ dids: batch, confirm: false, resolve: true })');
             for (const did of dids) {
                 batch.push(did);
@@ -134,6 +135,19 @@ program
                     await gatekeeper.resolveDID(did, { verify: true });
                 }
                 console.timeEnd('resolveDID(did, { verify: true })');
+
+                batch = [];
+                console.time('getDIDs({ dids: batch, verify: true, resolve: true })');
+                for (const did of dids) {
+                    batch.push(did);
+
+                    if (batch.length > 99) {
+                        await gatekeeper.getDIDs({ dids: batch, verify: true, resolve: true });
+                        batch = [];
+                    }
+                }
+                await gatekeeper.getDIDs({ dids: batch, verify: true, resolve: true });
+                console.timeEnd('getDIDs({ dids: batch, verify: true, resolve: true })');
             }
         }
         catch (error) {

--- a/scripts/admin-cli.js
+++ b/scripts/admin-cli.js
@@ -244,20 +244,10 @@ program
             registry = 'local';
         }
 
-        function shuffleArray(array) {
-            for (let i = array.length - 1; i > 0; i--) {
-                const j = Math.floor(Math.random() * (i + 1));
-                [array[i], array[j]] = [array[j], array[i]];
-            }
-            return array;
-        }
-
         try {
             const contents = fs.readFileSync(file).toString();
             let batch = JSON.parse(contents);
             let chunk = [];
-
-            //batch = shuffleArray(batch);
 
             for (const event of batch) {
                 event.registry = registry;

--- a/services/gatekeeper/server/src/gatekeeper-api.js
+++ b/services/gatekeeper/server/src/gatekeeper-api.js
@@ -258,32 +258,12 @@ async function verifyLoop() {
     setTimeout(verifyLoop, 60 * 60 * 1000);
 }
 
-async function importLoop() {
-    let response;
-
-    try {
-        console.log(`importLoop: processingEvents...`);
-        response = await gatekeeper.processEvents();
-        console.log(`importLoop: ${JSON.stringify(response)}`);
-    } catch (error) {
-        console.error(`Error in verifyLoop: ${error}`);
-    }
-
-    if (response.added > 0 || response.merged > 0) {
-        setTimeout(importLoop, 0);
-    }
-    else {
-        setTimeout(importLoop, 20 * 1000);
-    }
-}
-
 async function main() {
     console.time('checkDb');
     const check = await gatekeeper.checkDb();
     console.timeEnd('checkDb');
     console.log(`check: ${JSON.stringify(check)}`);
 
-    //setTimeout(importLoop, 60 * 1000);
     setTimeout(verifyLoop, 60 * 60 * 1000);
 
     const registries = await gatekeeper.initRegistries(config.registries);

--- a/services/gatekeeper/server/src/gatekeeper-api.js
+++ b/services/gatekeeper/server/src/gatekeeper-api.js
@@ -283,7 +283,7 @@ async function main() {
     console.timeEnd('checkDb');
     console.log(`check: ${JSON.stringify(check)}`);
 
-    setTimeout(importLoop, 60 * 1000);
+    //setTimeout(importLoop, 60 * 1000);
     setTimeout(verifyLoop, 60 * 60 * 1000);
 
     const registries = await gatekeeper.initRegistries(config.registries);

--- a/services/mediators/satoshi/src/satoshi-mediator.js
+++ b/services/mediators/satoshi/src/satoshi-mediator.js
@@ -150,8 +150,10 @@ async function importBatches() {
                 await importBatch(db, item);
             }
             catch (error) {
-                console.error(`Error importing ${item.did}: ${error.error || JSON.stringify(error)}`);
-                continue;
+                // OK if DID not found, we'll just try again later
+                if (error.error !== 'DID not found') {
+                    console.error(`Error importing ${item.did}: ${error.error || JSON.stringify(error)}`);
+                }
             }
         }
     }

--- a/tests/gatekeeper.test.js
+++ b/tests/gatekeeper.test.js
@@ -1746,7 +1746,7 @@ describe('processEvents', () => {
         expect(doc.didDocument.id).toBe(did);
     });
 
-    it('should defer operation validation when keys cannot be confirmed', async () => {
+    it('should handle deferred operation validation when keys cannot be confirmed', async () => {
         mockFs({});
 
         const keypair = cipher.generateRandomJwk();
@@ -1768,20 +1768,8 @@ describe('processEvents', () => {
         // Reverse the ops so that the updates come before the create ops
         await gatekeeper.importBatch(ops.reverse());
 
-        // On the first pass we can only verify the agent create op
         const response1 = await gatekeeper.processEvents();
-        expect(response1.added).toBe(1);
-        expect(response1.deferred).toBe(3);
-
-        // On the second pass we can verify the agent update and the asset create
-        const response2 = await gatekeeper.processEvents();
-        expect(response2.added).toBe(2);
-        expect(response2.deferred).toBe(1);
-
-        // On the third pass we can verify the asset update
-        const response3 = await gatekeeper.processEvents();
-        expect(response3.added).toBe(1);
-        expect(response3.deferred).toBe(0);
+        expect(response1.added).toBe(4);
     });
 });
 


### PR DESCRIPTION
Removed import loop from gatekeeper-api, clients are responsible for invoking processEvents when they are finished importing event batches.

Removed batch tracking from hyperswarm-mediator, the gatekeeper-api is now responsible for tracking which events have already been seen so they can be discarded from the import queue.

Also, satoshi-mediator no longer reports an error if a batch DID discovered on the blockchain can't be resolved yet.
