### PR TITLE
fix: extension prevent truncation on JSON viewer

### DIFF
--- a/browser/chrome-extension/src/viewer/JsonViewer.tsx
+++ b/browser/chrome-extension/src/viewer/JsonViewer.tsx
@@ -22,7 +22,7 @@ function JsonViewer() {
             <Typography sx={{ fontFamily: "Courier, monospace" }}>
                 {did}
             </Typography>
-            <JsonView value={data} />
+            <JsonView value={data} shortenTextAfterLength={0} />
         </div>
     );
 }

--- a/browser/chrome-extension/src/wallet/WalletUI.tsx
+++ b/browser/chrome-extension/src/wallet/WalletUI.tsx
@@ -333,7 +333,11 @@ const WalletUI = () => {
             <Box>
                 <pre>{mnemonicString}</pre>
             </Box>
-            <Box>{walletObject && <JsonView value={walletObject} />}</Box>
+            <Box>
+                {walletObject && (
+                    <JsonView value={walletObject} shortenTextAfterLength={0} />
+                )}
+            </Box>
         </Box>
     );
 };


### PR DESCRIPTION
In the Chrome browser extension data is truncated, this PR disables truncation.
Resolves: https://github.com/KeychainMDIP/kc/issues/557