### PR TITLE
refactor: keymaster API

### DIFF
--- a/packages/gatekeeper/src/gatekeeper-client.js
+++ b/packages/gatekeeper/src/gatekeeper-client.js
@@ -138,28 +138,17 @@ export default class GatekeeperClient {
         }
     }
 
-    async resolveDID(did, { atTime, atVersion, confirm, verify } = {}) {
+    async resolveDID(did, options) {
         try {
-            let params = '';
-
-            if (atTime) {
-                params += `atTime=${atTime}&`;
+            if (options) {
+                const queryParams = new URLSearchParams(options);
+                const response = await axios.get(`${this.API}/did/${did}?${queryParams.toString()}`);
+                return response.data;
             }
-
-            if (atVersion) {
-                params += `atVersion=${atVersion}&`;
+            else {
+                const response = await axios.get(`${this.API}/did/${did}`);
+                return response.data;
             }
-
-            if (confirm) {
-                params += `confirm=${confirm}&`;
-            }
-
-            if (verify) {
-                params += `verify=${verify}&`;
-            }
-
-            const response = await axios.get(`${this.API}/did/${did}?${params}`);
-            return response.data;
         }
         catch (error) {
             throwError(error);

--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -966,6 +966,16 @@ export default class Keymaster {
         return this.saveWallet(wallet);
     }
 
+    async getName(name) {
+        const wallet = await this.loadWallet();
+
+        if (wallet.names && Object.keys(wallet.names).includes(name)) {
+            return wallet.names[name];
+        }
+
+        return null;
+    }
+
     async removeName(name) {
         const wallet = await this.loadWallet();
 

--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -867,11 +867,6 @@ export default class Keymaster {
         }
     }
 
-    async resolveId(name) {
-        const id = await this.fetchIdInfo(name);
-        return this.resolveDID(id.did);
-    }
-
     async backupId(controller = null) {
         // Backs up current ID if name is missing
         const id = await this.fetchIdInfo(controller);

--- a/packages/keymaster/src/keymaster-sdk.js
+++ b/packages/keymaster/src/keymaster-sdk.js
@@ -308,14 +308,15 @@ export default class KeymasterClient {
         }
     }
 
-    async resolveDID(name, options) {
+    async resolveDID(id, options) {
         try {
             if (options) {
-                const response = await axios.post(`${this.API}/names/${name}`, { options });
+                const queryParams = new URLSearchParams(options);
+                const response = await axios.get(`${this.API}/did/${id}?${queryParams.toString()}`);
                 return response.data.docs;
             }
             else {
-                const response = await axios.get(`${this.API}/names/${name}`);
+                const response = await axios.get(`${this.API}/did/${id}`);
                 return response.data.docs;
             }
         }

--- a/packages/keymaster/src/keymaster-sdk.js
+++ b/packages/keymaster/src/keymaster-sdk.js
@@ -298,6 +298,16 @@ export default class KeymasterClient {
         }
     }
 
+    async getName(name) {
+        try {
+            const response = await axios.get(`${this.API}/names/${name}`);
+            return response.data.did;
+        }
+        catch (error) {
+            throwError(error);
+        }
+    }
+
     async removeName(name) {
         try {
             const response = await axios.delete(`${this.API}/names/${name}`);

--- a/packages/keymaster/src/keymaster-sdk.js
+++ b/packages/keymaster/src/keymaster-sdk.js
@@ -238,16 +238,6 @@ export default class KeymasterClient {
         }
     }
 
-    async resolveId(id) {
-        try {
-            const response = await axios.get(`${this.API}/ids/${id}`);
-            return response.data.docs;
-        }
-        catch (error) {
-            throwError(error);
-        }
-    }
-
     async createId(name, options) {
         try {
             const response = await axios.post(`${this.API}/ids`, { name, options });

--- a/python/keymaster_sdk/src/keymaster_sdk/keymaster_sdk.py
+++ b/python/keymaster_sdk/src/keymaster_sdk/keymaster_sdk.py
@@ -169,13 +169,8 @@ def list_registries():
     return response["registries"]
 
 
-def resolve_id(identifier):
-    response = proxy_request("GET", f"{_keymaster_api}/ids/{identifier}")
-    return response["docs"]
-
-
 def resolve_did(name):
-    response = proxy_request("GET", f"{_keymaster_api}/names/{name}")
+    response = proxy_request("GET", f"{_keymaster_api}/did/{name}")
     return response["docs"]
 
 
@@ -362,6 +357,11 @@ def add_name(name, did):
         "POST", f"{_keymaster_api}/names", json={"name": name, "did": did}
     )
     return response["ok"]
+
+
+def get_name(name):
+    response = proxy_request("GET", f"{_keymaster_api}/names/{name}")
+    return response["did"]
 
 
 def remove_name(name):

--- a/scripts/keychain-cli.js
+++ b/scripts/keychain-cli.js
@@ -613,6 +613,19 @@ program
     });
 
 program
+    .command('get-name <name>')
+    .description('Get DID assigned to name')
+    .action(async (name) => {
+        try {
+            const did = await keymaster.getName(name);
+            console.log(did || `${name} not found`);
+        }
+        catch (error) {
+            console.error(error.message || error);
+        }
+    });
+
+program
     .command('remove-name <name>')
     .description('Removes a name for a DID')
     .action(async (name) => {

--- a/services/keymaster/server/src/keymaster-api.js
+++ b/services/keymaster/server/src/keymaster-api.js
@@ -155,7 +155,7 @@ v1router.post('/ids/', async (req, res) => {
 
 v1router.get('/ids/:id', async (req, res) => {
     try {
-        const docs = await keymaster.resolveId(req.params.id);
+        const docs = await keymaster.resolveDID(req.params.id);
         res.json({ docs });
     } catch (error) {
         return res.status(404).send({ error: 'ID not found' });

--- a/services/keymaster/server/src/keymaster-api.js
+++ b/services/keymaster/server/src/keymaster-api.js
@@ -115,6 +115,15 @@ v1router.get('/wallet/mnemonic', async (req, res) => {
     }
 });
 
+v1router.get('/did/:id', async (req, res) => {
+    try {
+        const docs = await keymaster.resolveDID(req.params.id, req.query);
+        res.json({ docs });
+    } catch (error) {
+        res.status(404).send({ error: 'DID not found' });
+    }
+});
+
 v1router.get('/ids/current', async (req, res) => {
     try {
         const current = await keymaster.getCurrentId();
@@ -209,20 +218,9 @@ v1router.post('/names', async (req, res) => {
     }
 });
 
-// eslint-disable-next-line
 v1router.get('/names/:name', async (req, res) => {
     try {
-        const docs = await keymaster.resolveDID(req.params.name);
-        res.json({ docs });
-    } catch (error) {
-        res.status(404).send({ error: 'DID not found' });
-    }
-});
-
-v1router.post('/names/:name', async (req, res) => {
-    try {
-        const { options } = req.body;
-        const docs = await keymaster.resolveDID(req.params.name, options);
+        const docs = await keymaster.resolveDID(req.params.name, req.query);
         res.json({ docs });
     } catch (error) {
         res.status(404).send({ error: 'DID not found' });

--- a/services/keymaster/server/src/keymaster-api.js
+++ b/services/keymaster/server/src/keymaster-api.js
@@ -220,8 +220,8 @@ v1router.post('/names', async (req, res) => {
 
 v1router.get('/names/:name', async (req, res) => {
     try {
-        const docs = await keymaster.resolveDID(req.params.name, req.query);
-        res.json({ docs });
+        const did = await keymaster.getName(req.params.name);
+        res.json({ did });
     } catch (error) {
         res.status(404).send({ error: 'DID not found' });
     }

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -626,23 +626,6 @@ describe('setCurrentId', () => {
     });
 });
 
-describe('resolveId', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
-    it('should resolve a new ID', async () => {
-        mockFs({});
-
-        const name = 'Bob';
-        const did = await keymaster.createId(name);
-        const doc = await keymaster.resolveId();
-
-        expect(doc.didDocument.id).toBe(did);
-    });
-});
-
 describe('backupId', () => {
 
     afterEach(() => {
@@ -657,7 +640,7 @@ describe('backupId', () => {
 
         const ok = await keymaster.backupId();
 
-        const doc = await keymaster.resolveId();
+        const doc = await keymaster.resolveDID(name);
         const vault = await keymaster.resolveDID(doc.didDocumentData.vault);
 
         expect(ok).toBe(true);
@@ -988,11 +971,10 @@ describe('resolveDID', () => {
     it('should resolve a valid id name', async () => {
         mockFs({});
 
-        await keymaster.createId('Bob');
-        const doc1 = await keymaster.resolveId();
-        const doc2 = await keymaster.resolveDID('Bob');
+        const did = await keymaster.createId('Bob');
+        const doc = await keymaster.resolveDID('Bob');
 
-        expect(doc1).toStrictEqual(doc2);
+        expect(doc.didDocument.id).toBe(did);
     });
 
     it('should resolve a valid asset name', async () => {

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -901,6 +901,51 @@ describe('addName', () => {
     });
 });
 
+describe('getName', () => {
+
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should return DID for a new name', async () => {
+        mockFs({});
+
+        const bob = await keymaster.createId('Bob');
+        const ok = await keymaster.addName('Jack', bob);
+        const did = await keymaster.getName('Jack');
+
+        expect(ok).toBe(true);
+        expect(did).toBe(bob);
+    });
+
+    it('should return null for unknown name', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const did = await keymaster.getName('Jack');
+
+        expect(did).toBe(null);
+    });
+
+    it('should return null for non-string names', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+
+        let did = await keymaster.getName();
+        expect(did).toBe(null);
+
+        did = await keymaster.getName(333);
+        expect(did).toBe(null);
+
+        did = await keymaster.getName([1, 2, 3]);
+        expect(did).toBe(null);
+
+        did = await keymaster.getName({ id: 'mock' });
+        expect(did).toBe(null);
+    });
+});
+
 describe('removeName', () => {
 
     afterEach(() => {


### PR DESCRIPTION
Removes `resolveId` method from keymaster interface. Use `resolveDID` instead since it is equivalent.

Adds `getName` to keymaster interface which returns the DID associated with the given name.

CHANGES `GET /names/:name` endpoint in API. Maps to `getName` rather than `resolveDID`
ADDS `GET /did/:id` endpoint to API. Resolves an identifier (id can be a name or a DID)