### PR TITLE
feat: Added updateAsset to keymaster API

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Commands:
   backup-wallet-file <file>                  Backup wallet to file
   bind-credential <schema> <subject>         Create bound credential for a user
   check-wallet                               Validate DIDs in wallet
-  create-asset <file>                        Create an asset from a JSON file
+  create-asset [file]                        Create an asset from a JSON file
   create-challenge [file] [name]             Create challenge (optionally from a file)
   create-challenge-cc <did> [name]           Create challenge from a credential DID
   create-group <name>                        Create a new group
@@ -87,7 +87,7 @@ Commands:
   encrypt-message <message> <did>            Encrypt a message for a DID
   encrypt-wallet                             Encrypt wallet
   fix-wallet                                 Remove invalid DIDs from the wallet
-  get-asset <did>                            Get asset by DID
+  get-asset <id>                             Get asset by name or DID
   get-credential <did>                       Get credential by DID
   get-group <did>                            Get group by DID
   get-name <name>                            Get DID assigned to name
@@ -119,6 +119,8 @@ Commands:
   reveal-poll <poll>                         Publish results to poll, revealing ballots
   revoke-credential <did>                    Revokes a verifiable credential
   rotate-keys                                Generates new set of keys for current ID
+  set-asset <id> [file]                      Update an asset from a JSON file
+  set-property <id> <key> [value]            Assign a key-value pair to an asset
   show-mnemonic                              Show recovery phrase for wallet
   show-wallet                                Show wallet
   sign-file <file>                           Sign a JSON file

--- a/doc/keychain/clients/cli/README.md
+++ b/doc/keychain/clients/cli/README.md
@@ -82,7 +82,7 @@ Keychain CLI tool
 Options:
   -V, --version                              output the version number
   -h, --help                                 display help for command
-Commands:
+  Commands:
   accept-credential <did> [name]             Save verifiable credential for current ID
   add-group-member <group> <member>          Add a member to a group
   add-name <name> <did>                      Adds a name for a DID
@@ -91,7 +91,7 @@ Commands:
   backup-wallet-file <file>                  Backup wallet to file
   bind-credential <schema> <subject>         Create bound credential for a user
   check-wallet                               Validate DIDs in wallet
-  create-asset <file>                        Create an asset from a JSON file
+  create-asset [file]                        Create an asset from a JSON file
   create-challenge [file] [name]             Create challenge (optionally from a file)
   create-challenge-cc <did> [name]           Create challenge from a credential DID
   create-group <name>                        Create a new group
@@ -109,7 +109,7 @@ Commands:
   encrypt-message <message> <did>            Encrypt a message for a DID
   encrypt-wallet                             Encrypt wallet
   fix-wallet                                 Remove invalid DIDs from the wallet
-  get-asset <did>                            Get asset by DID
+  get-asset <id>                             Get asset by name or DID
   get-credential <did>                       Get credential by DID
   get-group <did>                            Get group by DID
   get-name <name>                            Get DID assigned to name
@@ -141,6 +141,8 @@ Commands:
   reveal-poll <poll>                         Publish results to poll, revealing ballots
   revoke-credential <did>                    Revokes a verifiable credential
   rotate-keys                                Generates new set of keys for current ID
+  set-asset <id> [file]                      Update an asset from a JSON file
+  set-property <id> <key> [value]            Assign a key-value pair to an asset
   show-mnemonic                              Show recovery phrase for wallet
   show-wallet                                Show wallet
   sign-file <file>                           Sign a JSON file

--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -498,7 +498,7 @@ export default class Keymaster {
         return null;
     }
 
