### PR TITLE
feat: Added renameId

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Details on each command can be found in the [CLI User Manual](https://keychain.o
 ## Quick start
 
 Recommended system requirements:
+
 - GNU/Linux OS with [docker](https://www.docker.com/) for containerized operation
 - node 18.18.2 and npm 9.8.1 or newer for manual and local operation
 - minimum of 8Gb RAM if operating a full trustless node
@@ -18,6 +19,7 @@ $ cd kc
 $ cp sample.env .env
 $ ./start-node
 ```
+
 ## Node configuration
 
 Customize your node in the kc/.env file.
@@ -44,9 +46,9 @@ $ ./scripts/tbtc-cli getwalletinfo           # Get a general status of confirmed
 ```
 
 ## Command line interface wallet
+
 Use the CLI `./kc` or the web app at http://localhost:4226 to access the server-side wallet.
 Use the web app at http://localhost:4224 to access a client-side (browser) wallet.
-
 
 ```
 $ ./kc
@@ -63,7 +65,8 @@ Commands:
   add-group-member <group> <member>          Add a member to a group
   add-name <name> <did>                      Adds a name for a DID
   backup-id                                  Backup the current ID to its registry
-  backup-wallet                              Backup wallet to encrypted DID and seed bank
+  backup-wallet-did                          Backup wallet to encrypted DID and seed bank
+  backup-wallet-file <file>                  Backup wallet to file
   bind-credential <schema> <subject>         Create bound credential for a user
   check-wallet                               Validate DIDs in wallet
   create-asset <file>                        Create an asset from a JSON file
@@ -87,6 +90,7 @@ Commands:
   get-asset <did>                            Get asset by DID
   get-credential <did>                       Get credential by DID
   get-group <did>                            Get group by DID
+  get-name <name>                            Get DID assigned to name
   get-schema <did>                           Get schema by DID
   help [command]                             display help for command
   import-wallet <recovery-phrase>            Create new wallet from a recovery phrase
@@ -102,13 +106,15 @@ Commands:
   publish-credential <did>                   Publish the existence of a credential to the current user manifest
   publish-poll <poll>                        Publish results to poll, hiding ballots
   recover-id <did>                           Recovers the ID from the DID
-  recover-wallet [did]                       Recover wallet from seed bank or encrypted DID
+  recover-wallet-did [did]                   Recover wallet from seed bank or encrypted DID
   remove-group-member <group> <member>       Remove a member from a group
   remove-id <name>                           Deletes named ID
   remove-name <name>                         Removes a name for a DID
+  rename-id <oldName> <newName>              Renames the ID
   resolve-did <did> [confirm]                Return document associated with DID
   resolve-did-version <did> <version>        Return specified version of document associated with DID
   resolve-id                                 Resolves the current ID
+  restore-wallet-file <file>                 Restore wallet from backup file
   reveal-credential <did>                    Reveal a credential to the current user manifest
   reveal-poll <poll>                         Publish results to poll, revealing ballots
   revoke-credential <did>                    Revokes a verifiable credential

--- a/doc/keychain/clients/cli/03-ids.md
+++ b/doc/keychain/clients/cli/03-ids.md
@@ -118,7 +118,7 @@ $ kc resolve-id
     "didDocumentData": {
         "vault": "did:mdip:test:z3v8AuafhKoRuEkDTjyoabgPXKx4Yi4cPmPdzUgMNyKxkzYNA6u"
     },
-    
+
     ...
 
 }
@@ -135,6 +135,15 @@ $ kc remove-id Alice
 ID Alice removed
 ```
 
+## Renamng an ID
+
+At any time, a user may rename an ID in their wallet:
+
+```sh
+$ kc rename-id Alice Bob
+OK
+```
+
 ## Recovering an ID
 
 Recovery of a DID's history using the Vault DID is possible because the Vault data is encrypted with the wallet's keys. The wallet keys are used to decrypt the Vault DID data containing the DID's private history:
@@ -148,7 +157,7 @@ Recovered Alice!
 
 A user's wallet may contain any number of MDIP agent DID identities:
 
-```sh 
+```sh
 $ kc create-id Bob
 did:mdip:test:z3v8AuairhLoGZqf6UDKw7zXyBknTvanvSzFHnLpwy8nwa7WLzk
 ```

--- a/doc/keychain/clients/cli/README.md
+++ b/doc/keychain/clients/cli/README.md
@@ -22,49 +22,49 @@ Keychain is provided as a set of docker containers and scripts:
 
 1. From your terminal, download the repository and move to it:
 
-    ```sh
-    # SSH
-    git@github.com:KeychainMDIP/kc.git
-    #HTTPS
-    https://github.com/KeychainMDIP/kc.git
+   ```sh
+   # SSH
+   git@github.com:KeychainMDIP/kc.git
+   #HTTPS
+   https://github.com/KeychainMDIP/kc.git
 
-    cd kc
-    ```
+   cd kc
+   ```
 
 1. Copy `sample.env` to `.env`:
 
-    ```env
-    cp sample.env .env
-    ```
+   ```env
+   cp sample.env .env
+   ```
 
 1. Edit the `KC_NODE_ID` and `KC_NODE_NAME` with unique values. The remaining values will be covered in futher documentation:
 
-    ```sh title=".env" {2-3}
-    # Gatekeeper
-    KC_DEBUG=false
-    KC_NODE_NAME=mynode
-    KC_NODE_ID=mynodeID
-    KC_GATEKEEPER_DB=json
-    KC_GATEKEEPER_REGISTRIES=hyperswarm,TBTC,TFTC
+   ```sh title=".env" {2-3}
+   # Gatekeeper
+   KC_DEBUG=false
+   KC_NODE_NAME=mynode
+   KC_NODE_ID=mynodeID
+   KC_GATEKEEPER_DB=json
+   KC_GATEKEEPER_REGISTRIES=hyperswarm,TBTC,TFTC
 
-    ...
-    ```
+   ...
+   ```
 
 1. Run the keychain start script:
 
-    ```sh
-    # Tied to the shell session:
-    ./start-node
+   ```sh
+   # Tied to the shell session:
+   ./start-node
 
-    # Daemonized:
-    ./start-node -d
-    ```
+   # Daemonized:
+   ./start-node -d
+   ```
 
 1. There's also a script to stop Keychain:
 
-    ```sh
-    ./stop-node
-    ```
+   ```sh
+   ./stop-node
+   ```
 
 ### CLI
 
@@ -82,13 +82,13 @@ Keychain CLI tool
 Options:
   -V, --version                              output the version number
   -h, --help                                 display help for command
-
 Commands:
   accept-credential <did> [name]             Save verifiable credential for current ID
   add-group-member <group> <member>          Add a member to a group
   add-name <name> <did>                      Adds a name for a DID
   backup-id                                  Backup the current ID to its registry
-  backup-wallet                              Backup wallet to encrypted DID and seed bank
+  backup-wallet-did                          Backup wallet to encrypted DID and seed bank
+  backup-wallet-file <file>                  Backup wallet to file
   bind-credential <schema> <subject>         Create bound credential for a user
   check-wallet                               Validate DIDs in wallet
   create-asset <file>                        Create an asset from a JSON file
@@ -112,6 +112,7 @@ Commands:
   get-asset <did>                            Get asset by DID
   get-credential <did>                       Get credential by DID
   get-group <did>                            Get group by DID
+  get-name <name>                            Get DID assigned to name
   get-schema <did>                           Get schema by DID
   help [command]                             display help for command
   import-wallet <recovery-phrase>            Create new wallet from a recovery phrase
@@ -127,13 +128,15 @@ Commands:
   publish-credential <did>                   Publish the existence of a credential to the current user manifest
   publish-poll <poll>                        Publish results to poll, hiding ballots
   recover-id <did>                           Recovers the ID from the DID
-  recover-wallet [did]                       Recover wallet from seed bank or encrypted DID
+  recover-wallet-did [did]                   Recover wallet from seed bank or encrypted DID
   remove-group-member <group> <member>       Remove a member from a group
   remove-id <name>                           Deletes named ID
   remove-name <name>                         Removes a name for a DID
+  rename-id <oldName> <newName>              Renames the ID
   resolve-did <did> [confirm]                Return document associated with DID
   resolve-did-version <did> <version>        Return specified version of document associated with DID
   resolve-id                                 Resolves the current ID
+  restore-wallet-file <file>                 Restore wallet from backup file
   reveal-credential <did>                    Reveal a credential to the current user manifest
   reveal-poll <poll>                         Publish results to poll, revealing ballots
   revoke-credential <did>                    Revokes a verifiable credential
@@ -161,7 +164,7 @@ $ kc
 ```
 
 > [!NOTE]
->Unless you edit your shell's `$PATH` variable, you need to invoke kc with a `./` prefix to run the script in the current directory:
+> Unless you edit your shell's `$PATH` variable, you need to invoke kc with a `./` prefix to run the script in the current directory:
 
 ```sh
 $ ./kc

--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -871,22 +871,22 @@ export default class Keymaster {
         return this.saveWallet(wallet);
     }
 
-    async renameId(oldName, newName) {
+    async renameId(id, name) {
         const wallet = await this.loadWallet();
 
-        if (!(oldName in wallet.ids)) {
+        if (!(id in wallet.ids)) {
             throw new UnknownIDError();
         }
 
-        if (newName in wallet.ids) {
-            throw new InvalidParameterError(`newName ${newName} already exists`);
+        if (name in wallet.ids) {
+            throw new InvalidParameterError(`${name} already exists`);
         }
 
-        wallet.ids[newName] = wallet.ids[oldName];
-        delete wallet.ids[oldName];
+        wallet.ids[name] = wallet.ids[id];
+        delete wallet.ids[id];
 
-        if (wallet.current && wallet.current === oldName) {
-            wallet.current = newName;
+        if (wallet.current && wallet.current === id) {
+            wallet.current = name;
         }
 
         return this.saveWallet(wallet);

--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -857,22 +857,39 @@ export default class Keymaster {
 
     async removeId(name) {
         const wallet = await this.loadWallet();
-        let ids = Object.keys(wallet.ids);
 
-        if (ids.includes(name)) {
-            delete wallet.ids[name];
-
-            if (wallet.current === name) {
-                ids = Object.keys(wallet.ids);
-                wallet.current = ids.length > 0 ? ids[0] : '';
-            }
-
-            await this.saveWallet(wallet);
-            return true;
-        }
-        else {
+        if (!(name in wallet.ids)) {
             throw new UnknownIDError();
         }
+
+        delete wallet.ids[name];
+
+        if (wallet.current === name) {
+            wallet.current = Object.keys(wallet.ids)[0] || '';
+        }
+
+        return this.saveWallet(wallet);
+    }
+
+    async renameId(oldName, newName) {
+        const wallet = await this.loadWallet();
+
+        if (!(oldName in wallet.ids)) {
+            throw new UnknownIDError();
+        }
+
+        if (newName in wallet.ids) {
+            throw new InvalidParameterError(`newName ${newName} already exists`);
+        }
+
+        wallet.ids[newName] = wallet.ids[oldName];
+        delete wallet.ids[oldName];
+
+        if (wallet.current && wallet.current === oldName) {
+            wallet.current = newName;
+        }
+
+        return this.saveWallet(wallet);
     }
 
     async backupId(controller = null) {

--- a/packages/keymaster/src/keymaster-sdk.js
+++ b/packages/keymaster/src/keymaster-sdk.js
@@ -258,6 +258,16 @@ export default class KeymasterClient {
         }
     }
 
+    async renameId(id, name) {
+        try {
+            const response = await axios.post(`${this.API}/ids/${id}/rename`, { name });
+            return response.data.ok;
+        }
+        catch (error) {
+            throwError(error);
+        }
+    }
+
     async backupId(id) {
         try {
             const response = await axios.post(`${this.API}/ids/${id}/backup`);

--- a/python/keymaster_sdk/src/keymaster_sdk/keymaster_sdk.py
+++ b/python/keymaster_sdk/src/keymaster_sdk/keymaster_sdk.py
@@ -70,6 +70,13 @@ def remove_id(identifier):
     return response["ok"]
 
 
+def rename_id(identifier, name):
+    response = proxy_request(
+        "POST", f"{_keymaster_api}/ids/{identifier}/rename", json={"name": name}
+    )
+    return response["ok"]
+
+
 def backup_id(identifier):
     response = proxy_request("POST", f"{_keymaster_api}/ids/{identifier}/backup")
     return response["ok"]

--- a/scripts/keychain-cli.js
+++ b/scripts/keychain-cli.js
@@ -228,6 +228,19 @@ program
     });
 
 program
+    .command('rename-id <oldName> <newName>')
+    .description('Renames the ID')
+    .action(async (oldName, newName) => {
+        try {
+            const ok = await keymaster.renameId(oldName, newName);
+            console.log(ok ? UPDATE_OK : UPDATE_FAILED);
+        }
+        catch (error) {
+            console.error(error.message || error);
+        }
+    });
+
+program
     .command('list-ids')
     .description('List IDs and show current ID')
     .action(async () => {
@@ -1049,7 +1062,7 @@ async function run() {
         waitUntilReady: true,
         intervalSeconds: 1,
         chatty: false,
-        becomeChattyAfter: 5
+        becomeChattyAfter: 2
     });
     program.parse(process.argv);
 }

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -207,6 +207,23 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
         }
     }
 
+    async function renameId() {
+        try {
+            const input = window.prompt("Please enter new name:");
+
+            if (input) {
+                const name = input.trim();
+
+                if (name.length > 0) {
+                    await keymaster.renameId(selectedId, name);
+                    refreshAll();
+                }
+            }
+        } catch (error) {
+            showError(error);
+        }
+    }
+
     async function removeId() {
         try {
             if (window.confirm(`Are you sure you want to remove ${selectedId}?`)) {
@@ -1018,13 +1035,18 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                     </Button>
                                 </Grid>
                                 <Grid item>
+                                    <Button variant="contained" color="primary" onClick={renameId}>
+                                        Rename...
+                                    </Button>
+                                </Grid>
+                                <Grid item>
                                     <Button variant="contained" color="primary" onClick={removeId}>
                                         Remove...
                                     </Button>
                                 </Grid>
                                 <Grid item>
                                     <Button variant="contained" color="primary" onClick={backupId}>
-                                        Backup
+                                        Backup...
                                     </Button>
                                 </Grid>
                                 <Grid item>

--- a/services/keymaster/client/src/KeymasterUI.js
+++ b/services/keymaster/client/src/KeymasterUI.js
@@ -207,6 +207,23 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
         }
     }
 
+    async function renameId() {
+        try {
+            const input = window.prompt("Please enter new name:");
+
+            if (input) {
+                const name = input.trim();
+
+                if (name.length > 0) {
+                    await keymaster.renameId(selectedId, name);
+                    refreshAll();
+                }
+            }
+        } catch (error) {
+            showError(error);
+        }
+    }
+
     async function removeId() {
         try {
             if (window.confirm(`Are you sure you want to remove ${selectedId}?`)) {
@@ -1018,13 +1035,18 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                     </Button>
                                 </Grid>
                                 <Grid item>
+                                    <Button variant="contained" color="primary" onClick={renameId}>
+                                        Rename...
+                                    </Button>
+                                </Grid>
+                                <Grid item>
                                     <Button variant="contained" color="primary" onClick={removeId}>
                                         Remove...
                                     </Button>
                                 </Grid>
                                 <Grid item>
                                     <Button variant="contained" color="primary" onClick={backupId}>
-                                        Backup
+                                        Backup...
                                     </Button>
                                 </Grid>
                                 <Grid item>

--- a/services/keymaster/server/src/keymaster-api.js
+++ b/services/keymaster/server/src/keymaster-api.js
@@ -186,6 +186,16 @@ v1router.delete('/ids/:id', async (req, res) => {
     }
 });
 
+v1router.post('/ids/:id/rename', async (req, res) => {
+    try {
+        const { name } = req.body;
+        const ok = await keymaster.renameId(req.params.id, name);
+        res.json({ ok });
+    } catch (error) {
+        res.status(400).send({ error: error.toString() });
+    }
+});
+
 v1router.post('/ids/:id/backup', async (req, res) => {
     try {
         const ok = await keymaster.backupId(req.params.id);


### PR DESCRIPTION
Adds the renameId() function to Keymaster lib and KeymasterClient sdk. Also adds corresponding `POST /ids/:id/rename` endpoint to the API, and `rename-id` command to the CLI.

Added bonus: ID names support Unicode...

![image](https://github.com/user-attachments/assets/50f47049-f8e6-4fc9-a19e-3b6bc14bf07e)
