### PR TITLE
refactor: Default DID prefix configuration

### DIFF
--- a/packages/gatekeeper/src/config.js
+++ b/packages/gatekeeper/src/config.js
@@ -1,9 +1,0 @@
-import dotenv from 'dotenv';
-
-dotenv.config();
-
-const config = {
-    didPrefix: process.env.KC_DID_PREFIX || "did:test",
-};
-
-export default config;

--- a/packages/gatekeeper/src/gatekeeper.js
+++ b/packages/gatekeeper/src/gatekeeper.js
@@ -7,7 +7,6 @@ import {
     InvalidOperationError
 } from '@mdip/common/errors';
 import IPFS from '@mdip/ipfs';
-import config from './config.js';
 
 const ValidVersions = [1];
 const ValidTypes = ['agent', 'asset'];
@@ -37,6 +36,7 @@ export default class Gatekeeper {
         this.isProcessingEvents = false;
         this.ipfs = new IPFS({ minimal: true });
         this.cipher = new CipherNode();
+        this.defaultPrefix = process.env.KC_DID_PREFIX || 'did:test';
     }
 
     async verifyDb(options = {}) {
@@ -211,7 +211,8 @@ export default class Gatekeeper {
 
     async generateDID(operation) {
         const cid = await this.generateCID(operation);
-        return `${config.didPrefix}:${cid}`;
+        const prefix = operation.mdip.prefix || this.defaultPrefix;
+        return `${prefix}:${cid}`;
     }
 
     async verifyOperation(operation) {
@@ -627,7 +628,7 @@ export default class Gatekeeper {
         let { dids, updatedAfter, updatedBefore, confirm, verify, resolve } = options;
         if (!dids) {
             const keys = await this.db.getAllKeys();
-            dids = keys.map(key => `${config.didPrefix}:${key}`);
+            dids = keys.map(key => `${this.defaultPrefix}:${key}`);
         }
 
         if (updatedAfter || updatedBefore || resolve) {

--- a/packages/gatekeeper/src/gatekeeper.js
+++ b/packages/gatekeeper/src/gatekeeper.js
@@ -450,6 +450,7 @@ export default class Gatekeeper {
                     },
                     "didDocumentMetadata": {
                         "created": anchor.created,
+                        "canonicalId": did
                     },
                     "didDocumentData": {},
                     "mdip": anchor.mdip,
@@ -466,6 +467,7 @@ export default class Gatekeeper {
                     },
                     "didDocumentMetadata": {
                         "created": anchor.created,
+                        "canonicalId": did
                     },
                     "didDocumentData": anchor.data,
                     "mdip": anchor.mdip,
@@ -490,6 +492,7 @@ export default class Gatekeeper {
 
         const anchor = events[0];
         let doc = await this.generateDoc(anchor.operation);
+        doc.didDocument.id = did; // overwrite the canonicalId with the requested DID
 
         if (atTime && new Date(doc.mdip.created) > new Date(atTime)) {
             // TBD What to return if DID was created after specified time?

--- a/tests/gatekeeper.test.js
+++ b/tests/gatekeeper.test.js
@@ -226,6 +226,7 @@ describe('generateDoc', () => {
 
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
+        const did = await gatekeeper.generateDID(agentOp);
         const doc = await gatekeeper.generateDoc(agentOp);
         const expected = {
             // eslint-disable-next-line
@@ -238,7 +239,7 @@ describe('generateDoc', () => {
                 authentication: [
                     "#key-1",
                 ],
-                id: expect.any(String),
+                id: did,
                 verificationMethod: [
                     {
                         controller: expect.any(String),
@@ -251,6 +252,7 @@ describe('generateDoc', () => {
             didDocumentData: {},
             didDocumentMetadata: {
                 created: expect.any(String),
+                canonicalId: did
             },
             mdip: agentOp.mdip,
         };
@@ -265,6 +267,7 @@ describe('generateDoc', () => {
         const agentOp = await createAgentOp(keypair);
         const agent = await gatekeeper.createDID(agentOp);
         const assetOp = await createAssetOp(agent, keypair);
+        const did = await gatekeeper.generateDID(assetOp);
         const doc = await gatekeeper.generateDoc(assetOp);
         const expected = {
             // eslint-disable-next-line
@@ -274,12 +277,13 @@ describe('generateDoc', () => {
                     // eslint-disable-next-line
                     "https://www.w3.org/ns/did/v1",
                 ],
-                id: expect.any(String),
+                id: did,
                 controller: agent,
             },
             didDocumentData: assetOp.data,
             didDocumentMetadata: {
                 created: expect.any(String),
+                canonicalId: did
             },
             mdip: assetOp.mdip,
         };
@@ -569,6 +573,7 @@ describe('resolveDID', () => {
                 created: expect.any(String),
                 version: 1,
                 confirmed: true,
+                canonicalId: did
             },
             mdip: {
                 ...agentOp.mdip,
@@ -617,6 +622,7 @@ describe('resolveDID', () => {
                 updated: expect.any(String),
                 version: 2,
                 confirmed: true,
+                canonicalId: did
             },
             mdip: {
                 ...agentOp.mdip,
@@ -687,6 +693,7 @@ describe('resolveDID', () => {
                 updated: expect.any(String),
                 version: 2,
                 confirmed: true,
+                canonicalId: did
             },
             mdip: {
                 ...agentOp.mdip,
@@ -736,6 +743,7 @@ describe('resolveDID', () => {
                 updated: expect.any(String),
                 version: 2,
                 confirmed: false,
+                canonicalId: did
             },
             mdip: {
                 ...agentOp.mdip,
@@ -847,6 +855,7 @@ describe('resolveDID', () => {
                 created: expect.any(String),
                 version: 1,
                 confirmed: true,
+                canonicalId: did
             },
             mdip: {
                 ...assetOp.mdip,

--- a/tests/gatekeeper.test.js
+++ b/tests/gatekeeper.test.js
@@ -162,6 +162,43 @@ describe('generateDID', () => {
         expect(did.startsWith('did:test:')).toBe(true);
     });
 
+    it('should create DID from operation with configured prefix', async () => {
+        mockFs({});
+
+        const mockTxn = {
+            type: "create",
+            created: new Date().toISOString(),
+            mdip: {
+                registry: "mockRegistry"
+            }
+        };
+
+        process.env.KC_DID_PREFIX = 'did:mock:';
+        const gatekeeper = new Gatekeeper({ db: db_json, console: mockConsole });
+        const did = await gatekeeper.generateDID(mockTxn);
+
+        expect(did.startsWith('did:mock:')).toBe(true);
+    });
+
+    it('should create DID from operation with custom prefix', async () => {
+        mockFs({});
+
+        const mockTxn = {
+            type: "create",
+            created: new Date().toISOString(),
+            mdip: {
+                registry: "mockRegistry",
+                prefix: 'did:custom'
+            }
+        };
+
+        process.env.KC_DID_PREFIX = 'did:mock:';
+        const gatekeeper = new Gatekeeper({ db: db_json, console: mockConsole });
+        const did = await gatekeeper.generateDID(mockTxn);
+
+        expect(did.startsWith('did:custom:')).toBe(true);
+    });
+
     it('should create same DID from same operation with date included', async () => {
         mockFs({});
 


### PR DESCRIPTION
Also adds `canonicalId` to didDocumentMetadata as per [W3C recommendation](https://www.w3.org/TR/did-core/#did-document-metadata) which can have a different prefix than the requested DID.