### PR TITLE
fix: Improve batch import tracking

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.ftc
+    image: keychainmdip/ftc-node
     volumes:
       - ./data/tftc:/root/.feathercoin
 

--- a/packages/gatekeeper/src/gatekeeper-lib.js
+++ b/packages/gatekeeper/src/gatekeeper-lib.js
@@ -508,6 +508,10 @@ export async function resolveDID(did, options = {}) {
             break;
         }
 
+        if (atVersion && version === atVersion) {
+            break;
+        }
+
         confirmed = confirmed && mdip.registry === registry;
 
         if (confirm && !confirmed) {
@@ -557,10 +561,6 @@ export async function resolveDID(did, options = {}) {
             }
 
             // console.error(`unknown type ${operation.type}`);
-        }
-
-        if (atVersion && version === atVersion) {
-            break;
         }
     }
 

--- a/packages/gatekeeper/src/gatekeeper-lib.js
+++ b/packages/gatekeeper/src/gatekeeper-lib.js
@@ -794,10 +794,10 @@ export async function processEvents() {
     }
 
     console.log(JSON.stringify(eventsQueue, null, 4));
-    eventsQueue = [];
+    const pending = eventsQueue.length;
 
     isProcessingEvents = false;
-    return { added, merged };
+    return { added, merged, pending };
 }
 
 export async function verifyEvent(event) {

--- a/services/mediators/satoshi/src/satoshi-mediator.js
+++ b/services/mediators/satoshi/src/satoshi-mediator.js
@@ -116,7 +116,8 @@ async function scanBlocks() {
 async function importBatch(item) {
     if (item.imported && item.processed) {
         const processed = item.processed.added + item.processed.merged;
-        if (item.imported.total === processed) {
+        // Importing an update (e.g. key change) could trigger the validation of many pending ops
+        if (processed >= item.imported.total) {
             return;
         }
     }
@@ -146,9 +147,6 @@ async function importBatch(item) {
     item.imported.total = batch.length;
     if (item.imported.queued > 0) {
         item.processed = await gatekeeper.processEvents();
-    }
-    else {
-        item.processed = null;
     }
     console.log(JSON.stringify(item, null, 4));
 }

--- a/services/mediators/satoshi/src/satoshi-mediator.js
+++ b/services/mediators/satoshi/src/satoshi-mediator.js
@@ -115,7 +115,8 @@ async function scanBlocks() {
 
 async function importBatch(item) {
     if (item.imported && item.processed) {
-        if (item.imported.total === (item.processed.added + item.processed.merged)) {
+        const processed = item.processed.added + item.processed.merged;
+        if (item.imported.total === processed) {
             return;
         }
     }

--- a/services/mediators/satoshi/src/satoshi-mediator.js
+++ b/services/mediators/satoshi/src/satoshi-mediator.js
@@ -113,7 +113,13 @@ async function scanBlocks() {
     }
 }
 
-async function importBatch(db, item) {
+async function importBatch(item) {
+    if (item.imported && item.processed) {
+        if (item.imported.total === (item.processed.added + item.processed.merged)) {
+            return;
+        }
+    }
+
     console.log(JSON.stringify(item, null, 4));
 
     const queue = await keymaster.resolveAsset(item.did);
@@ -135,9 +141,14 @@ async function importBatch(db, item) {
     }
 
     console.log(JSON.stringify(batch, null, 4));
-    const imported = await gatekeeper.importBatch(batch);
-    item.imported = imported;
-    writeDb(db);
+    item.imported = await gatekeeper.importBatch(batch);
+    item.imported.total = batch.length;
+    if (item.imported.queued > 0) {
+        item.processed = await gatekeeper.processEvents();
+    }
+    else {
+        item.processed = null;
+    }
     console.log(JSON.stringify(item, null, 4));
 }
 
@@ -145,18 +156,18 @@ async function importBatches() {
     const db = loadDb();
 
     for (const item of db.discovered) {
-        if (!item.imported) {
-            try {
-                await importBatch(db, item);
-            }
-            catch (error) {
-                // OK if DID not found, we'll just try again later
-                if (error.error !== 'DID not found') {
-                    console.error(`Error importing ${item.did}: ${error.error || JSON.stringify(error)}`);
-                }
+        try {
+            await importBatch(item);
+        }
+        catch (error) {
+            // OK if DID not found, we'll just try again later
+            if (error.error !== 'DID not found') {
+                console.error(`Error importing ${item.did}: ${error.error || JSON.stringify(error)}`);
             }
         }
     }
+
+    writeDb(db);
 }
 
 export async function createOpReturnTxn(opReturnData) {
@@ -429,13 +440,13 @@ async function main() {
 
     if (config.importInterval > 0) {
         console.log(`Importing operations every ${config.importInterval} minute(s)`);
-        importLoop();
+        setTimeout(importLoop, config.importInterval * 60 * 1000);
     }
 
     if (config.exportInterval > 0) {
         console.log(`Exporting operations every ${config.exportInterval} minute(s)`);
         console.log(`Txn fees (${config.chain}): minimum: ${config.feeMin}, maximum: ${config.feeMax}, increment ${config.feeInc}`);
-        exportLoop();
+        setTimeout(exportLoop, config.exportInterval * 60 * 1000);
     }
 
     await keymaster.stop();

--- a/tests/gatekeeper.test.js
+++ b/tests/gatekeeper.test.js
@@ -5,10 +5,10 @@ import * as db_json from '@mdip/gatekeeper/db/json';
 import * as exceptions from '@mdip/exceptions';
 
 const mockConsole = {
-    log: () => {},
-    error: () => {},
-    time: () => {},
-    timeEnd: () => {},
+    log: () => { },
+    error: () => { },
+    time: () => { },
+    timeEnd: () => { },
 }
 
 beforeEach(async () => {
@@ -823,6 +823,28 @@ describe('resolveDID', () => {
 
         const doc = await gatekeeper.resolveDID(did, { atVersion: expected.didDocumentMetadata.version });
         expect(doc).toStrictEqual(expected);
+    });
+
+    it('should resolve all specified versions', async () => {
+
+        mockFs({});
+
+        const keypair = cipher.generateRandomJwk();
+        const agentOp = await createAgentOp(keypair);
+        const did = await gatekeeper.createDID(agentOp);
+
+        // Add 10 versions
+        for (let i = 0; i < 10; i++) {
+            const update = await gatekeeper.resolveDID(did);
+            update.didDocumentData = { mock: 1 };
+            const updateOp = await createUpdateOp(keypair, did, update);
+            await gatekeeper.updateDID(updateOp);
+        }
+
+        for (let i = 0; i < 10; i++) {
+            const doc = await gatekeeper.resolveDID(did, { atVersion: i+1 });
+            expect(doc.didDocumentMetadata.version).toBe(i+1);
+        }
     });
 
     it('should resolve a valid asset DID', async () => {
@@ -1720,12 +1742,12 @@ describe('processEvents', () => {
         await gatekeeper.resetDb();
 
         const { queued, rejected } = await gatekeeper.importBatch(ops);
-        expect(queued).toBe(N+1);
+        expect(queued).toBe(N + 1);
         expect(rejected).toBe(0);
 
         const response = await gatekeeper.processEvents();
 
-        expect(response.added).toBe(N+1);
+        expect(response.added).toBe(N + 1);
         expect(response.merged).toBe(0);
     });
 

--- a/tests/gatekeeper.test.js
+++ b/tests/gatekeeper.test.js
@@ -1768,7 +1768,7 @@ describe('processEvents', () => {
         expect(doc.didDocument.id).toBe(did);
     });
 
-    it('should handle deferred operation validation when keys cannot be confirmed', async () => {
+    it('should handle processing events in any order', async () => {
         mockFs({});
 
         const keypair = cipher.generateRandomJwk();
@@ -1780,7 +1780,7 @@ describe('processEvents', () => {
 
         const assetOp = await createAssetOp(agentDID, keypair);
         const assetDID = await gatekeeper.createDID(assetOp);
-        const assetDoc = await gatekeeper.resolveDID(agentDID);
+        const assetDoc = await gatekeeper.resolveDID(assetDID);
         const updateOp2 = await createUpdateOp(keypair, assetDID, assetDoc);
         await gatekeeper.updateDID(updateOp2);
 
@@ -1792,6 +1792,57 @@ describe('processEvents', () => {
 
         const response1 = await gatekeeper.processEvents();
         expect(response1.added).toBe(4);
+    });
+
+    it('should handle deferred operation validation when asset ownership changes', async () => {
+        mockFs({});
+
+        const keypair1 = cipher.generateRandomJwk();
+        const agentOp1 = await createAgentOp(keypair1, 1, 'TFTC');
+        const agentDID1 = await gatekeeper.createDID(agentOp1);
+
+        const keypair2 = cipher.generateRandomJwk();
+        const agentOp2 = await createAgentOp(keypair2, 1, 'TFTC');
+        const agentDID2 = await gatekeeper.createDID(agentOp2);
+
+        const assetOp = await createAssetOp(agentDID1, keypair1, 'TFTC');
+        const assetDID = await gatekeeper.createDID(assetOp);
+        const assetDoc1 = await gatekeeper.resolveDID(assetDID);
+
+        // agent1 transfers ownership of asset to agent2
+        assetDoc1.didDocument.controller = agentDID2;
+        const updateOp1 = await createUpdateOp(keypair1, assetDID, assetDoc1);
+        await gatekeeper.updateDID(updateOp1);
+
+        // agent2 transfers ownership of asset back to agent1
+        assetDoc1.didDocument.controller = agentDID1;
+        const updateOp2 = await createUpdateOp(keypair2, assetDID, assetDoc1);
+        await gatekeeper.updateDID(updateOp2);
+
+        const dids = await gatekeeper.exportDIDs();
+        const events = dids.flat();
+        await gatekeeper.resetDb();
+        await gatekeeper.importBatch(events);
+
+        const response1 = await gatekeeper.processEvents();
+        expect(response1.added).toBe(events.length);
+
+        const assetDoc2 = await gatekeeper.resolveDID(assetDID);
+        expect(assetDoc2.didDocumentMetadata.version).toBe(3);
+        expect(assetDoc2.didDocumentMetadata.confirmed).toBe(false);
+
+        for (const event of events) {
+            event.registry = 'TFTC';
+        }
+
+        await gatekeeper.importBatch(events);
+
+        const response2 = await gatekeeper.processEvents();
+        expect(response2.added).toBe(events.length);
+
+        const assetDoc3 = await gatekeeper.resolveDID(assetDID);
+        expect(assetDoc3.didDocumentMetadata.version).toBe(3);
+        expect(assetDoc3.didDocumentMetadata.confirmed).toBe(true);
     });
 });
 


### PR DESCRIPTION
Original intent was to improve the information the satoshi-mediator saves to track importing batches of operations from the blockchain. A typical entry now includes separate properties `imported` and `processed` to record the responses to `importBatch` and `processEvents` respectively:

```
        {
            "height": 89080,
            "index": 1,
            "time": "2024-10-17T14:03:03.000Z",
            "txid": "153a0f3810d1ed026ee2cbfe3eb58be9e73ec481ec952870186efa9a5d27664a",
            "did": "did:test:z3v8AuaeY7Lammz8Xm1iQqt4Uz2ScCVHsTWZ8FEVuBVHtFMKbEZ",
            "imported": {
                "queued": 1,
                "processed": 0,
                "rejected": 0,
                "total": 1
            },
            "processed": {
                "added": 0,
                "merged": 1,
                "pending": 0
            }
        }
```

Two related issues were discovered and fixed:
- gatekeeper was removing events from its processing queue at the completion of processEvents under the mistaken assumption that they would always be added later by satoshi-mediator, but that is not the case for create events
- gatekeeper resolveDID was returning the latest version instead of the first version when atVersion was specified to be 1

A new unit test was added to simulate the edge case where a new node syncs from scratch with the case where a DID is created and ownership is transferred to another agent and back again. The 2nd update operation to transfer ownership back to the original creator cannot be validated until the previous operations are confirmed on the (simulated) blockchain registry.