### PR TITLE
fix: Don't add ephemeral DIDs to wallet

### DIFF
--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -1023,9 +1023,7 @@ export async function issueCredential(credential, options = {}) {
     }
 
     const signed = await addSignature(credential);
-    const cipherDid = await encryptJSON(signed, credential.credentialSubject.id, { ...options, includeHash: true });
-    await addToOwned(cipherDid);
-    return cipherDid;
+    return encryptJSON(signed, credential.credentialSubject.id, { ...options, includeHash: true });
 }
 
 export async function updateCredential(did, credential) {

--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -781,6 +781,11 @@ export async function updateAsset(did, data) {
     return updateDID(doc);
 }
 
+export async function listAssets(owner) {
+    const id = await fetchIdInfo(owner);
+    return id.owned || [];
+}
+
 export async function createId(name, options = {}) {
     const { registry = defaultRegistry } = options;
 

--- a/packages/keymaster/src/keymaster-sdk.js
+++ b/packages/keymaster/src/keymaster-sdk.js
@@ -326,6 +326,16 @@ export async function createAsset(data, options = {}) {
     }
 }
 
+export async function listAssets() {
+    try {
+        const response = await axios.get(`${URL}/api/v1/assets`);
+        return response.data.assets;
+    }
+    catch (error) {
+        throwError(error);
+    }
+}
+
 export async function resolveAsset(name) {
     try {
         const response = await axios.get(`${URL}/api/v1/assets/${name}`);

--- a/scripts/keychain-cli.js
+++ b/scripts/keychain-cli.js
@@ -810,6 +810,19 @@ program
     });
 
 program
+    .command('list-assets')
+    .description('List assets owned by current ID')
+    .action(async () => {
+        try {
+            const assets = await keymaster.listAssets();
+            console.log(JSON.stringify(assets, null, 4));
+        }
+        catch (error) {
+            console.error(error.message || error);
+        }
+    });
+
+program
     .command('create-poll-template')
     .description('Generate a poll template')
     .action(async () => {

--- a/services/keymaster/server/src/keymaster-api.js
+++ b/services/keymaster/server/src/keymaster-api.js
@@ -573,11 +573,20 @@ v1router.post('/schemas/:id/template/', async (req, res) => {
     }
 });
 
-v1router.post('/assets/', async (req, res) => {
+v1router.post('/assets', async (req, res) => {
     try {
         const { data, options } = req.body;
         const did = await keymaster.createAsset(data, options);
         res.json({ did });
+    } catch (error) {
+        res.status(500).send({ error: error.toString() });
+    }
+});
+
+v1router.get('/assets', async (req, res) => {
+    try {
+        const assets = await keymaster.listAssets();
+        res.json({ assets });
     } catch (error) {
         res.status(500).send({ error: error.toString() });
     }

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -1150,6 +1150,46 @@ describe('createAsset', () => {
     });
 });
 
+describe('listAssets', () => {
+
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should return empty list when no assets', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const assets = await keymaster.listAssets();
+
+        expect(assets).toStrictEqual([]);
+    });
+
+    it('should return assets owned by current ID', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const mockAnchor = { name: 'mockAnchor' };
+        const dataDid = await keymaster.createAsset(mockAnchor);
+        const assets = await keymaster.listAssets();
+
+        expect(assets).toStrictEqual([dataDid]);
+    });
+
+    it('should return assets owned by specified ID', async () => {
+        mockFs({});
+
+        await keymaster.createId('Alice');
+        const mockAnchor = { name: 'mockAnchor' };
+        const dataDid = await keymaster.createAsset(mockAnchor);
+
+        await keymaster.createId('Bob');
+        const assets = await keymaster.listAssets('Alice');
+
+        expect(assets).toStrictEqual([dataDid]);
+    });
+});
+
 describe('updateDID', () => {
 
     afterEach(() => {

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -1184,9 +1184,24 @@ describe('listAssets', () => {
         const dataDid = await keymaster.createAsset(mockAnchor);
 
         await keymaster.createId('Bob');
-        const assets = await keymaster.listAssets('Alice');
+        const assetsBob = await keymaster.listAssets();
+        const assetsAlice = await keymaster.listAssets('Alice');
 
-        expect(assets).toStrictEqual([dataDid]);
+        expect(assetsBob).toStrictEqual([]);
+        expect(assetsAlice).toStrictEqual([dataDid]);
+    });
+
+    it('should not include ephemeral assets', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const mockAnchor = { name: 'mockAnchor' };
+        const validUntil = new Date();
+        validUntil.setMinutes(validUntil.getMinutes() + 1);
+        await keymaster.createAsset(mockAnchor, { validUntil });
+        const assets = await keymaster.listAssets();
+
+        expect(assets).toStrictEqual([]);
     });
 });
 
@@ -1674,9 +1689,6 @@ describe('issueCredential', () => {
 
         const isValid = await keymaster.verifySignature(vc);
         expect(isValid).toBe(true);
-
-        const wallet = await keymaster.loadWallet();
-        expect(wallet.ids['Bob'].owned.includes(did)).toEqual(true);
     });
 
     it('should throw an exception if user is not issuer', async () => {


### PR DESCRIPTION
Fixes `issueCredential()` so that it no longer adds ephemeral DIDs to the wallet.

Also adds `listAssets()` to keymaster lib and sdk, `GET /assets` to the api, and `list-assets` to the CLI.