### PR TITLE
feat: Added gatekeeper status

### DIFF
--- a/packages/gatekeeper/src/gatekeeper-lib.js
+++ b/packages/gatekeeper/src/gatekeeper-lib.js
@@ -117,11 +117,16 @@ export async function verifyDb(options = {}) {
 }
 
 export async function checkDIDs(options = {}) {
-    const { chatty = false } = options;
-    const dids = await getDIDs();
+    let { chatty = false, dids } = options;
+
+    if (!dids) {
+        dids = await getDIDs();
+    }
+
     const total = dids.length;
     let n = 0;
     let ephemeral = 0;
+    let invalid = 0;
     const byRegistry = {};
 
     for (const did of dids) {
@@ -144,13 +149,14 @@ export async function checkDIDs(options = {}) {
             }
         }
         catch (error) {
+            invalid += 1;
             if (chatty) {
                 console.log(`can't resolve ${n}/${total} ${did} ${error}`);
             }
         }
     }
 
-    return { total, ephemeral, byRegistry };
+    return { total, ephemeral, invalid, byRegistry };
 }
 
 export async function initRegistries(csvRegistries) {

--- a/packages/gatekeeper/src/gatekeeper-lib.js
+++ b/packages/gatekeeper/src/gatekeeper-lib.js
@@ -116,7 +116,7 @@ export async function verifyDb(options = {}) {
     return { total, verified, expired, invalid };
 }
 
-export async function checkDb(options = {}) {
+export async function checkDIDs(options = {}) {
     const { chatty = false } = options;
     const dids = await getDIDs();
     const total = dids.length;

--- a/packages/gatekeeper/src/gatekeeper-sdk.js
+++ b/packages/gatekeeper/src/gatekeeper-sdk.js
@@ -107,6 +107,16 @@ export async function getVersion() {
     }
 }
 
+export async function getStatus() {
+    try {
+        const response = await axios.get(`${API}/status`);
+        return response.data;
+    }
+    catch (error) {
+        throwError(error);
+    }
+}
+
 export async function createDID(operation) {
     try {
         const response = await axios.post(`${API}/did/`, operation);

--- a/scripts/admin-cli.js
+++ b/scripts/admin-cli.js
@@ -441,6 +441,19 @@ program
         }
     });
 
+program
+    .command('get-status')
+    .description('Report gatekeeper status')
+    .action(async () => {
+        try {
+            const response = await gatekeeper.getStatus();
+            console.log(JSON.stringify(response, null, 4));
+        }
+        catch (error) {
+            console.error(error);
+        }
+    });
+
 async function run() {
     gatekeeper.start({ url: gatekeeperURL });
     await keymaster.start({ gatekeeper, wallet, cipher });

--- a/services/gatekeeper/server/src/gatekeeper-api.js
+++ b/services/gatekeeper/server/src/gatekeeper-api.js
@@ -271,9 +271,9 @@ async function gcLoop() {
 let didCheck;
 
 async function main() {
-    console.time('checkDb');
-    didCheck = await gatekeeper.checkDb({ chatty: true });
-    console.timeEnd('checkDb');
+    console.time('checkDIDs');
+    didCheck = await gatekeeper.checkDIDs({ chatty: true });
+    console.timeEnd('checkDIDs');
     console.log(`check: ${JSON.stringify(didCheck)}`);
 
     console.log(`Starting DID garbage collection in ${config.gcInterval} minutes`);

--- a/services/gatekeeper/server/src/gatekeeper-api.js
+++ b/services/gatekeeper/server/src/gatekeeper-api.js
@@ -298,6 +298,7 @@ async function reportStatus() {
         console.log(`    ${registry}: ${status.dids.byRegistry[registry]}`);
     }
     console.log(`  Ephemeral: ${status.dids.ephemeral}`);
+    console.log(`  Invalid: ${status.dids.invalid}`);
 
     console.log('Memory Usage Report:');
     console.log(`  RSS: ${formatBytes(status.memoryUsage.rss)} (Resident Set Size - total memory allocated for the process)`);

--- a/services/gatekeeper/server/src/gatekeeper-api.js
+++ b/services/gatekeeper/server/src/gatekeeper-api.js
@@ -370,7 +370,7 @@ function formatBytes(bytes) {
 async function main() {
     console.log(`Starting Gatekeeper with a db (${config.db}) check...`);
     await reportStatus();
-    setInterval(reportStatus, 5 * 60 * 1000);
+    setInterval(reportStatus, 60 * 1000);
 
     console.log(`Starting DID garbage collection in ${config.gcInterval} minutes`);
     setTimeout(gcLoop, config.gcInterval * 60 * 1000);

--- a/services/gatekeeper/server/src/gatekeeper-api.js
+++ b/services/gatekeeper/server/src/gatekeeper-api.js
@@ -298,7 +298,7 @@ process.on('unhandledRejection', (reason, promise) => {
 
 function getStatus() {
     return {
-        uptime: Math.floor((new Date() - startTime) / 1000),
+        uptimeSeconds: Math.floor((new Date() - startTime) / 1000),
         memoryUsage: process.memoryUsage()
     };
 }
@@ -307,7 +307,7 @@ function reportStatus() {
     const status = getStatus();
     const memoryUsage = status.memoryUsage;
 
-    console.log(`Uptime: ${status.uptime}s (${formatDuration(status.uptime)})`);
+    console.log(`Uptime: ${status.uptimeSeconds}s (${formatDuration(status.uptimeSeconds)})`);
     console.log('Memory Usage Report:');
     console.log(`  RSS: ${formatBytes(memoryUsage.rss)} (Resident Set Size - total memory allocated for the process)`);
     console.log(`  Heap Total: ${formatBytes(memoryUsage.heapTotal)} (Total heap allocated)`);

--- a/tests/gatekeeper.test.js
+++ b/tests/gatekeeper.test.js
@@ -2626,6 +2626,26 @@ describe('checkDIDs', () => {
 
         expect(check.total).toBe(2);
         expect(check.ephemeral).toBe(1);
+        expect(check.invalid).toBe(0);
+    });
+
+    it('should report invalid DIDs', async () => {
+        mockFs({});
+
+        const keypair = cipher.generateRandomJwk();
+        const agentOp = await createAgentOp(keypair);
+        const agentDID = await gatekeeper.createDID(agentOp);
+        const assetOp = await createAssetOp(agentDID, keypair);
+        await gatekeeper.createDID(assetOp);
+
+        const dids = await gatekeeper.getDIDs();
+        dids.push('mock');
+
+        const check = await gatekeeper.checkDIDs({ chatty: true, dids });
+
+        expect(check.total).toBe(3);
+        expect(check.ephemeral).toBe(0);
+        expect(check.invalid).toBe(1);
     });
 
     it('should reset a corrupted db', async () => {

--- a/tests/gatekeeper.test.js
+++ b/tests/gatekeeper.test.js
@@ -2608,7 +2608,7 @@ describe('verifyDb', () => {
     });
 });
 
-describe('checkDb', () => {
+describe('checkDIDs', () => {
     afterEach(() => {
         mockFs.restore();
     });
@@ -2622,7 +2622,7 @@ describe('checkDb', () => {
         const assetOp = await createAssetOp(agentDID, keypair);
         await gatekeeper.createDID(assetOp);
 
-        const { total } = await gatekeeper.checkDb();
+        const { total } = await gatekeeper.checkDIDs();
 
         expect(total).toBe(2);
     });
@@ -2638,7 +2638,7 @@ describe('checkDb', () => {
 
         fs.writeFileSync('data/test.json', "{ dids: {");
 
-        const { total } = await gatekeeper.checkDb();
+        const { total } = await gatekeeper.checkDIDs();
 
         expect(total).toBe(0);
     });

--- a/tests/gatekeeper.test.js
+++ b/tests/gatekeeper.test.js
@@ -2619,12 +2619,13 @@ describe('checkDIDs', () => {
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agentDID = await gatekeeper.createDID(agentOp);
-        const assetOp = await createAssetOp(agentDID, keypair);
+        const assetOp = await createAssetOp(agentDID, keypair, 'local', new Date().toISOString());
         await gatekeeper.createDID(assetOp);
 
-        const { total } = await gatekeeper.checkDIDs();
+        const check = await gatekeeper.checkDIDs({ chatty: true });
 
-        expect(total).toBe(2);
+        expect(check.total).toBe(2);
+        expect(check.ephemeral).toBe(1);
     });
 
     it('should reset a corrupted db', async () => {


### PR DESCRIPTION
Adds `GET /status` to the gatekeeper endpoints. The command `./admin get-status` can be used to see the results:

```bash
$ ./admin get-status
{
    "uptimeSeconds": 1165,
    "dids": {
        "total": 10545,
        "ephemeral": 3,
        "invalid": 0,
        "byRegistry": {
            "TFTC": 3106,
            "hyperswarm": 1719,
            "TBTC": 3117,
            "TESS": 2579,
            "local": 24
        }
    },
    "memoryUsage": {
        "rss": 220835840,
        "heapTotal": 78938112,
        "heapUsed": 44739752,
        "external": 23612780,
        "arrayBuffers": 21134862
    }
}
```

gatekeeper will log the status every minute:
```
gatekeeper-1  | Status -----------------------------
gatekeeper-1  | DID Database:
gatekeeper-1  |   Total: 10545
gatekeeper-1  |   By registry:
gatekeeper-1  |     TFTC: 3106
gatekeeper-1  |     hyperswarm: 1719
gatekeeper-1  |     TBTC: 3117
gatekeeper-1  |     TESS: 2579
gatekeeper-1  |     local: 24
gatekeeper-1  |   Ephemeral: 3
gatekeeper-1  |   Invalid: 0
gatekeeper-1  | Memory Usage Report:
gatekeeper-1  |   RSS: 213.18 MB (Resident Set Size - total memory allocated for the process)
gatekeeper-1  |   Heap Total: 76.28 MB (Total heap allocated)
gatekeeper-1  |   Heap Used: 48.75 MB (Heap actually used)
gatekeeper-1  |   External: 22.99 MB (Memory used by C++ objects bound to JavaScript)
gatekeeper-1  |   Array Buffers: 20.63 MB (Memory used by ArrayBuffer and SharedArrayBuffer)
gatekeeper-1  | Uptime: 1089s (18 minutes, 9 seconds)
```