### PR TITLE
fix: Recover ID for server wallet

### DIFF
--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -903,7 +903,10 @@ export default class Keymaster {
             const backup = this.cipher.decryptMessage(keypair.publicJwk, keypair.privateJwk, vault.backup);
             const data = JSON.parse(backup);
 
-            // TBD handle the case where name already exists in wallet
+            if (wallet.ids[data.name]) {
+                throw new KeymasterError(`${data.name} already exists in wallet`);
+            }
+
             wallet.ids[data.name] = data.id;
             wallet.current = data.name;
             wallet.counter += 1;
@@ -912,8 +915,13 @@ export default class Keymaster {
 
             return wallet.current;
         }
-        catch {
-            throw new InvalidDIDError();
+        catch (error) {
+            if (error.type === 'Keymaster') {
+                throw error;
+            }
+            else {
+                throw new InvalidDIDError();
+            }
         }
     }
 

--- a/services/keymaster/server/src/keymaster-api.js
+++ b/services/keymaster/server/src/keymaster-api.js
@@ -195,11 +195,15 @@ v1router.post('/ids/:id/backup', async (req, res) => {
 
 v1router.post('/ids/:id/recover', async (req, res) => {
     try {
-        const { did } = req.body;
-        const current = await keymaster.recoverId(did);
+        const current = await keymaster.recoverId(req.params.id);
         res.json({ recovered: current });
     } catch (error) {
-        res.status(400).send({ error: error.toString() });
+        if (error.error === 'DID not found') {
+            res.status(404).send({ error: 'DID not found' });
+        }
+        else {
+            res.status(500).send({ error: error.toString() });
+        }
     }
 });
 

--- a/services/keymaster/server/src/keymaster-api.js
+++ b/services/keymaster/server/src/keymaster-api.js
@@ -22,6 +22,8 @@ app.use(express.json());
 // Define __dirname in ES module scope
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+const DIDNotFound = { error: 'DID not found' };
+
 // Serve the React frontend
 app.use(express.static(path.join(__dirname, '../../client/build')));
 
@@ -124,7 +126,7 @@ v1router.get('/did/:id', async (req, res) => {
         const docs = await keymaster.resolveDID(req.params.id, req.query);
         res.json({ docs });
     } catch (error) {
-        res.status(404).send({ error: 'DID not found' });
+        res.status(404).send(DIDNotFound);
     }
 });
 
@@ -198,8 +200,8 @@ v1router.post('/ids/:id/recover', async (req, res) => {
         const current = await keymaster.recoverId(req.params.id);
         res.json({ recovered: current });
     } catch (error) {
-        if (error.error === 'DID not found') {
-            res.status(404).send({ error: 'DID not found' });
+        if (error.error === DIDNotFound.error) {
+            res.status(404).send(DIDNotFound);
         }
         else {
             res.status(500).send({ error: error.toString() });
@@ -231,7 +233,7 @@ v1router.get('/names/:name', async (req, res) => {
         const did = await keymaster.getName(req.params.name);
         res.json({ did });
     } catch (error) {
-        res.status(404).send({ error: 'DID not found' });
+        res.status(404).send(DIDNotFound);
     }
 });
 

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -715,6 +715,21 @@ describe('recoverId', () => {
         expect(wallet.counter === 1);
     });
 
+    it('should not overwrite an id with the same name', async () => {
+        mockFs({});
+
+        const did = await keymaster.createId('Bob');
+        await keymaster.backupId();
+
+        try {
+            await keymaster.recoverId(did);
+            throw new ExpectedExceptionError();
+        }
+        catch (error) {
+            expect(error.message).toBe('Keymaster: Bob already exists in wallet');
+        }
+    });
+
     it('should not recover an id to a different wallet', async () => {
         mockFs({});
 


### PR DESCRIPTION
Fixes an issue in Keymaster service that was causing the recoverId feature to fail.

Also now throws an error if the recovered ID already exists in the wallet, preventing accidental overwriting.