### PR TITLE
fix: satoshi-mediator startup improvements

### DIFF
--- a/services/mediators/satoshi/src/satoshi-mediator.js
+++ b/services/mediators/satoshi/src/satoshi-mediator.js
@@ -4,6 +4,7 @@ import * as gatekeeper from '@mdip/gatekeeper/sdk';
 import * as keymaster from '@mdip/keymaster/lib';
 import * as wallet from '@mdip/keymaster/db/json';
 import * as cipher from '@mdip/cipher/node';
+import * as exceptions from '@mdip/exceptions';
 import config from './config.js';
 
 const REGISTRY = config.chain;
@@ -395,22 +396,99 @@ async function waitForChain() {
 
     console.log(`Connecting to ${config.chain} node on ${config.host}:${config.port} using wallet '${config.wallet}'`);
 
+    // Step 1: Wait until the blockchain is ready
     while (!isReady) {
         try {
-            const walletInfo = await client.getWalletInfo();
-            console.log(JSON.stringify(walletInfo, null, 4));
+            const blockchainInfo = await client.getBlockchainInfo();
+            console.log("Blockchain Info:", JSON.stringify(blockchainInfo, null, 4));
+            isReady = true; // If the above call succeeds, set isReady to true
+        } catch (error) {
 
-            const address = await client.getNewAddress('funds', 'bech32');
-            console.log(`Send ${config.chain} to ${address}`);
-
-            isReady = true;
-        }
-        catch {
-            console.log(`Waiting for ${config.chain} node...`);
+            if (error.code === 'ECONNREFUSED') {
+                console.log(`Waiting for ${config.chain} node...`);
+            } else {
+                console.error("Error connecting to blockchain:", error);
+            }
         }
 
         if (!isReady) {
             await new Promise(resolve => setTimeout(resolve, 2000));
+        }
+    }
+
+    // Step 2: Create the wallet if it does not already exist
+    try {
+        await client.createWallet(config.wallet);
+        console.log(`Wallet '${config.wallet}' created successfully.`);
+    } catch (error) {
+        // If wallet already exists, log a message
+        if (error.message.includes("already exists")) {
+            console.log(`Wallet '${config.wallet}' already exists.`);
+        } else {
+            console.error("Error creating wallet:", error);
+            return false;
+        }
+    }
+
+    // Step 3: Load the wallet
+    try {
+        await client.loadWallet(config.wallet);
+        console.log(`Wallet '${config.wallet}' loaded successfully.`);
+    } catch (error) {
+        // If wallet is already loaded, log a message
+        if (error.message.includes("already loaded")) {
+            console.log(`Wallet '${config.wallet}' is already loaded.`);
+        } else {
+            console.error("Error loading wallet:", error);
+            return false;
+        }
+    }
+
+    // Step 4: Get wallet info
+    try {
+        const walletInfo = await client.getWalletInfo();
+        console.log("Wallet Info:", JSON.stringify(walletInfo, null, 4));
+    } catch (error) {
+        console.error("Error fetching wallet info:", error);
+        return false;
+    }
+
+    // Step 5: Get a new address
+    try {
+        const address = await client.getNewAddress('funds', 'bech32');
+        console.log(`Send ${config.chain} to address: ${address}`);
+    } catch (error) {
+        console.error("Error generating new address:", error);
+        return false;
+    }
+
+    return true;
+}
+
+async function waitForNodeID() {
+    let isReady = false;
+
+    while (!isReady) {
+        try {
+            await keymaster.resolveDID(config.nodeID);
+            console.log(`Using node ID '${config.nodeID}'`);
+            isReady = true;
+        }
+        catch {
+            try {
+                await keymaster.createId(config.nodeID);
+                console.log(`Created node ID '${config.nodeID}'`);
+                isReady = true;
+            }
+            catch (error) {
+                if (error.message === exceptions.INVALID_PARAMETER) {
+                    console.log(`Waiting for gatekeeper to sync...`);
+                }
+            }
+        }
+
+        if (!isReady) {
+            await new Promise(resolve => setTimeout(resolve, 10000));
         }
     }
 }
@@ -433,7 +511,11 @@ async function main() {
         writeDb(db);
     }
 
