### PR TITLE
fix: update api and mediator to set wallet when using encryption

### DIFF
--- a/services/keymaster/server/src/keymaster-api.js
+++ b/services/keymaster/server/src/keymaster-api.js
@@ -694,6 +694,7 @@ app.listen(port, async () => {
 
     if (config.keymasterPassphrase) {
         wallet_enc.setPassphrase(config.keymasterPassphrase);
+        wallet_enc.setWallet(wallet);
         wallet = wallet_enc;
     }
 

--- a/services/mediators/satoshi/src/satoshi-mediator.js
+++ b/services/mediators/satoshi/src/satoshi-mediator.js
@@ -506,6 +506,7 @@ async function main() {
 
     if (config.keymasterPassphrase) {
         wallet_enc.setPassphrase(config.keymasterPassphrase);
+        wallet_enc.setWallet(wallet);
         wallet = wallet_enc;
     }
 


### PR DESCRIPTION
Call to setWallet() when using encryption is missing on the API and Satoshi mediator.