### PR TITLE
feat: Added encrypted wallet support to services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
     environment:
       - KC_KEYMASTER_PORT=4226
       - KC_GATEKEEPER_URL=http://gatekeeper:4224
+      - KC_ENCRYPTED_PASSPHRASE=${KC_ENCRYPTED_PASSPHRASE}
     volumes:
       - ./data:/app/keymaster/data
     user: "${KC_UID}:${KC_GID}"
@@ -82,6 +83,7 @@ services:
     environment:
       - KC_GATEKEEPER_URL=http://gatekeeper:4224
       - KC_NODE_ID=${KC_NODE_ID}
+      - KC_ENCRYPTED_PASSPHRASE=${KC_ENCRYPTED_PASSPHRASE}
       - KC_SAT_CHAIN=TFTC
       - KC_SAT_NETWORK=testnet
       - KC_SAT_START_BLOCK=0
@@ -116,6 +118,7 @@ services:
     environment:
       - KC_GATEKEEPER_URL=http://gatekeeper:4224
       - KC_NODE_ID=${KC_NODE_ID}
+      - KC_ENCRYPTED_PASSPHRASE=${KC_ENCRYPTED_PASSPHRASE}
       - KC_SAT_CHAIN=TBTC
       - KC_SAT_NETWORK=testnet
       - KC_SAT_HOST=tbtc-node

--- a/packages/keymaster/src/db-wallet-json-enc.js
+++ b/packages/keymaster/src/db-wallet-json-enc.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import crypto from 'crypto';
 
 const dataFolder = 'data';
-const walletName = `${dataFolder}/wallet-enc.json`;
+const walletName = `${dataFolder}/wallet.json`;
 
 const algorithm = 'aes-256-cbc';       // Algorithm
 const keyLength = 32;                 // 256 bit AES-256

--- a/packages/keymaster/src/db-wallet-json.js
+++ b/packages/keymaster/src/db-wallet-json.js
@@ -25,7 +25,7 @@ export function loadWallet() {
     const walletData = JSON.parse(walletJson);
 
     if (walletData && walletData.salt && walletData.iv && walletData.data) {
-        throw new Error('Wallet encrypted but KC_ENCRYPTED_PASSPHRASE not set');
+        throw new Error('Wallet is encrypted');
     }
 
     return walletData;

--- a/scripts/keychain-cli.js
+++ b/scripts/keychain-cli.js
@@ -5,7 +5,7 @@ import dotenv from 'dotenv';
 import * as gatekeeper_sdk from '@mdip/gatekeeper/sdk';
 import * as keymaster_lib from '@mdip/keymaster/lib';
 import * as keymaster_sdk from '@mdip/keymaster/sdk';
-import * as db_wallet from '@mdip/keymaster/db/json';
+import * as db_wallet_json from '@mdip/keymaster/db/json';
 import * as db_wallet_enc from '@mdip/keymaster/db/json/enc';
 import * as cipher from '@mdip/cipher/node';
 
@@ -949,14 +949,17 @@ program
             }
 
             db_wallet_enc.setPassphrase(keymasterPassphrase);
