### PR TITLE
refactor: issueCredential

### DIFF
--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -1020,6 +1020,10 @@ export async function bindCredential(schemaId, subjectId, options = {}) {
 export async function issueCredential(credential, options = {}) {
     const id = await fetchIdInfo();
 
+    if (options.schema && options.subject) {
+        credential = await bindCredential(options.schema, options.subject, { credential, ...options });
+    }
+
     if (credential.issuer !== id.did) {
         throw new Error(exceptions.INVALID_PARAMETER);
     }

--- a/python/keymaster_sdk.py
+++ b/python/keymaster_sdk.py
@@ -48,6 +48,10 @@ def createSchema(schema, options={}):
     response = proxy_request('POST', f'{KEYMASTER_API}/schemas', json={"schema": schema, "options": options})
     return response['did']
 
+def createTemplate(schema):
+    response = proxy_request('POST', f'{KEYMASTER_API}/schemas/did/template', json={"schema": schema})
+    return response['template']
+
 def bindCredential(schema, subject, options={}):
     response = proxy_request('POST', f'{KEYMASTER_API}/credentials/bind', json={"schema": schema, "subject": subject, "options": options})
     return response['credential']
@@ -55,3 +59,7 @@ def bindCredential(schema, subject, options={}):
 def issueCredential(credential, options={}):
     response = proxy_request('POST', f'{KEYMASTER_API}/credentials/issued', json={"credential": credential, "options": options})
     return response['did']
+
+def decryptJSON(did):
+    response = proxy_request('POST', f'{KEYMASTER_API}/keys/decrypt/json', json={"did": did})
+    return response['json']

--- a/python/test.py
+++ b/python/test.py
@@ -1,22 +1,22 @@
 import keymaster_sdk as keymaster
 import json
-from datetime import datetime, timedelta
+import argparse
+from datetime import datetime, timedelta, timezone
 
 def main():
+    # Set up argument parsing
+    parser = argparse.ArgumentParser(description="Run Keymaster credential issuance")
+    parser.add_argument('-c', '--credentials', type=int, default=100, help="Number of credentials to issue (default is 100)")
+    args = parser.parse_args()
+
     try:
         ready = keymaster.isReady()
         print(f"Keymaster is ready: {ready}")
 
-        ids = keymaster.listIds()
-        print(f"All IDs: {ids}")
-
         currentId = keymaster.getCurrendId()
         print(f"Current ID: {currentId}")
 
-        docs = keymaster.resolveId(currentId)
-        print(json.dumps(docs, indent=4))
-
-        expires = datetime.now() + timedelta(minutes=1)
+        expires = datetime.now(timezone.utc) + timedelta(minutes=1)
 
         test_options = {
             'registry': 'local',
@@ -25,12 +25,18 @@ def main():
 
         schema = keymaster.createSchema(None, test_options)
 
-        credential = keymaster.bindCredential(schema, currentId)
+        credential = keymaster.createTemplate(schema)
         print(json.dumps(credential, indent=4))
 
-        for i in range(100):
+        test_options['subject'] = currentId
+        test_options['schema'] = schema
+
+        for i in range(args.credentials):
             vcDID = keymaster.issueCredential(credential, test_options)
             print(f"VC {i}: {vcDID}")
+
+            vc = keymaster.decryptJSON(vcDID)
+            print(json.dumps(vc, indent=4))
 
     except Exception as e:
         print(f"Error: {e}")

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -1530,14 +1530,9 @@ describe('issueCredential', () => {
         mockFs({});
 
         await keymaster.createId('Alice');
-        const bob = await keymaster.createId('Bob');
-
-        await keymaster.setCurrentId('Alice');
 
         const schema = await keymaster.createSchema(mockSchema);
         const unboundCredential = await keymaster.createTemplate(schema);
-
-        await keymaster.setCurrentId('Bob');
 
         try {
             await keymaster.issueCredential(unboundCredential);

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -1458,15 +1458,15 @@ describe('issueCredential', () => {
     it('should issue a bound credential when user is issuer', async () => {
         mockFs({});
 
-        const userDid = await keymaster.createId('Bob');
-        const credentialDid = await keymaster.createSchema(mockSchema);
-        const boundCredential = await keymaster.bindCredential(credentialDid, userDid);
+        const subject = await keymaster.createId('Bob');
+        const schema = await keymaster.createSchema(mockSchema);
+        const boundCredential = await keymaster.bindCredential(schema, subject);
 
         const did = await keymaster.issueCredential(boundCredential);
 
         const vc = await keymaster.decryptJSON(did);
-        expect(vc.issuer).toBe(userDid);
-        expect(vc.credentialSubject.id).toBe(userDid);
+        expect(vc.issuer).toBe(subject);
+        expect(vc.credentialSubject.id).toBe(subject);
         expect(vc.credential.email).toEqual(expect.any(String));
 
         const isValid = await keymaster.verifySignature(vc);
@@ -1481,14 +1481,21 @@ describe('issueCredential', () => {
 
         const subject = await keymaster.createId('Bob');
         const schema = await keymaster.createSchema(mockSchema);
-        const credential = await keymaster.createTemplate(schema);
+        const unboundCredential = await keymaster.createTemplate(schema);
 
-        const did = await keymaster.issueCredential(credential, { subject, schema });
+        const now = new Date();
+        const validFrom = now.toISOString();
+        now.setFullYear(now.getFullYear() + 1);
+        const validUntil = now.toISOString();
+
+        const did = await keymaster.issueCredential(unboundCredential, { subject, schema, validFrom, validUntil });
 
         const vc = await keymaster.decryptJSON(did);
         expect(vc.issuer).toBe(subject);
         expect(vc.credentialSubject.id).toBe(subject);
         expect(vc.credential.email).toEqual(expect.any(String));
+        expect(vc.validFrom).toBe(validFrom);
+        expect(vc.validUntil).toBe(validUntil);
 
         const isValid = await keymaster.verifySignature(vc);
         expect(isValid).toBe(true);
@@ -1505,13 +1512,35 @@ describe('issueCredential', () => {
 
         await keymaster.setCurrentId('Alice');
 
-        const credentialDid = await keymaster.createSchema(mockSchema);
-        const boundCredential = await keymaster.bindCredential(credentialDid, bob);
+        const schema = await keymaster.createSchema(mockSchema);
+        const boundCredential = await keymaster.bindCredential(schema, bob);
 
         await keymaster.setCurrentId('Bob');
 
         try {
             await keymaster.issueCredential(boundCredential);
+            throw new Error(exceptions.EXPECTED_EXCEPTION);
+        }
+        catch (error) {
+            expect(error.message).toBe(exceptions.INVALID_PARAMETER);
+        }
+    });
+
+    it('should throw an exception on unbound credential without binding options', async () => {
+        mockFs({});
+
+        await keymaster.createId('Alice');
+        const bob = await keymaster.createId('Bob');
+
+        await keymaster.setCurrentId('Alice');
+
+        const schema = await keymaster.createSchema(mockSchema);
+        const unboundCredential = await keymaster.createTemplate(schema);
+
+        await keymaster.setCurrentId('Bob');
+
+        try {
+            await keymaster.issueCredential(unboundCredential);
             throw new Error(exceptions.EXPECTED_EXCEPTION);
         }
         catch (error) {

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -1476,6 +1476,27 @@ describe('issueCredential', () => {
         expect(wallet.ids['Bob'].owned.includes(did)).toEqual(true);
     });
 
+    it('should bind and issue a credential', async () => {
+        mockFs({});
+
+        const subject = await keymaster.createId('Bob');
+        const schema = await keymaster.createSchema(mockSchema);
+        const credential = await keymaster.createTemplate(schema);
+
+        const did = await keymaster.issueCredential(credential, { subject, schema });
+
+        const vc = await keymaster.decryptJSON(did);
+        expect(vc.issuer).toBe(subject);
+        expect(vc.credentialSubject.id).toBe(subject);
+        expect(vc.credential.email).toEqual(expect.any(String));
+
+        const isValid = await keymaster.verifySignature(vc);
+        expect(isValid).toBe(true);
+
+        const wallet = await keymaster.loadWallet();
+        expect(wallet.ids['Bob'].owned.includes(did)).toEqual(true);
+    });
+
     it('should throw an exception if user is not issuer', async () => {
         mockFs({});
 


### PR DESCRIPTION
Changes the semantics of issueCredential so that it properly handles unbound credentials if (and only if) the credential's schema and subject are specified in the options, like so:

```
const subject = await keymaster.createId('Bob');
const schema = await keymaster.createSchema(mockSchema);
const unboundCredential = await keymaster.createTemplate(schema);

const did = await keymaster.issueCredential(unboundCredential, { subject, schema });
```

Note that the signature of issueCredential (and the corresponding endpoint in the API) are unchanged.