### PR TITLE
feat: Added db and versions to status

### DIFF
--- a/packages/gatekeeper/src/gatekeeper-lib.js
+++ b/packages/gatekeeper/src/gatekeeper-lib.js
@@ -126,6 +126,7 @@ export async function checkDIDs(options = {}) {
     const total = dids.length;
     let n = 0;
     let confirmed = 0;
+    let unconfirmed = 0;
     let ephemeral = 0;
     let invalid = 0;
     const byRegistry = {};
@@ -141,6 +142,9 @@ export async function checkDIDs(options = {}) {
 
             if (doc.didDocumentMetadata.confirmed) {
                 confirmed += 1;
+            }
+            else {
+                unconfirmed += 1;
             }
 
             if (doc.mdip.validUntil) {
@@ -161,7 +165,7 @@ export async function checkDIDs(options = {}) {
         }
     }
 
-    return { total, confirmed, ephemeral, invalid, byRegistry, byVersion };
+    return { total, confirmed, unconfirmed, ephemeral, invalid, byRegistry, byVersion };
 }
 
 export async function initRegistries(csvRegistries) {

--- a/packages/gatekeeper/src/gatekeeper-lib.js
+++ b/packages/gatekeeper/src/gatekeeper-lib.js
@@ -125,9 +125,11 @@ export async function checkDIDs(options = {}) {
 
     const total = dids.length;
     let n = 0;
+    let confirmed = 0;
     let ephemeral = 0;
     let invalid = 0;
     const byRegistry = {};
+    const byVersion = {};
 
     for (const did of dids) {
         n += 1;
@@ -137,16 +139,19 @@ export async function checkDIDs(options = {}) {
                 console.log(`resolved ${n}/${total} ${did} OK`);
             }
 
+            if (doc.didDocumentMetadata.confirmed) {
+                confirmed += 1;
+            }
+
             if (doc.mdip.validUntil) {
                 ephemeral += 1;
             }
 
-            if (byRegistry[doc.mdip.registry]) {
-                byRegistry[doc.mdip.registry] += 1;
-            }
-            else {
-                byRegistry[doc.mdip.registry] = 1;
-            }
+            const registry = doc.mdip.registry;
+            byRegistry[registry] = (byRegistry[registry] || 0) + 1;
+
+            const version = doc.didDocumentMetadata.version;
+            byVersion[version] = (byVersion[version] || 0) + 1;
         }
         catch (error) {
             invalid += 1;
@@ -156,7 +161,7 @@ export async function checkDIDs(options = {}) {
         }
     }
 
-    return { total, ephemeral, invalid, byRegistry };
+    return { total, confirmed, ephemeral, invalid, byRegistry, byVersion };
 }
 
 export async function initRegistries(csvRegistries) {

--- a/services/gatekeeper/server/src/gatekeeper-api.js
+++ b/services/gatekeeper/server/src/gatekeeper-api.js
@@ -262,6 +262,7 @@ async function gcLoop() {
     try {
         const response = await gatekeeper.verifyDb();
         console.log(`DID garbage collection: ${JSON.stringify(response)} waiting ${config.gcInterval} minutes...`);
+        await checkDids();
     }
     catch (error) {
         console.error(`Error in DID garbage collection: ${error}`);
@@ -293,11 +294,23 @@ async function reportStatus() {
 
     console.log(`DID Database (${config.db}):`);
     console.log(`  Total: ${status.dids.total}`);
+
     console.log(`  By registry:`);
     const registries = Object.keys(status.dids.byRegistry).sort();
     for (let registry of registries) {
         console.log(`    ${registry}: ${status.dids.byRegistry[registry]}`);
     }
+
+    console.log(`  By version:`);
+    let count = 0;
+    for (let version of [1, 2, 3, 4, 5]) {
+        const num = status.dids.byVersion[version];
+        console.log(`    ${version}: ${num}`);
+        count += num;
+    }
+    console.log(`    6+: ${status.dids.total - count}`);
+
+    console.log(`  Confirmed: ${status.dids.confirmed}`);
     console.log(`  Ephemeral: ${status.dids.ephemeral}`);
     console.log(`  Invalid: ${status.dids.invalid}`);
 

--- a/services/gatekeeper/server/src/gatekeeper-api.js
+++ b/services/gatekeeper/server/src/gatekeeper-api.js
@@ -291,16 +291,17 @@ async function reportStatus() {
 
     console.log('Status -----------------------------');
 
-    console.log('DID Database:');
+    console.log(`DID Database (${config.db}):`);
     console.log(`  Total: ${status.dids.total}`);
     console.log(`  By registry:`);
-    for (let registry in status.dids.byRegistry) {
+    const registries = Object.keys(status.dids.byRegistry).sort();
+    for (let registry of registries) {
         console.log(`    ${registry}: ${status.dids.byRegistry[registry]}`);
     }
     console.log(`  Ephemeral: ${status.dids.ephemeral}`);
     console.log(`  Invalid: ${status.dids.invalid}`);
 
-    console.log('Memory Usage Report:');
+    console.log(`Memory Usage Report:`);
     console.log(`  RSS: ${formatBytes(status.memoryUsage.rss)} (Resident Set Size - total memory allocated for the process)`);
     console.log(`  Heap Total: ${formatBytes(status.memoryUsage.heapTotal)} (Total heap allocated)`);
     console.log(`  Heap Used: ${formatBytes(status.memoryUsage.heapUsed)} (Heap actually used)`);

--- a/services/gatekeeper/server/src/gatekeeper-api.js
+++ b/services/gatekeeper/server/src/gatekeeper-api.js
@@ -311,6 +311,7 @@ async function reportStatus() {
     console.log(`    6+: ${status.dids.total - count}`);
 
     console.log(`  Confirmed: ${status.dids.confirmed}`);
+    console.log(`  Unconfirmed: ${status.dids.unconfirmed}`);
     console.log(`  Ephemeral: ${status.dids.ephemeral}`);
     console.log(`  Invalid: ${status.dids.invalid}`);
 

--- a/tests/gatekeeper.test.js
+++ b/tests/gatekeeper.test.js
@@ -2625,8 +2625,11 @@ describe('checkDIDs', () => {
         const check = await gatekeeper.checkDIDs({ chatty: true });
 
         expect(check.total).toBe(2);
+        expect(check.confirmed).toBe(2);
         expect(check.ephemeral).toBe(1);
         expect(check.invalid).toBe(0);
+        expect(check.byRegistry['local']).toBe(2);
+        expect(check.byVersion[1]).toBe(2);
     });
 
     it('should report invalid DIDs', async () => {


### PR DESCRIPTION
Added the db type and confirmed count and DIDs by version to the status report:
```
gatekeeper-1  | Status -----------------------------
gatekeeper-1  | DID Database (redis):
gatekeeper-1  |   Total: 10600
gatekeeper-1  |   By registry:
gatekeeper-1  |     TBTC: 3117
gatekeeper-1  |     TESS: 2579
gatekeeper-1  |     TFTC: 3150
gatekeeper-1  |     hyperswarm: 1730
gatekeeper-1  |     local: 24
gatekeeper-1  |   By version:
gatekeeper-1  |     1: 9448
gatekeeper-1  |     2: 679
gatekeeper-1  |     3: 292
gatekeeper-1  |     4: 52
gatekeeper-1  |     5: 32
gatekeeper-1  |     6+: 97
gatekeeper-1  |   Confirmed: 10020
gatekeeper-1  |   Ephemeral: 2
gatekeeper-1  |   Invalid: 0
gatekeeper-1  | Memory Usage Report:
gatekeeper-1  |   RSS: 208.11 MB (Resident Set Size - total memory allocated for the process)
gatekeeper-1  |   Heap Total: 75.86 MB (Total heap allocated)
gatekeeper-1  |   Heap Used: 46.62 MB (Heap actually used)
gatekeeper-1  |   External: 21.60 MB (Memory used by C++ objects bound to JavaScript)
gatekeeper-1  |   Array Buffers: 19.24 MB (Memory used by ArrayBuffer and SharedArrayBuffer)
gatekeeper-1  | Uptime: 488s (8 minutes, 8 seconds)
```

The response to `get-status` contains all the version info which is summarized in the report:

```bash
./admin get-status
{
    "uptimeSeconds": 502,
    "dids": {
        "total": 10600,
        "confirmed": 10020,
        "ephemeral": 2,
        "invalid": 0,
        "byRegistry": {
            "TBTC": 3117,
            "TESS": 2579,
            "hyperswarm": 1730,
            "TFTC": 3150,
            "local": 24
        },
        "byVersion": {
            "1": 9448,
            "2": 679,
            "3": 292,
            "4": 52,
            "5": 32,
            "6": 17,
            "7": 15,
            "8": 10,
            "9": 8,
            "10": 4,
            "11": 4,
            "12": 8,
            "13": 3,
            "14": 1,
            "15": 2,
            "16": 5,
            "18": 4,
            "22": 3,
            "23": 1,
            "25": 2,
            "31": 1,
            "32": 1,
            "37": 1,
            "42": 1,
            "44": 1,
            "50": 1,
            "56": 1,
            "61": 1,
            "62": 1,
            "64": 1
        }
    },
    "memoryUsage": {
        "rss": 218214400,
        "heapTotal": 79548416,
        "heapUsed": 49622744,
        "external": 22649782,
        "arrayBuffers": 20171864
    }
}
```