### PR TITLE
refactor: Upgrade polls

### DIFF
--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -3126,9 +3126,9 @@ describe('createPoll', () => {
         template.roster = rosterDid;
 
         const did = await keymaster.createPoll(template);
-        const data = await keymaster.resolveAsset(did);
+        const asset = await keymaster.resolveAsset(did);
 
-        expect(data).toStrictEqual(template);
+        expect(asset.poll).toStrictEqual(template);
     });
 
     it('should not create a poll from an invalid template', async () => {
@@ -3380,10 +3380,10 @@ describe('updatePoll', () => {
         const ballotDid = await keymaster.votePoll(pollDid, 1);
 
         const ok = await keymaster.updatePoll(ballotDid);
-        const pollData = await keymaster.resolveAsset(pollDid);
+        const poll = await keymaster.getPoll(pollDid);
 
         expect(ok).toBe(true);
-        expect(pollData.ballots[bobDid].ballot).toBe(ballotDid);
+        expect(poll.ballots[bobDid].ballot).toBe(ballotDid);
     });
 
     it('should reject non-ballots', async () => {
@@ -3425,30 +3425,30 @@ describe('publishPoll', () => {
         await keymaster.updatePoll(ballotDid);
         const ok = await keymaster.publishPoll(pollDid);
 
-        const pollData = await keymaster.resolveAsset(pollDid);
+        const poll = await keymaster.getPoll(pollDid);
 
         expect(ok).toBe(true);
-        expect(pollData.results.final).toBe(true);
-        expect(pollData.results.votes.eligible).toBe(1);
-        expect(pollData.results.votes.pending).toBe(0);
-        expect(pollData.results.votes.received).toBe(1);
-        expect(pollData.results.tally.length).toBe(4);
-        expect(pollData.results.tally[0]).toStrictEqual({
+        expect(poll.results.final).toBe(true);
+        expect(poll.results.votes.eligible).toBe(1);
+        expect(poll.results.votes.pending).toBe(0);
+        expect(poll.results.votes.received).toBe(1);
+        expect(poll.results.tally.length).toBe(4);
+        expect(poll.results.tally[0]).toStrictEqual({
             vote: 0,
             option: 'spoil',
             count: 0,
         });
-        expect(pollData.results.tally[1]).toStrictEqual({
+        expect(poll.results.tally[1]).toStrictEqual({
             vote: 1,
             option: 'yes',
             count: 1,
         });
-        expect(pollData.results.tally[2]).toStrictEqual({
+        expect(poll.results.tally[2]).toStrictEqual({
             vote: 2,
             option: 'no',
             count: 0,
         });
-        expect(pollData.results.tally[3]).toStrictEqual({
+        expect(poll.results.tally[3]).toStrictEqual({
             vote: 3,
             option: 'abstain',
             count: 0,
@@ -3467,11 +3467,11 @@ describe('publishPoll', () => {
         const ballotDid = await keymaster.votePoll(pollDid, 1);
         await keymaster.updatePoll(ballotDid);
         const ok = await keymaster.publishPoll(pollDid, { reveal: true });
-        const pollData = await keymaster.resolveAsset(pollDid);
+        const poll = await keymaster.getPoll(pollDid);
 
         expect(ok).toBe(true);
-        expect(pollData.results.ballots.length).toBe(1);
-        expect(pollData.results.ballots[0]).toStrictEqual({
+        expect(poll.results.ballots.length).toBe(1);
+        expect(poll.results.ballots[0]).toStrictEqual({
             ballot: ballotDid,
             voter: bobDid,
             vote: 1,
@@ -3501,10 +3501,10 @@ describe('unpublishPoll', () => {
         await keymaster.publishPoll(pollDid);
         const ok = await keymaster.unpublishPoll(pollDid);
 
-        const pollData = await keymaster.resolveAsset(pollDid);
+        const poll = await keymaster.getPoll(pollDid);
 
         expect(ok).toBe(true);
-        expect(pollData.results).toBe(undefined);
+        expect(poll.results).toBe(undefined);
     });
 });
 

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -3293,7 +3293,7 @@ describe('getPoll', () => {
         expect(poll).toStrictEqual(template);
     });
 
-    it('should return null if non-group DID specified', async () => {
+    it('should return null if non-poll DID specified', async () => {
         mockFs({});
 
         const agentDID = await keymaster.createId('Bob');
@@ -3302,7 +3302,7 @@ describe('getPoll', () => {
         expect(group).toBe(null);
     });
 
-    it('should raise an exception if no DID specified', async () => {
+    it('should raise an exception if no poll DID specified', async () => {
         mockFs({});
 
         try {

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -3257,6 +3257,64 @@ describe('createPoll', () => {
     });
 });
 
+describe('getPoll', () => {
+
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should return the specified poll', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const rosterDid = await keymaster.createGroup('mockRoster');
+        const template = await keymaster.pollTemplate();
+
+        template.roster = rosterDid;
+
+        const did = await keymaster.createPoll(template);
+        const poll = await keymaster.getPoll(did);
+
+        expect(poll).toStrictEqual(template);
+    });
+
+    it('should return old style poll (TEMP during did:test)', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const rosterDid = await keymaster.createGroup('mockRoster');
+        const template = await keymaster.pollTemplate();
+
+        template.roster = rosterDid;
+
+        const did = await keymaster.createAsset(template);
+        const poll = await keymaster.getPoll(did);
+
+        expect(poll).toStrictEqual(template);
+    });
+
+    it('should return null if non-group DID specified', async () => {
+        mockFs({});
+
+        const agentDID = await keymaster.createId('Bob');
+        const group = await keymaster.getPoll(agentDID);
+
+        expect(group).toBe(null);
+    });
+
+    it('should raise an exception if no DID specified', async () => {
+        mockFs({});
+
+        try {
+            await keymaster.getPoll();
+            throw new Error(exceptions.EXPECTED_EXCEPTION);
+        }
+        catch (error) {
+            expect(error.message).toBe(exceptions.INVALID_DID);
+        }
+    });
+});
+
 describe('viewPoll', () => {
 
     afterEach(() => {


### PR DESCRIPTION
Moves poll properties under a `poll` label in the `didDocumentData`

Backwards compatible with existing poll DIDs which will be automatically upgraded if they are updated.
