### PR TITLE
Store extension state in memory

### DIFF
--- a/browser/chrome-extension/src/offscreen/offscreen.ts
+++ b/browser/chrome-extension/src/offscreen/offscreen.ts
@@ -1,4 +1,5 @@
-let passphrase: string = null;
+let passphrase: string | null = null;
+const extensionState: Record<string, any> = {};
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (message.action === "OPEN_AUTH_TAB") {
@@ -14,6 +15,22 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         sendResponse({ passphrase });
     } else if (message.action === "CLEAR_PASSPHRASE") {
         passphrase = null;
+        sendResponse({ success: true });
+    } else if (message.action === "STORE_STATE") {
+        extensionState[message.key] = message.value;
+        sendResponse({ success: true });
+    } else if (message.action === "GET_ALL_STATE") {
+        sendResponse({ extensionState });
+    } else if (message.action === "GET_STATE") {
+        const val = extensionState[message.key];
+        sendResponse({ value: val });
+    } else if (message.action === "CLEAR_ALL_STATE") {
+        for (const key in extensionState) {
+            delete extensionState[key];
+        }
+        sendResponse({ success: true });
+    } else if (message.action === "CLEAR_STATE") {
+        delete extensionState[message.key];
         sendResponse({ success: true });
     }
 

--- a/browser/chrome-extension/src/wallet/WalletUI.tsx
+++ b/browser/chrome-extension/src/wallet/WalletUI.tsx
@@ -52,17 +52,6 @@ const WalletUI = () => {
         setPendingWallet(null);
     };
 
-    const deleteValues = [
-        "selectedTab",
-        "currentId",
-        "registry",
-        "heldDID",
-        "authDID",
-        "callback",
-        "response",
-        "disableSendResponse",
-    ];
-
     const setError = (error: string) => {
         setSnackbar({
             open: true,

--- a/browser/chrome-extension/src/wallet/WalletUI.tsx
+++ b/browser/chrome-extension/src/wallet/WalletUI.tsx
@@ -72,8 +72,7 @@ const WalletUI = () => {
     };
 
     async function wipeStoredValues() {
-        await chrome.storage.local.remove(deleteValues);
-        await chrome.storage.local.remove(["challenge"]);
+        await chrome.runtime.sendMessage({ action: "CLEAR_ALL_STATE" });
         await chrome.runtime.sendMessage({ action: "CLEAR_PASSPHRASE" });
         window.close();
     }


### PR DESCRIPTION
Use the newly added offscreen HTML to store the browser extension state in memory and not store the state to disk.

Resolves: https://github.com/KeychainMDIP/kc/issues/550