### PR TITLE
chore: add tbtc dockerfile to project

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -59,6 +59,9 @@ jobs:
           - dockerfile: Dockerfile.ipfs
             tags: |
               ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/ipfs-mediator:${{ needs.generate.outputs.CALVER }}
+          - dockerfile: Dockerfile.tbtc
+            tags: |
+              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/tbtc-node:${{ needs.generate.outputs.CALVER }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,6 +60,9 @@ jobs:
           - dockerfile: Dockerfile.ipfs
             tags: |
               ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/ipfs-mediator:release
+          - dockerfile: Dockerfile.tbtc
+            tags: |
+              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/tbtc-node:release
     permissions:
       contents: read
       packages: write

--- a/Dockerfile.tbtc
+++ b/Dockerfile.tbtc
@@ -7,7 +7,7 @@ RUN \
         apt-get install -y build-essential libtool autotools-dev automake pkg-config bsdmainutils && \
 	apt-get install -y libboost-dev libboost-system-dev libboost-filesystem-dev libboost-test-dev libboost-thread-dev && \
 	apt-get install -y libssl-dev libevent-dev libsqlite3-dev libminiupnpc-dev libzmq3-dev
-RUN git clone https://github.com/bitcoin/bitcoin.git
+RUN git clone -b 27.x https://github.com/bitcoin/bitcoin.git
 WORKDIR /bitcoin
 RUN ./autogen.sh
 RUN ./configure --enable-wallet --disable-tests --disable-bench

--- a/Dockerfile.tbtc
+++ b/Dockerfile.tbtc
@@ -1,0 +1,20 @@
+FROM ubuntu:22.04
+RUN \
+        apt-get update && \
+        apt-get install -y software-properties-common && \
+        apt-get install -y apt-utils && \
+        apt-get install -y git vim less python3 && \
+        apt-get install -y build-essential libtool autotools-dev automake pkg-config bsdmainutils && \
+	apt-get install -y libboost-dev libboost-system-dev libboost-filesystem-dev libboost-test-dev libboost-thread-dev && \
+	apt-get install -y libssl-dev libevent-dev libsqlite3-dev libminiupnpc-dev libzmq3-dev
+RUN git clone https://github.com/bitcoin/bitcoin.git
+WORKDIR /bitcoin
+RUN ./autogen.sh
+RUN ./configure --enable-wallet --disable-tests --disable-bench
+RUN make
+RUN make install
+RUN strip /usr/local/bin/bitcoin*
+RUN rm -rf /bitcoin
+WORKDIR /root
+RUN mkdir /root/.bitcoin
+CMD ["bitcoind", "-printtoconsole"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,10 @@ services:
       - gatekeeper
 
   tbtc-node:
-    image: macterra/bitcoin-core:v27.99.0-2f7d9aec4d04
+    build:
+      context: .
+      dockerfile: Dockerfile.tbtc
+    image: keychainmdip/tbtc-node
     volumes:
       - ./data/tbtc:/root/.bitcoin
 


### PR DESCRIPTION
This adds the tbtc-node to the project and docker registry for consumption. Also updated the docker-compose file for running it locally.