-    async createAsset(data, options = {}) {
+    async createAsset(data = {}, options = {}) {
         let { registry = this.defaultRegistry, controller, validUntil } = options;
 
         if (validUntil) {

--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -435,6 +435,13 @@ export default class Keymaster {
         }
     }
 
+    didMatch(did1, did2) {
+        const suffix1 = did1.split(':').pop();
+        const suffix2 = did2.split(':').pop();
+
+        return (suffix1 === suffix2);
+    }
+
     async fetchIdInfo(id) {
         const wallet = await this.loadWallet();
         let idInfo = null;
@@ -444,7 +451,7 @@ export default class Keymaster {
                 for (const name of Object.keys(wallet.ids)) {
                     const info = wallet.ids[name];
 
-                    if (info.did === id) {
+                    if (this.didMatch(id, info.did)) {
                         idInfo = info;
                         break;
                     }

--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -509,15 +509,7 @@ export default class Keymaster {
             }
         }
 
-        function isEmpty(data) {
-            return (
-                !data ||
-                (Array.isArray(data) && data.length === 0) ||
-                (typeof data === 'object' && Object.keys(data).length === 0)
-            );
-        }
-
-        if (isEmpty(data)) {
+        if (!data) {
             throw new InvalidParameterError('data');
         }
 
@@ -782,7 +774,7 @@ export default class Keymaster {
     async resolveAsset(did) {
         const doc = await this.resolveDID(did);
 
-        if (doc?.didDocumentMetadata && !doc.didDocumentMetadata.deactivated) {
+        if (doc?.didDocumentData && !doc.didDocumentMetadata.deactivated) {
             return doc.didDocumentData;
         }
 

--- a/packages/keymaster/src/keymaster-sdk.js
+++ b/packages/keymaster/src/keymaster-sdk.js
@@ -373,10 +373,20 @@ export default class KeymasterClient {
         }
     }
 
-    async resolveAsset(name) {
+    async resolveAsset(id) {
         try {
-            const response = await axios.get(`${this.API}/assets/${name}`);
+            const response = await axios.get(`${this.API}/assets/${id}`);
             return response.data.asset;
+        }
+        catch (error) {
+            throwError(error);
+        }
+    }
+
+    async updateAsset(id, data) {
+        try {
+            const response = await axios.put(`${this.API}/assets/${id}`, { data });
+            return response.data.ok;
         }
         catch (error) {
             throwError(error);

--- a/services/keymaster/server/src/keymaster-api.js
+++ b/services/keymaster/server/src/keymaster-api.js
@@ -631,6 +631,16 @@ v1router.get('/assets/:id', async (req, res) => {
     }
 });
 
+v1router.put('/assets/:id', async (req, res) => {
+    try {
+        const { data } = req.body;
+        const ok = await keymaster.updateAsset(req.params.id, data);
+        res.json({ ok });
+    } catch (error) {
+        return res.status(404).send({ error: 'Asset not found' });
+    }
+});
+
 v1router.get('/templates/poll', async (req, res) => {
     try {
         const template = await keymaster.pollTemplate();

--- a/services/keymaster/server/src/keymaster-api.js
+++ b/services/keymaster/server/src/keymaster-api.js
@@ -637,7 +637,7 @@ v1router.put('/assets/:id', async (req, res) => {
         const ok = await keymaster.updateAsset(req.params.id, data);
         res.json({ ok });
     } catch (error) {
-        return res.status(404).send({ error: 'Asset not found' });
+        res.status(500).send({ error: error.toString() });
     }
 });
 

--- a/tests/keymaster-client.test.js
+++ b/tests/keymaster-client.test.js
@@ -1024,6 +1024,38 @@ describe('resolveAsset', () => {
     });
 });
 
+describe('updateAsset', () => {
+    const mockAssetId = 'asset1';
+    const mockAsset = { id: mockAssetId, data: 'some data' };
+
+    it('should resolve asset', async () => {
+        nock(KeymasterURL)
+            .put(`${Endpoints.assets}/${mockAssetId}`)
+            .reply(200, { ok: true });
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const ok = await keymaster.updateAsset(mockAssetId, mockAsset);
+
+        expect(ok).toBe(true);
+    });
+
+    it('should throw exception on resolveAsset server error', async () => {
+        nock(KeymasterURL)
+            .put(`${Endpoints.assets}/${mockAssetId}`)
+            .reply(500, ServerError);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+
+        try {
+            await keymaster.updateAsset(mockAssetId, mockAsset);
+            throw new ExpectedExceptionError();
+        }
+        catch (error) {
+            expect(error.message).toBe(ServerError.message);
+        }
+    });
+});
+
 describe('createChallenge', () => {
     const mockDID = 'did:mock:challenge';
 

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -1237,30 +1237,6 @@ describe('createAsset', () => {
             expect(error.message).toBe('Invalid parameter: data');
         }
     });
-
-    it('should throw an exception for an empty list anchor', async () => {
-        mockFs({});
-
-        try {
-            await keymaster.createId('Bob');
-            await keymaster.createAsset([]);
-            throw new ExpectedExceptionError();
-        } catch (error) {
-            expect(error.message).toBe('Invalid parameter: data');
-        }
-    });
-
-    it('should throw an exception for an empty object anchor', async () => {
-        mockFs({});
-
-        try {
-            await keymaster.createId('Bob');
-            await keymaster.createAsset({});
-            throw new ExpectedExceptionError();
-        } catch (error) {
-            expect(error.message).toBe('Invalid parameter: data');
-        }
-    });
 });
 
 describe('listAssets', () => {

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -1213,19 +1213,6 @@ describe('createAsset', () => {
         }
     });
 
-    it('should throw an exception for null anchor', async () => {
-        mockFs({});
-
-        try {
-            await keymaster.createId('Bob');
-            await keymaster.createAsset();
-            throw new ExpectedExceptionError();
-        } catch (error) {
-            // eslint-disable-next-line
-            expect(error.message).toBe('Invalid parameter: data');
-        }
-    });
-
     it('should throw an exception for an empty string anchor', async () => {
         mockFs({});
 


### PR DESCRIPTION
Adds `PUT /assets/:id` to the keymaster REST API, and the corresponding updateAsset() function in KeymasterClient. 

CLI changes

`create-asset` - The file is now optional. If missing, an empty asset is created.
`set-asset` - New command to set the data of an asset. If file is missing, data will be reset to empty.
`set-property` - New command to set a single key-value pair in an asset's data. If value is missing the key will be removed.

Also fixes an issue that allows allows keymasters to sign operations even if the connected gatekeeper changes its default DID prefix.