-    await waitForChain();
+    const ok = await waitForChain();
+
+    if (!ok) {
+        return;
+    }
 
     await gatekeeper.start({
         url: config.gatekeeperURL,
@@ -441,24 +523,9 @@ async function main() {
         intervalSeconds: 5,
         chatty: true,
     });
+
     await keymaster.start({ gatekeeper, wallet, cipher });
-
-    try {
-        await keymaster.resolveDID(config.nodeID);
-        console.log(`Using node ID '${config.nodeID}'`);
-    }
-    catch {
-        try {
-            await keymaster.createId(config.nodeID);
-            console.log(`Created node ID '${config.nodeID}'`);
-        }
-        catch (error) {
-            console.log(`Cannot create node ID '${config.nodeID}'`, error);
-            return;
-        }
-    }
-
-    console.log(`Using keymaster ID ${config.nodeID}`);
+    await waitForNodeID();
 
     if (config.importInterval > 0) {
         console.log(`Importing operations every ${config.importInterval} minute(s)`);

--- a/services/mediators/satoshi/src/satoshi-mediator.js
+++ b/services/mediators/satoshi/src/satoshi-mediator.js
@@ -400,14 +400,9 @@ async function waitForChain() {
         try {
             const blockchainInfo = await client.getBlockchainInfo();
             console.log("Blockchain Info:", JSON.stringify(blockchainInfo, null, 4));
-            isReady = true; // If the above call succeeds, set isReady to true
+            isReady = true;
         } catch (error) {
-
-            if (error.code === 'ECONNREFUSED') {
-                console.log(`Waiting for ${config.chain} node...`);
-            } else {
-                console.error("Error connecting to blockchain:", error);
-            }
+            console.log(`Waiting for ${config.chain} node...`);
         }
 
         if (!isReady) {

--- a/services/mediators/satoshi/src/satoshi-mediator.js
+++ b/services/mediators/satoshi/src/satoshi-mediator.js
@@ -108,7 +108,7 @@ async function scanBlocks() {
     }
 
     for (let height = start; height <= blockCount; height++) {
-        console.log(height);
+        console.log(`${height}/${blockCount} blocks (${(100 * height / blockCount).toFixed(2)}%)`);
         await fetchBlock(height, blockCount);
         blockCount = await client.getBlockCount();
     }
@@ -396,7 +396,6 @@ async function waitForChain() {
 
     console.log(`Connecting to ${config.chain} node on ${config.host}:${config.port} using wallet '${config.wallet}'`);
 
-    // Step 1: Wait until the blockchain is ready
     while (!isReady) {
         try {
             const blockchainInfo = await client.getBlockchainInfo();
@@ -416,7 +415,6 @@ async function waitForChain() {
         }
     }
 
-    // Step 2: Create the wallet if it does not already exist
     try {
         await client.createWallet(config.wallet);
         console.log(`Wallet '${config.wallet}' created successfully.`);
@@ -430,21 +428,6 @@ async function waitForChain() {
         }
     }
 
-    // Step 3: Load the wallet
-    try {
-        await client.loadWallet(config.wallet);
-        console.log(`Wallet '${config.wallet}' loaded successfully.`);
-    } catch (error) {
-        // If wallet is already loaded, log a message
-        if (error.message.includes("already loaded")) {
-            console.log(`Wallet '${config.wallet}' is already loaded.`);
-        } else {
-            console.error("Error loading wallet:", error);
-            return false;
-        }
-    }
-
-    // Step 4: Get wallet info
     try {
         const walletInfo = await client.getWalletInfo();
         console.log("Wallet Info:", JSON.stringify(walletInfo, null, 4));
@@ -453,7 +436,6 @@ async function waitForChain() {
         return false;
     }
 
-    // Step 5: Get a new address
     try {
         const address = await client.getNewAddress('funds', 'bech32');
         console.log(`Send ${config.chain} to address: ${address}`);

--- a/services/mediators/satoshi/src/satoshi-mediator.js
+++ b/services/mediators/satoshi/src/satoshi-mediator.js
@@ -150,7 +150,7 @@ async function importBatch(item) {
         });
     }
 
-    console.log(JSON.stringify(batch, null, 4));
+    // console.log(JSON.stringify(batch, null, 4));
 
     try {
         item.imported = await gatekeeper.importBatch(batch);


### PR DESCRIPTION
Improves the resilience of satoshi-mediator on startup. After connecting to the blockchain node the mediator will create the wallet if it doesn't already exist (fixes #312). If the mediator can't create or access the wallet it will exit immediately.

Then the mediator will either create the NodeID (agent) if it doesn't exist, or wait for gatekeeper to sync until the NodeID is resolveable (in case the gatekeeper is resyncing from an empty db).