### PR TITLE
fix: Specify platform for docker on mac

### DIFF
--- a/Dockerfile.gatekeeper
+++ b/Dockerfile.gatekeeper
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:18.18.2
+FROM --platform=linux/amd64 node:18.18.2
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.hyperswarm
+++ b/Dockerfile.hyperswarm
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:18.18.2
+FROM --platform=linux/amd64 node:18.18.2
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.ipfs
+++ b/Dockerfile.ipfs
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:18.18.2
+FROM --platform=linux/amd64 node:18.18.2
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.keymaster
+++ b/Dockerfile.keymaster
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:18.18.2
+FROM --platform=linux/amd64 node:18.18.2
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.satoshi
+++ b/Dockerfile.satoshi
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:18.18.2
+FROM --platform=linux/amd64 node:18.18.2
 
 # Set the working directory
 WORKDIR /app


### PR DESCRIPTION
Upgrading node from 18.15.0 to 18.18.2 in the Dockerfiles caused a regression on MacOS. Specifying the platform like we did for Dockerfile.ftc fixed the issue.