### PR TITLE
fix: Prevent hyperswarm gossip storm

### DIFF
--- a/services/mediators/hyperswarm/src/hyperswarm-mediator.js
+++ b/services/mediators/hyperswarm/src/hyperswarm-mediator.js
@@ -318,7 +318,6 @@ async function receiveMsg(conn, name, json) {
 
     console.log(`received ${msg.type} from: ${shortName(name)} (${msg.node || 'anon'})`);
     connectionLastSeen[name] = new Date().getTime();
-    connectionNodeName[name] = msg.node || 'anon';
 
     if (msg.type === 'batch') {
         if (newBatch(msg.data)) {
@@ -344,6 +343,7 @@ async function receiveMsg(conn, name, json) {
     }
 
     if (msg.type === 'ping') {
+        connectionNodeName[name] = msg.node || 'anon';
         return;
     }
 

--- a/services/mediators/hyperswarm/src/hyperswarm-mediator.js
+++ b/services/mediators/hyperswarm/src/hyperswarm-mediator.js
@@ -298,11 +298,9 @@ function newBatch(batch) {
 
     if (!batchesSeen[hash]) {
         batchesSeen[hash] = true;
-        console.log(`>>> newBatch: ${hash}`);
         return true;
     }
 
-    console.log(`>>> oldBatch: ${hash}`);
     return false;
 }
 
@@ -323,8 +321,8 @@ async function receiveMsg(conn, name, json) {
     connectionNodeName[name] = msg.node || 'anon';
 
     if (msg.type === 'batch') {
-        logBatch(msg.data, msg.node || 'anon');
         if (newBatch(msg.data)) {
+            logBatch(msg.data, msg.node || 'anon');
             importQueue.push({ name, msg });
         }
         return;


### PR DESCRIPTION
The hyperswarm-mediator (once again) tracks the batches that it receives from other nodes via `batch` and `queue` messages, and discards the ones that it has seen before. This doesn't prevent gossip storms caused by nodes running older versions, but new nodes will not make the problem worse. Once all nodes are upgraded, the problem should be mitigated.