-            const wallet = db_wallet.loadWallet();
+            const wallet = db_wallet_json.loadWallet();
 
             if (wallet === null) {
                 await keymaster.newWallet();
             } else {
-                const result = db_wallet_enc.saveWallet(wallet);
-                if (!result) {
-                    console.error('Encrypted wallet file already exists');
+                const ok = db_wallet_enc.saveWallet(wallet, true);
+                if (ok) {
+                    console.log(UPDATE_OK);
+                }
+                else {
+                    console.log(UPDATE_FAILED);
                 }
             }
         } catch (error) {
@@ -1007,7 +1010,7 @@ function getDBWallet() {
         db_wallet_enc.setPassphrase(keymasterPassphrase);
         return db_wallet_enc;
     }
-    return db_wallet;
+    return db_wallet_json;
 }
 
 async function run() {

--- a/services/keymaster/server/src/config.js
+++ b/services/keymaster/server/src/config.js
@@ -5,6 +5,7 @@ dotenv.config();
 const config = {
     gatekeeperURL: process.env.KC_GATEKEEPER_URL || 'http://localhost:4224',
     keymasterPort: process.env.KC_KEYMASTER_PORT ? parseInt(process.env.KC_KEYMASTER_PORT) : 4226,
+    keymasterPassphrase: process.env.KC_ENCRYPTED_PASSPHRASE,
 };
 
 export default config;

--- a/services/keymaster/server/src/keymaster-api.js
+++ b/services/keymaster/server/src/keymaster-api.js
@@ -8,7 +8,6 @@ import * as wallet_json from '@mdip/keymaster/db/json';
 import * as wallet_enc from '@mdip/keymaster/db/json/enc';
 import * as cipher from '@mdip/cipher/node';
 import config from './config.js';
-import { exit } from 'process';
 const app = express();
 const v1router = express.Router();
 

--- a/services/mediators/satoshi/src/config.js
+++ b/services/mediators/satoshi/src/config.js
@@ -5,6 +5,7 @@ dotenv.config();
 const config = {
     nodeID: process.env.KC_NODE_ID,
     gatekeeperURL: process.env.KC_GATEKEEPER_URL || 'http://localhost:4224',
+    keymasterPassphrase: process.env.KC_ENCRYPTED_PASSPHRASE,
     chain: process.env.KC_SAT_CHAIN || 'BTC',
     network: process.env.KC_SAT_NETWORK || 'mainnet',
     host: process.env.KC_SAT_HOST || 'localhost',

--- a/services/mediators/satoshi/src/satoshi-mediator.js
+++ b/services/mediators/satoshi/src/satoshi-mediator.js
@@ -2,7 +2,8 @@ import fs from 'fs';
 import BtcClient from 'bitcoin-core';
 import * as gatekeeper from '@mdip/gatekeeper/sdk';
 import * as keymaster from '@mdip/keymaster/lib';
-import * as wallet from '@mdip/keymaster/db/json';
+import * as wallet_json from '@mdip/keymaster/db/json';
+import * as wallet_enc from '@mdip/keymaster/db/json/enc';
 import * as cipher from '@mdip/cipher/node';
 import config from './config.js';
 import { InvalidParameterError } from '@mdip/common/errors';
@@ -500,6 +501,13 @@ async function main() {
         intervalSeconds: 5,
         chatty: true,
     });
+
+    let wallet = wallet_json;
+
+    if (config.keymasterPassphrase) {
+        wallet_enc.setPassphrase(config.keymasterPassphrase);
+        wallet = wallet_enc;
+    }
 
     await keymaster.start({ gatekeeper, wallet, cipher });
     await waitForNodeID();

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -138,7 +138,7 @@ describe('loadWallet', () => {
             throw new ExpectedExceptionError();
         } catch (error) {
             expect(ok).toBe(true);
-            expect(error.message).toBe('Wallet encrypted but KC_ENCRYPTED_PASSPHRASE not set');
+            expect(error.message).toBe('Wallet is encrypted');
         }
     });
 
@@ -301,7 +301,7 @@ describe('saveWallet', () => {
             'data': {}
         });
 
-        const walletFile = 'data/wallet-enc.json';
+        const walletFile = 'data/wallet.json';
         const mockWallet = { mock: 1 };
         fs.writeFileSync(walletFile, JSON.stringify(mockWallet, null, 4));
 


### PR DESCRIPTION
Adds encrypted wallet support to keymaster-api and satoshi-mediator. Also changes the CLI `encrypt-wallet` command to encrypt the wallet in-place (same file).

Procedure to switch to encrypted server wallet:
1. `./stop-node` 
1. `cp data/wallet.json ~` to backup the current wallet file to your home directory
1. Add `KC_ENCRYPTED_PASSPHRASE="your secret passphrase"` to your .env file
1. `./start-node gatekeeper` to start just the gatekeeper service
1. `./kc encrypt-wallet` (should return OK)
1. `./stop-node`
1. `./start-node gatekeeper keymaster` and check keymaster log for errors
1. `./stop-node`
1. `./start-node`

Procedure to switch back to unencrypted wallet:
1. `./kc show-wallet > unencrypted.json`
1. `./stop-node`
1. Set `KC_ENCRYPTED_PASSPHRASE=""` in your .env file
1. `mv unencrypted.json data/wallet.json`
1. `./start-node`