### PR TITLE
refactor: Added name validation

### DIFF
--- a/packages/keymaster/src/keymaster-lib.js
+++ b/packages/keymaster/src/keymaster-lib.js
@@ -48,7 +48,7 @@ export default class Keymaster {
             throw new InvalidParameterError('options.cipher');
         }
 
-        this.defaultRegistry = process.env.KC_DEFAULT_REGISTRY || 'hyperswarm';
+        this.defaultRegistry = options.defaultRegistry || 'hyperswarm';
         this.ephemeralRegistry = 'hyperswarm';
         this.maxNameLength = options.maxNameLength || 32;
     }

--- a/services/keymaster/server/src/config.js
+++ b/services/keymaster/server/src/config.js
@@ -8,6 +8,7 @@ const config = {
     db: process.env.KC_KEYMASTER_DB || 'json',
     keymasterPassphrase: process.env.KC_ENCRYPTED_PASSPHRASE,
     walletCache: process.env.KC_WALLET_CACHE ? process.env.KC_WALLET_CACHE === 'true' : false,
+    defaultRegistry: process.env.KC_DEFAULT_REGISTRY
 };
 
 export default config;

--- a/services/keymaster/server/src/keymaster-api.js
+++ b/services/keymaster/server/src/keymaster-api.js
@@ -817,7 +817,8 @@ app.listen(port, async () => {
 
     const wallet = await initWallet();
     const cipher = new CipherNode();
-    keymaster = new Keymaster({ gatekeeper, wallet, cipher });
+    const defaultRegistry = config.defaultRegistry;
+    keymaster = new Keymaster({ gatekeeper, wallet, cipher, defaultRegistry });
     console.log(`Keymaster server running on port ${port}`);
     console.log(`Keymaster server persisting to ${config.db}`);
 

--- a/tests/keymaster.test.js
+++ b/tests/keymaster.test.js
@@ -82,6 +82,15 @@ describe('constructor', () => {
         catch (error) {
             expect(error.message).toBe('Invalid parameter: options.cipher');
         }
+
+        // Cover the ExpectedExceptionError class for completeness
+        try {
+            new Keymaster({ gatekeeper, wallet, cipher });
+            throw new ExpectedExceptionError();
+        }
+        catch (error) {
+            expect(error.message).toBe('Expected to throw an exception');
+        }
     });
 });
 
@@ -546,14 +555,14 @@ describe('createId', () => {
     it('should create a new ID on customized default registry', async () => {
         mockFs({});
 
-        process.env.KC_DEFAULT_REGISTRY = 'TFTC';
-        const keymaster = new Keymaster({ gatekeeper, wallet, cipher });
+        const defaultRegistry = 'TFTC';
+        const keymaster = new Keymaster({ gatekeeper, wallet, cipher, defaultRegistry });
 
         const name = 'Bob';
         const did = await keymaster.createId(name);
         const doc = await keymaster.resolveDID(did);
 
-        expect(doc.mdip.registry).toBe('TFTC');
+        expect(doc.mdip.registry).toBe(defaultRegistry);
     });
 
     it('should throw to create a second ID with the same name', async () => {


### PR DESCRIPTION
Keymaster wallet names (IDs and DID aliases) are now limited to 32 characters.  Additionally they cannot contain nonprintable characters such as a carriage return.