### PR TITLE
refactor: Replaced json-schema-faker dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7182,10 +7182,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/call-me-maybe": {
-      "version": "1.0.2",
-      "license": "MIT"
-    },
     "node_modules/caller-callsite": {
       "version": "2.0.0",
       "license": "MIT",
@@ -9382,10 +9378,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/format-util": {
-      "version": "1.0.5",
-      "license": "MIT"
     },
     "node_modules/freeport-promise": {
       "version": "2.0.0",
@@ -12999,26 +12991,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema-faker": {
-      "version": "0.5.6",
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-ref-parser": "^6.1.0",
-        "jsonpath-plus": "^7.2.0"
-      },
-      "bin": {
-        "jsf": "bin/gen.cjs"
-      }
-    },
-    "node_modules/json-schema-ref-parser": {
-      "version": "6.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^3.12.1",
-        "ono": "^4.0.11"
-      }
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "dev": true,
@@ -13045,13 +13017,6 @@
       "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsonpath-plus": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -14738,13 +14703,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ono": {
-      "version": "4.0.11",
-      "license": "MIT",
-      "dependencies": {
-        "format-util": "^1.0.3"
       }
     },
     "node_modules/open": {
@@ -17762,8 +17720,7 @@
       "dependencies": {
         "@mdip/cipher": "*",
         "@mdip/exceptions": "*",
-        "axios": "^1.7.7",
-        "json-schema-faker": "^0.5.6"
+        "axios": "^1.7.7"
       }
     }
   }

--- a/packages/keymaster/package.json
+++ b/packages/keymaster/package.json
@@ -18,8 +18,7 @@
   "dependencies": {
     "@mdip/cipher": "*",
     "@mdip/exceptions": "*",
-    "axios": "^1.7.7",
-    "json-schema-faker": "^0.5.6"
+    "axios": "^1.7.7"
   },
   "repository": {
     "type": "git",

--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -978,7 +978,7 @@ export async function testAgent(id) {
 }
 
 export async function bindCredential(schemaId, subjectId, options = {}) {
-    let { validFrom, validUntil } = options;
+    let { validFrom, validUntil, credential } = options;
 
     if (!validFrom) {
         validFrom = new Date().toISOString();
@@ -986,9 +986,12 @@ export async function bindCredential(schemaId, subjectId, options = {}) {
 
     const id = await fetchIdInfo();
     const type = await lookupDID(schemaId);
-    const schema = await resolveAsset(type);
-    const credential = generateSchema(schema);
     const subjectDID = await lookupDID(subjectId);
+
+    if (!credential) {
+        const schema = await resolveAsset(type);
+        credential = generateSchema(schema);
+    }
 
     return {
         "@context": [

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -1398,50 +1398,6 @@ const mockSchema = {
     "type": "object"
 };
 
-describe('createSchema', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
-    it('should create a credential from a schema', async () => {
-        mockFs({});
-
-        await keymaster.createId('Bob');
-
-        const did = await keymaster.createSchema(mockSchema);
-        const doc = await keymaster.resolveDID(did);
-
-        expect(doc.didDocument.id).toBe(did);
-        expect(doc.didDocumentData).toStrictEqual(mockSchema);
-    });
-});
-
-describe('listSchemas', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
-    it('should return list of schemas', async () => {
-        mockFs({});
-
-        await keymaster.createId('Bob');
-
-        const schema1 = await keymaster.createSchema();
-        const schema2 = await keymaster.createSchema();
-        const schema3 = await keymaster.createSchema();
-        const group1 = await keymaster.createGroup('mockGroup');
-
-        const schemas = await keymaster.listSchemas();
-
-        expect(schemas.includes(schema1)).toBe(true);
-        expect(schemas.includes(schema2)).toBe(true);
-        expect(schemas.includes(schema3)).toBe(true);
-        expect(schemas.includes(group1)).toBe(false);
-    });
-});
-
 describe('bindCredential', () => {
 
     afterEach(() => {
@@ -3497,6 +3453,18 @@ describe('createSchema', () => {
         mockFs.restore();
     });
 
+    it('should create a credential from a schema', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+
+        const did = await keymaster.createSchema(mockSchema);
+        const doc = await keymaster.resolveDID(did);
+
+        expect(doc.didDocument.id).toBe(did);
+        expect(doc.didDocumentData).toStrictEqual(mockSchema);
+    });
+
     it('should create a default schema', async () => {
         mockFs({});
 
@@ -3529,6 +3497,31 @@ describe('createSchema', () => {
         } catch (error) {
             expect(error.message).toBe(exceptions.INVALID_PARAMETER);
         }
+    });
+});
+
+describe('listSchemas', () => {
+
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should return list of schemas', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+
+        const schema1 = await keymaster.createSchema();
+        const schema2 = await keymaster.createSchema();
+        const schema3 = await keymaster.createSchema();
+        const group1 = await keymaster.createGroup('mockGroup');
+
+        const schemas = await keymaster.listSchemas();
+
+        expect(schemas.includes(schema1)).toBe(true);
+        expect(schemas.includes(schema2)).toBe(true);
+        expect(schemas.includes(schema3)).toBe(true);
+        expect(schemas.includes(group1)).toBe(false);
     });
 });
 

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -1417,6 +1417,20 @@ describe('bindCredential', () => {
         expect(vc.credential.email).toEqual(expect.any(String));
     });
 
+    it('should create a bound credential with provided default', async () => {
+        mockFs({});
+
+        const userDid = await keymaster.createId('Bob');
+        const credentialDid = await keymaster.createSchema(mockSchema);
+
+        const credential = { email: 'bob@mock.com' };
+        const vc = await keymaster.bindCredential(credentialDid, userDid, { credential });
+
+        expect(vc.issuer).toBe(userDid);
+        expect(vc.credentialSubject.id).toBe(userDid);
+        expect(vc.credential.email).toEqual(credential.email);
+    });
+
     it('should create a bound credential for a different user', async () => {
         mockFs({});
 

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -3499,7 +3499,6 @@ describe('createSchema', () => {
         expect(doc.didDocumentData).toStrictEqual(mockSchema);
     });
 
-
     it('should throw an exception on create invalid schema', async () => {
         mockFs({});
 
@@ -3507,6 +3506,19 @@ describe('createSchema', () => {
 
         try {
             await keymaster.createSchema({ mock: 'not a schema' });
+            throw new Error(exceptions.EXPECTED_EXCEPTION);
+        } catch (error) {
+            expect(error.message).toBe(exceptions.INVALID_PARAMETER);
+        }
+    });
+
+    it('should throw an exception on schema missing properties', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+
+        try {
+            await keymaster.createSchema({ "$schema": "http://json-schema.org/draft-07/schema#" });
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         } catch (error) {
             expect(error.message).toBe(exceptions.INVALID_PARAMETER);


### PR DESCRIPTION
Replaces the json-schema-faker package dependency with a simple utility function `generateSchema` that works only with simple schemas (list of named properties).

Also improves `bindCredential` to use a default credential if specified in options rather than generating a default from the schema.
