### PR TITLE
feat: Re-enable hash check on operations

### DIFF
--- a/doc/mdip/scheme.md
+++ b/doc/mdip/scheme.md
@@ -146,7 +146,7 @@ A DID Update is a change to any of the documents associated with the DID. To ini
         1. `didDocumentMetadata` the document's metadata
         1. `didDocumentData` the document's data
         1. `mdip` the MDIP protocol spec
-    1. `prev` the sha256 hash of the canonicalized JSON of the previous version's doc
+    1. `cid` the CID of the previous operation
 1. Sign the JSON with the private key of the controller of the DID
 1. Submit the operation to the MDIP node. For example, with a REST API, post the operation to the MDIP node's endpoint to update DIDs (e.g. `/api/v1/did/`)
 
@@ -191,7 +191,7 @@ Example update to rotate keys for an agent DID:
             "version": 1
         }
     },
-    "prev": "fb794984f44fe869a75fade8a7bf31ce0f3f46a3eaded4e286769c62f5d9a9ff",
+    "cid": "z3v8Auaa5U9xP6TRzobvzZE7j6N8nkatxW1UuWiay5xrbAR5D9e",
     "signature": {
         "signer": "did:mdip:test:z3v8AuadvRQErtPapNx3ncdUJpPc5dBDGTXXiRxsaH2N8Lj2KzL",
         "signed": "2024-03-25T14:57:26.343Z",
@@ -203,7 +203,7 @@ Example update to rotate keys for an agent DID:
 
 Upon receiving the operation the MDIP node must:
 1. Verify the signature is valid for the controller of the DID.
-1. Verify the previous hash.
+1. Verify the cid is identical to the latest version's operation CID.
 1. Record the operation on the DID specified registry (or forward the request to a trusted node that supports the specified registry).
 
 For registries such as BTC with non-trivial transaction costs, it is expected that update operations will be placed in a queue, then registered periodically in a batch in order to balance costs and latency of updates. If the registry has trivial transaction costs, the update operation may be distributed individually and immediately. MDIP defers this tradeoff between cost, speed, and security to the node operators.
@@ -217,7 +217,7 @@ To revoke a DID, the MDIP client must sign and submit a `delete` operation to th
 1. Create a operation object with these fields in any order:
     1. `type`  must be "delete"
     1. `did` specifies the DID to be deleted
-    1. `prev` the sha256 hash of the canonicalized JSON of the previous version's doc
+    1. `cid` the CID of the previous operation
 1. Sign the JSON with the private key of the controller of the DID
 1. Submit the operation to the MDIP node. For example, with a REST API, post the operation using the `DELETE` method to the MDIP node's endpoint to update DIDs (e.g. `/api/v1/did/`)
 
@@ -227,7 +227,7 @@ Example deletion operation:
 {
     "type": "delete",
     "did": "did:mdip:z3v8AuagQPwk6WhAjauVgkFCBJfHJBVBmNAYEhDNMBEXEmWQrHr",
-    "prev": "9f7f0a67b729248c966bb8945cb80320713aa1de42021c88ca849a4ca029f8d7",
+    "cid": "z3v8AuaWLbUPpU31mCazznLYy6JtTWmgx9QFsDVveDPDU8Na1sJ",
     "signature": {
         "signer": "did:mdip:z3v8Auad6fdVkSZE4khWmMwgTjpoMtv82fiT7c56ivNBdjzeMS2",
         "created": "2024-02-05T20:00:54.171Z",
@@ -239,7 +239,7 @@ Example deletion operation:
 
 Upon receiving the operation the MDIP node must:
 1. Verify the signature is valid for the controller of the DID.
-1. Verify the previous hash.
+1. Verify the cid is identical to the latest version's operation CID.
 1. Record the operation on the DID specified registry (or forward the request to a trusted node that supports the specified registry).
 
 After revocation is confirmed on the DID's registry, resolving the DID will result in response like this:

--- a/doc/mdip/scheme.md
+++ b/doc/mdip/scheme.md
@@ -146,7 +146,7 @@ A DID Update is a change to any of the documents associated with the DID. To ini
         1. `didDocumentMetadata` the document's metadata
         1. `didDocumentData` the document's data
         1. `mdip` the MDIP protocol spec
-    1. `cid` the CID of the previous operation
+    1. `previd` the CID of the previous operation
 1. Sign the JSON with the private key of the controller of the DID
 1. Submit the operation to the MDIP node. For example, with a REST API, post the operation to the MDIP node's endpoint to update DIDs (e.g. `/api/v1/did/`)
 
@@ -191,7 +191,7 @@ Example update to rotate keys for an agent DID:
             "version": 1
         }
     },
-    "cid": "z3v8Auaa5U9xP6TRzobvzZE7j6N8nkatxW1UuWiay5xrbAR5D9e",
+    "previd": "z3v8Auaa5U9xP6TRzobvzZE7j6N8nkatxW1UuWiay5xrbAR5D9e",
     "signature": {
         "signer": "did:mdip:test:z3v8AuadvRQErtPapNx3ncdUJpPc5dBDGTXXiRxsaH2N8Lj2KzL",
         "signed": "2024-03-25T14:57:26.343Z",
@@ -203,7 +203,7 @@ Example update to rotate keys for an agent DID:
 
 Upon receiving the operation the MDIP node must:
 1. Verify the signature is valid for the controller of the DID.
-1. Verify the cid is identical to the latest version's operation CID.
+1. Verify the previd is identical to the latest version's operation CID.
 1. Record the operation on the DID specified registry (or forward the request to a trusted node that supports the specified registry).
 
 For registries such as BTC with non-trivial transaction costs, it is expected that update operations will be placed in a queue, then registered periodically in a batch in order to balance costs and latency of updates. If the registry has trivial transaction costs, the update operation may be distributed individually and immediately. MDIP defers this tradeoff between cost, speed, and security to the node operators.
@@ -217,7 +217,7 @@ To revoke a DID, the MDIP client must sign and submit a `delete` operation to th
 1. Create a operation object with these fields in any order:
     1. `type`  must be "delete"
     1. `did` specifies the DID to be deleted
-    1. `cid` the CID of the previous operation
+    1. `previd` the CID of the previous operation
 1. Sign the JSON with the private key of the controller of the DID
 1. Submit the operation to the MDIP node. For example, with a REST API, post the operation using the `DELETE` method to the MDIP node's endpoint to update DIDs (e.g. `/api/v1/did/`)
 
@@ -227,7 +227,7 @@ Example deletion operation:
 {
     "type": "delete",
     "did": "did:mdip:z3v8AuagQPwk6WhAjauVgkFCBJfHJBVBmNAYEhDNMBEXEmWQrHr",
-    "cid": "z3v8AuaWLbUPpU31mCazznLYy6JtTWmgx9QFsDVveDPDU8Na1sJ",
+    "previd": "z3v8AuaWLbUPpU31mCazznLYy6JtTWmgx9QFsDVveDPDU8Na1sJ",
     "signature": {
         "signer": "did:mdip:z3v8Auad6fdVkSZE4khWmMwgTjpoMtv82fiT7c56ivNBdjzeMS2",
         "created": "2024-02-05T20:00:54.171Z",
@@ -239,7 +239,7 @@ Example deletion operation:
 
 Upon receiving the operation the MDIP node must:
 1. Verify the signature is valid for the controller of the DID.
-1. Verify the cid is identical to the latest version's operation CID.
+1. Verify the previd is identical to the latest version's operation CID.
 1. Record the operation on the DID specified registry (or forward the request to a trusted node that supports the specified registry).
 
 After revocation is confirmed on the DID's registry, resolving the DID will result in response like this:

--- a/packages/gatekeeper/src/db-json-cache.js
+++ b/packages/gatekeeper/src/db-json-cache.js
@@ -89,21 +89,21 @@ export async function addEvent(did, event) {
 }
 
 export async function getEvents(did) {
+    let events = [];
+
     try {
         const db = loadDb();
         const suffix = did.split(':').pop();
         const updates = db.dids[suffix];
 
         if (updates && updates.length > 0) {
-            return updates;
-        }
-        else {
-            return [];
+            events = updates;
         }
     }
     catch {
-        return [];
     }
+
+    return JSON.parse(JSON.stringify(events));
 }
 
 export async function setEvents(did, events) {

--- a/packages/gatekeeper/src/gatekeeper-lib.js
+++ b/packages/gatekeeper/src/gatekeeper-lib.js
@@ -497,6 +497,7 @@ export async function resolveDID(did, options = {}) {
                 throw new InvalidOperationError('signature');
             }
 
+            // TEMP during did:test, operation.cid is optional
             if (operation.cid && operation.cid !== doc.mdip.opcid) {
                 throw new InvalidOperationError('cid');
             }
@@ -688,6 +689,7 @@ async function importEvent(event) {
         const ok = await verifyOperation(event.operation);
 
         if (ok) {
+            // TEMP during did:test, operation.cid is optional
             if (currentEvents.length > 0 && event.operation.cid) {
                 const lastEvent = currentEvents[currentEvents.length-1];
                 const opcid = await generateCID(lastEvent.operation);

--- a/packages/gatekeeper/src/gatekeeper-lib.js
+++ b/packages/gatekeeper/src/gatekeeper-lib.js
@@ -170,8 +170,8 @@ export async function generateCID(operation) {
     return ipfs.add(JSON.parse(canonicalize(operation)));
 }
 
-export async function anchorSeed(seed) {
-    const cid = await generateCID(seed);
+export async function generateDID(operation) {
+    const cid = await generateCID(operation);
     return `${config.didPrefix}:${cid}`;
 }
 
@@ -340,7 +340,7 @@ export async function createDID(operation) {
     const valid = await verifyCreateOperation(operation);
 
     if (valid) {
-        const did = await anchorSeed(operation);
+        const did = await generateDID(operation);
         const ops = await exportDID(did);
 
         // Check to see if we already have this DID in the db
@@ -387,7 +387,7 @@ export async function generateDoc(anchor) {
             return {};
         }
 
-        const did = await anchorSeed(anchor);
+        const did = await generateDID(anchor);
 
         if (anchor.mdip.type === 'agent') {
             // TBD support different key types?
@@ -646,7 +646,7 @@ async function importEvent(event) {
             event.did = event.operation.did;
         }
         else {
-            event.did = await anchorSeed(event.operation);
+            event.did = await generateDID(event.operation);
         }
     }
 

--- a/packages/gatekeeper/src/gatekeeper-lib.js
+++ b/packages/gatekeeper/src/gatekeeper-lib.js
@@ -166,10 +166,12 @@ export async function resetDb() {
     verifiedDIDs = {};
 }
 
+export async function generateCID(operation) {
+    return ipfs.add(JSON.parse(canonicalize(operation)));
+}
+
 export async function anchorSeed(seed) {
-    //console.time('>>ipfs.add');
-    const cid = await ipfs.add(JSON.parse(canonicalize(seed)));
-    //console.timeEnd('>>ipfs.add');
+    const cid = await generateCID(seed);
     return `${config.didPrefix}:${cid}`;
 }
 
@@ -530,6 +532,7 @@ export async function resolveDID(did, options = {}) {
 
             // console.error(`unknown type ${operation.type}`);
         }
+        doc.mdip.opcid = await generateCID(operation);
     }
 
     return copyJSON(doc);

--- a/packages/gatekeeper/src/gatekeeper-lib.js
+++ b/packages/gatekeeper/src/gatekeeper-lib.js
@@ -462,7 +462,7 @@ export async function resolveDID(did, options = {}) {
     doc.didDocumentMetadata.confirmed = confirmed;
 
     for (const { time, operation, registry, blockchain } of events) {
-        const opcid = await generateCID(operation);
+        const opid = await generateCID(operation);
 
         if (operation.type === 'create') {
             if (verify) {
@@ -472,7 +472,7 @@ export async function resolveDID(did, options = {}) {
                     throw new InvalidOperationError('signature');
                 }
             }
-            doc.mdip.opcid = opcid;
+            doc.mdip.opid = opid;
             continue;
         }
 
@@ -497,9 +497,9 @@ export async function resolveDID(did, options = {}) {
                 throw new InvalidOperationError('signature');
             }
 
-            // TEMP during did:test, operation.cid is optional
-            if (operation.cid && operation.cid !== doc.mdip.opcid) {
-                throw new InvalidOperationError('cid');
+            // TEMP during did:test, operation.previd is optional
+            if (operation.previd && operation.previd !== doc.mdip.opid) {
+                throw new InvalidOperationError('previd');
             }
         }
 
@@ -513,7 +513,7 @@ export async function resolveDID(did, options = {}) {
             doc.didDocumentMetadata.updated = time;
             doc.didDocumentMetadata.version = version;
             doc.didDocumentMetadata.confirmed = confirmed;
-            doc.mdip.opcid = opcid;
+            doc.mdip.opid = opid;
 
             if (blockchain) {
                 doc.mdip.registration = blockchain;
@@ -528,7 +528,7 @@ export async function resolveDID(did, options = {}) {
             doc.didDocumentMetadata.deactivated = true;
             doc.didDocumentMetadata.deleted = time;
             doc.didDocumentMetadata.confirmed = confirmed;
-            doc.mdip.opcid = opcid;
+            doc.mdip.opid = opid;
 
             if (blockchain) {
                 doc.mdip.registration = blockchain;
@@ -689,13 +689,13 @@ async function importEvent(event) {
         const ok = await verifyOperation(event.operation);
 
         if (ok) {
-            // TEMP during did:test, operation.cid is optional
-            if (currentEvents.length > 0 && event.operation.cid) {
-                const lastEvent = currentEvents[currentEvents.length-1];
-                const opcid = await generateCID(lastEvent.operation);
+            // TEMP during did:test, operation.previd is optional
+            if (currentEvents.length > 0 && event.operation.previd) {
+                const lastEvent = currentEvents[currentEvents.length - 1];
+                const opid = await generateCID(lastEvent.operation);
 
-                if (opcid !== event.operation.cid) {
-                    throw new InvalidOperationError('cid');
+                if (opid !== event.operation.previd) {
+                    throw new InvalidOperationError('previd');
                 }
             }
 

--- a/packages/gatekeeper/src/gatekeeper-lib.js
+++ b/packages/gatekeeper/src/gatekeeper-lib.js
@@ -496,7 +496,7 @@ export async function resolveDID(did, options = {}) {
             }
 
             if (operation.cid && operation.cid !== doc.mdip.opcid) {
-                throw new InvalidOperationError('opcid');
+                throw new InvalidOperationError('operation.cid');
             }
         }
 

--- a/packages/gatekeeper/src/gatekeeper-lib.js
+++ b/packages/gatekeeper/src/gatekeeper-lib.js
@@ -471,6 +471,7 @@ export async function resolveDID(did, options = {}) {
                     throw new InvalidOperationError('signature');
                 }
             }
+            doc.mdip.opcid = await generateCID(operation);
             continue;
         }
 
@@ -510,6 +511,7 @@ export async function resolveDID(did, options = {}) {
             doc.didDocumentMetadata.version = version;
             doc.didDocumentMetadata.confirmed = confirmed;
             doc.mdip = mdip;
+            doc.mdip.opcid = await generateCID(operation);
 
             if (blockchain) {
                 doc.mdip.registration = blockchain;
@@ -524,6 +526,7 @@ export async function resolveDID(did, options = {}) {
             doc.didDocumentMetadata.deactivated = true;
             doc.didDocumentMetadata.deleted = time;
             doc.didDocumentMetadata.confirmed = confirmed;
+            doc.mdip.opcid = await generateCID(operation);
         }
         else {
             if (verify) {
@@ -532,7 +535,6 @@ export async function resolveDID(did, options = {}) {
 
             // console.error(`unknown type ${operation.type}`);
         }
-        doc.mdip.opcid = await generateCID(operation);
     }
 
     return copyJSON(doc);

--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -318,13 +318,13 @@ async function updateSeedBank(doc) {
     const keypair = await hdKeyPair();
     const did = doc.didDocument.id;
     const current = await gatekeeper.resolveDID(did);
-    const prev = cipher.hashJSON(current);
+    const cid = current.mdip.opcid;
 
     const operation = {
         type: "update",
-        did: did,
-        doc: doc,
-        prev: prev,
+        did,
+        cid,
+        doc,
     };
 
     const msgHash = cipher.hashJSON(operation);
@@ -656,13 +656,13 @@ export async function verifySignature(obj) {
 export async function updateDID(doc) {
     const did = doc.didDocument.id;
     const current = await resolveDID(did);
-    const prev = cipher.hashJSON(current);
+    const cid = current.mdip.opcid;
 
     const operation = {
         type: "update",
-        did: did,
-        doc: doc,
-        prev: prev,
+        did,
+        cid,
+        doc,
     };
 
     const controller = current.didDocument.controller || current.didDocument.id;
@@ -672,12 +672,12 @@ export async function updateDID(doc) {
 
 export async function revokeDID(did) {
     const current = await resolveDID(did);
-    const prev = cipher.hashJSON(current);
+    const cid = current.mdip.opcid;
 
     const operation = {
         type: "delete",
-        did: did,
-        prev: prev,
+        did,
+        cid,
     };
 
     const controller = current.didDocument.controller || current.didDocument.id;
@@ -1238,7 +1238,7 @@ async function findMatchingCredential(credential) {
 }
 
 export async function createResponse(challengeDID, options = {}) {
-    let { retries = 0, delay = 1000} = options;
+    let { retries = 0, delay = 1000 } = options;
 
     if (!options.registry) {
         options.registry = ephemeralRegistry;

--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -318,12 +318,12 @@ async function updateSeedBank(doc) {
     const keypair = await hdKeyPair();
     const did = doc.didDocument.id;
     const current = await gatekeeper.resolveDID(did);
-    const cid = current.mdip.opcid;
+    const previd = current.mdip.opid;
 
     const operation = {
         type: "update",
         did,
-        cid,
+        previd,
         doc,
     };
 
@@ -656,12 +656,12 @@ export async function verifySignature(obj) {
 export async function updateDID(doc) {
     const did = doc.didDocument.id;
     const current = await resolveDID(did);
-    const cid = current.mdip.opcid;
+    const previd = current.mdip.opid;
 
     const operation = {
         type: "update",
         did,
-        cid,
+        previd,
         doc,
     };
 
@@ -672,12 +672,12 @@ export async function updateDID(doc) {
 
 export async function revokeDID(did) {
     const current = await resolveDID(did);
-    const cid = current.mdip.opcid;
+    const previd = current.mdip.opid;
 
     const operation = {
         type: "delete",
         did,
-        cid,
+        previd,
     };
 
     const controller = current.didDocument.controller || current.didDocument.id;

--- a/tests/gatekeeper.test.js
+++ b/tests/gatekeeper.test.js
@@ -1060,7 +1060,7 @@ describe('resolveDID', () => {
             await gatekeeper.resolveDID(did, { verify: true });
             throw new ExpectedExceptionError();
         } catch (error) {
-            expect(error.message).toBe('Invalid operation: operation.cid');
+            expect(error.message).toBe('Invalid operation: cid');
         }
     });
 });
@@ -1969,11 +1969,19 @@ describe('processEvents', () => {
             await gatekeeper.updateDID(updateOp);
         }
 
-        const ops = await gatekeeper.exportDID(did);
+        const events = await gatekeeper.exportDID(did);
 
+        for (let i = 0; i < events.length-1; i++) {
+            const opcid1 = await gatekeeper.generateCID(events[i].operation);
+            const opcid2 = events[i+1].operation.cid;
+            const equal = opcid1 === opcid2;
+            console.log(opcid1, opcid2, equal);
+        }
+
+        await gatekeeper.resolveDID(did, { verify: true });
         await gatekeeper.resetDb();
 
-        const { queued, rejected } = await gatekeeper.importBatch(ops);
+        const { queued, rejected } = await gatekeeper.importBatch(events);
         expect(queued).toBe(N + 1);
         expect(rejected).toBe(0);
 

--- a/tests/gatekeeper.test.js
+++ b/tests/gatekeeper.test.js
@@ -539,7 +539,10 @@ describe('resolveDID', () => {
                 version: 1,
                 confirmed: true,
             },
-            mdip: agentOp.mdip,
+            mdip: {
+                ...agentOp.mdip,
+                opcid: expect.any(String),
+            }
         };
 
         expect(doc).toStrictEqual(expected);
@@ -906,7 +909,10 @@ describe('resolveDID', () => {
                 version: 1,
                 confirmed: true,
             },
-            mdip: assetOp.mdip,
+            mdip: {
+                ...assetOp.mdip,
+                opcid: expect.any(String),
+            }
         };
 
         expect(doc).toStrictEqual(expected);

--- a/tests/gatekeeper.test.js
+++ b/tests/gatekeeper.test.js
@@ -148,7 +148,7 @@ describe('start', () => {
     });
 });
 
-describe('anchorSeed', () => {
+describe('generateDID', () => {
 
     afterEach(() => {
         mockFs.restore();
@@ -164,7 +164,7 @@ describe('anchorSeed', () => {
                 registry: "mockRegistry"
             }
         };
-        const did = await gatekeeper.anchorSeed(mockTxn);
+        const did = await gatekeeper.generateDID(mockTxn);
 
         expect(did.startsWith('did:test:')).toBe(true);
     });
@@ -179,8 +179,8 @@ describe('anchorSeed', () => {
                 registry: "mockRegistry"
             }
         };
-        const did1 = await gatekeeper.anchorSeed(mockTxn);
-        const did2 = await gatekeeper.anchorSeed(mockTxn);
+        const did1 = await gatekeeper.generateDID(mockTxn);
+        const did2 = await gatekeeper.generateDID(mockTxn);
 
         expect(did1 === did2).toBe(true);
     });

--- a/tests/gatekeeper.test.js
+++ b/tests/gatekeeper.test.js
@@ -509,6 +509,7 @@ describe('resolveDID', () => {
 
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
+        const opcid = await gatekeeper.generateCID(agentOp);
         const did = await gatekeeper.createDID(agentOp);
         const doc = await gatekeeper.resolveDID(did);
         const expected = {
@@ -540,7 +541,7 @@ describe('resolveDID', () => {
             },
             mdip: {
                 ...agentOp.mdip,
-                opcid: expect.any(String),
+                opcid,
             }
         };
 
@@ -557,6 +558,7 @@ describe('resolveDID', () => {
         const doc = await gatekeeper.resolveDID(did);
         doc.didDocumentData = { mock: 1 };
         const updateOp = await createUpdateOp(keypair, did, doc);
+        const opcid = await gatekeeper.generateCID(updateOp);
         const ok = await gatekeeper.updateDID(updateOp);
         const updatedDoc = await gatekeeper.resolveDID(did);
         const expected = {
@@ -587,7 +589,7 @@ describe('resolveDID', () => {
             },
             mdip: {
                 ...agentOp.mdip,
-                opcid: expect.any(String),
+                opcid,
             }
         };
 
@@ -670,6 +672,7 @@ describe('resolveDID', () => {
         const update = await gatekeeper.resolveDID(did);
         update.didDocumentData = { mock: 1 };
         const updateOp = await createUpdateOp(keypair, did, update);
+        const opcid = await gatekeeper.generateCID(updateOp);
         const ok = await gatekeeper.updateDID(updateOp);
         const confirmedDoc = await gatekeeper.resolveDID(did, { confirm: true });
 
@@ -701,7 +704,7 @@ describe('resolveDID', () => {
             },
             mdip: {
                 ...agentOp.mdip,
-                opcid: expect.any(String),
+                opcid,
             }
         };
 
@@ -720,6 +723,7 @@ describe('resolveDID', () => {
         const update = await gatekeeper.resolveDID(did);
         update.didDocumentData = { mock: 1 };
         const updateOp = await createUpdateOp(keypair, did, update);
+        const opcid = await gatekeeper.generateCID(updateOp);
         const ok = await gatekeeper.updateDID(updateOp);
         const verifiedDoc = await gatekeeper.resolveDID(did, { verify: true });
 
@@ -751,7 +755,7 @@ describe('resolveDID', () => {
             },
             mdip: {
                 ...agentOp.mdip,
-                opcid: expect.any(String),
+                opcid,
             }
         };
 
@@ -769,6 +773,7 @@ describe('resolveDID', () => {
         const update = await gatekeeper.resolveDID(did);
         update.didDocumentData = { mock: 1 };
         const updateOp = await createUpdateOp(keypair, did, update);
+        const opcid = await gatekeeper.generateCID(updateOp);
         const ok = await gatekeeper.updateDID(updateOp);
         const updatedDoc = await gatekeeper.resolveDID(did, { confirm: false });
         const expected = {
@@ -799,7 +804,7 @@ describe('resolveDID', () => {
             },
             mdip: {
                 ...agentOp.mdip,
-                opcid: expect.any(String),
+                opcid,
             }
         };
 
@@ -890,6 +895,7 @@ describe('resolveDID', () => {
         const agentOp = await createAgentOp(keypair);
         const agent = await gatekeeper.createDID(agentOp);
         const assetOp = await createAssetOp(agent, keypair);
+        const opcid = await gatekeeper.generateCID(assetOp);
         const did = await gatekeeper.createDID(assetOp);
         const doc = await gatekeeper.resolveDID(did);
         const expected = {
@@ -909,7 +915,7 @@ describe('resolveDID', () => {
             },
             mdip: {
                 ...assetOp.mdip,
-                opcid: expect.any(String),
+                opcid,
             }
         };
 
@@ -1080,11 +1086,12 @@ describe('updateDID', () => {
         const doc = await gatekeeper.resolveDID(did);
         doc.didDocumentData = { mock: 1 };
         const updateOp = await createUpdateOp(keypair, did, doc);
+        const opcid = await gatekeeper.generateCID(updateOp);
         const ok = await gatekeeper.updateDID(updateOp);
         const updatedDoc = await gatekeeper.resolveDID(did);
         doc.didDocumentMetadata.updated = expect.any(String);
         doc.didDocumentMetadata.version = 2;
-        doc.mdip.opcid = expect.any(String);
+        doc.mdip.opcid = opcid;
 
         expect(ok).toBe(true);
         expect(updatedDoc).toStrictEqual(doc);

--- a/tests/gatekeeper.test.js
+++ b/tests/gatekeeper.test.js
@@ -1977,18 +1977,9 @@ describe('processEvents', () => {
         }
 
         const events = await gatekeeper.exportDID(did);
-
-        for (let i = 0; i < events.length-1; i++) {
-            const opcid1 = await gatekeeper.generateCID(events[i].operation);
-            const opcid2 = events[i+1].operation.cid;
-            const equal = opcid1 === opcid2;
-            console.log(opcid1, opcid2, equal);
-        }
-
-        await gatekeeper.resolveDID(did, { verify: true });
         await gatekeeper.resetDb();
-
         const { queued, rejected } = await gatekeeper.importBatch(events);
+        
         expect(queued).toBe(N + 1);
         expect(rejected).toBe(0);
 

--- a/tests/gatekeeper.test.js
+++ b/tests/gatekeeper.test.js
@@ -54,6 +54,7 @@ async function createAgentOp(keypair, version = 1, registry = 'local') {
 async function createUpdateOp(keypair, did, doc) {
     const current = await gatekeeper.resolveDID(did);
     const prev = cipher.hashJSON(current);
+    //const prevop = current.mdip.opcid;
 
     const operation = {
         type: "update",
@@ -554,6 +555,7 @@ describe('resolveDID', () => {
         const doc = await gatekeeper.resolveDID(did);
         doc.didDocumentData = { mock: 1 };
         const updateOp = await createUpdateOp(keypair, did, doc);
+        const updateOpCID = await gatekeeper.generateCID(updateOp);
         const ok = await gatekeeper.updateDID(updateOp);
         const updatedDoc = await gatekeeper.resolveDID(did);
         const expected = {
@@ -582,7 +584,10 @@ describe('resolveDID', () => {
                 version: 2,
                 confirmed: true,
             },
-            mdip: agentOp.mdip,
+            mdip: {
+                ...agentOp.mdip,
+                opcid: expect.any(String),
+            }
         };
 
         expect(ok).toBe(true);
@@ -693,7 +698,10 @@ describe('resolveDID', () => {
                 version: 2,
                 confirmed: true,
             },
-            mdip: agentOp.mdip,
+            mdip: {
+                ...agentOp.mdip,
+                opcid: expect.any(String),
+            }
         };
 
         expect(ok).toBe(true);
@@ -740,7 +748,10 @@ describe('resolveDID', () => {
                 version: 2,
                 confirmed: true,
             },
-            mdip: agentOp.mdip,
+            mdip: {
+                ...agentOp.mdip,
+                opcid: expect.any(String),
+            }
         };
 
         expect(ok).toBe(true);
@@ -785,7 +796,10 @@ describe('resolveDID', () => {
                 version: 2,
                 confirmed: false,
             },
-            mdip: agentOp.mdip,
+            mdip: {
+                ...agentOp.mdip,
+                opcid: expect.any(String),
+            }
         };
 
         expect(ok).toBe(true);
@@ -994,6 +1008,7 @@ describe('updateDID', () => {
         const updatedDoc = await gatekeeper.resolveDID(did);
         doc.didDocumentMetadata.updated = expect.any(String);
         doc.didDocumentMetadata.version = 2;
+        doc.mdip.opcid = expect.any(String);
 
         expect(ok).toBe(true);
         expect(updatedDoc).toStrictEqual(doc);


### PR DESCRIPTION
Adds a `previd` property to all update and delete operations that references the CID of the latest version's operation (replacing the unused `prev` property). This new property is used to verify that the operation is applied to specified version.

The operation cid is also included as `mdip.opid` in every resolved DID.

Also includes a fix for an issued discovered during testing in getEvents() in db-json-cache. The fix ensures a copy of the events is returned instead of a mutable reference.
