### PR TITLE
fix: Add registry queue size limit

### DIFF
--- a/packages/gatekeeper/src/db/json.js
+++ b/packages/gatekeeper/src/db/json.js
@@ -2,7 +2,7 @@ import fs from 'fs';
 import { InvalidDIDError } from '@mdip/common/errors';
 
 export default class DbJson {
-    constructor(name, folder='data') {
+    constructor(name, folder = 'data') {
         this.dataFolder = folder;
         this.dbName = `${this.dataFolder}/${name}.json`;
     }
@@ -98,7 +98,7 @@ export default class DbJson {
             db.queue = {};
         }
 
-        if (Object.keys(db.queue).includes(registry)) {
+        if (registry in db.queue) {
             db.queue[registry].push(op);
         }
         else {
@@ -106,6 +106,8 @@ export default class DbJson {
         }
 
         this.writeDb(db);
+
+        return db.queue[registry].length;
     }
 
     async getQueue(registry) {

--- a/packages/gatekeeper/src/db/mongo.js
+++ b/packages/gatekeeper/src/db/mongo.js
@@ -74,11 +74,13 @@ export default class DbMongo {
     }
 
     async queueOperation(registry, op) {
-        await this.db.collection('queue').updateOne(
+        const result = await this.db.collection('queue').findOneAndUpdate(
             { id: registry },
             { $push: { ops: op } },
-            { upsert: true }
+            { upsert: true, returnDocument: 'after' }
         );
+
+        return result.value.ops.length;
     }
 
     async getQueue(registry) {

--- a/packages/gatekeeper/src/db/mongo.js
+++ b/packages/gatekeeper/src/db/mongo.js
@@ -19,6 +19,7 @@ export default class DbMongo {
 
     async resetDb() {
         await this.db.collection('dids').deleteMany({});
+        await this.db.collection('queue').deleteMany({});
     }
 
     async addEvent(did, event) {

--- a/packages/gatekeeper/src/db/redis.js
+++ b/packages/gatekeeper/src/db/redis.js
@@ -77,7 +77,7 @@ export default class DbRedis {
     }
 
     async queueOperation(registry, op) {
-        await this.redis.rpush(`${this.dbName}/queue/${registry}`, JSON.stringify(op));
+        return this.redis.rpush(`${this.dbName}/queue/${registry}`, JSON.stringify(op));
     }
 
     async getQueue(registry) {

--- a/packages/gatekeeper/src/db/sqlite.js
+++ b/packages/gatekeeper/src/db/sqlite.js
@@ -31,6 +31,7 @@ export default class DbSqlite {
 
     async resetDb() {
         await this.db.run('DELETE FROM dids');
+        await this.db.run('DELETE FROM queue');
     }
 
     async addEvent(did, event) {

--- a/packages/gatekeeper/src/db/sqlite.js
+++ b/packages/gatekeeper/src/db/sqlite.js
@@ -89,7 +89,9 @@ export default class DbSqlite {
 
         ops.push(op);
 
-        return this.db.run(`INSERT OR REPLACE INTO queue(id, ops) VALUES(?, ?)`, registry, JSON.stringify(ops));
+        await this.db.run(`INSERT OR REPLACE INTO queue(id, ops) VALUES(?, ?)`, registry, JSON.stringify(ops));
+
+        return ops.length;
     }
 
     async getQueue(registry) {

--- a/packages/gatekeeper/src/gatekeeper.js
+++ b/packages/gatekeeper/src/gatekeeper.js
@@ -43,6 +43,7 @@ export default class Gatekeeper {
         this.cipher = new CipherNode();
         this.didPrefix = options.didPrefix || 'did:test';
         this.maxOpBytes = options.maxOpBytes || 64 * 1024; // 64KB
+        this.maxQueueSize = options.maxQueueSize || 100;
 
         // Only DIDs registered on supported registries will be created by this node
         this.supportedRegistries = options.registries || ['local'];
@@ -407,8 +408,12 @@ export default class Gatekeeper {
                 // Create events are distributed only by hyperswarm
                 // (because the DID's registry specifies where to look for *update* events)
                 // Don't distribute local DIDs
-                if (operation.mdip.registry !== 'local') {
-                    await this.db.queueOperation('hyperswarm', operation);
+                if (operation.mdip.registry !== 'local' && this.supportedRegistries.includes('hyperswarm')) {
+                    const queueSize = await this.db.queueOperation('hyperswarm', operation);
+
+                    if (queueSize >= this.maxQueueSize) {
+                        this.supportedRegistries = this.supportedRegistries.filter(registry => registry !== 'hyperswarm');
+                    }
                 }
             }
 
@@ -619,6 +624,11 @@ export default class Gatekeeper {
 
         const registry = doc.mdip.registry;
 
+        // Reject operations with unsupported registries
+        if (this.supportedRegistries && !this.supportedRegistries.includes(registry)) {
+            throw new InvalidOperationError(`doc.mdip.registry=${registry}`);
+        }
+
         await this.db.addEvent(operation.did, {
             registry: 'local',
             time: operation.signature.signed,
@@ -631,10 +641,18 @@ export default class Gatekeeper {
             return true;
         }
 
-        await this.db.queueOperation(registry, operation);
+        const queueSize = await this.db.queueOperation(registry, operation);
 
-        if (registry !== 'hyperswarm') {
-            await this.db.queueOperation('hyperswarm', operation);
+        if (queueSize >= this.maxQueueSize) {
+            this.supportedRegistries = this.supportedRegistries.filter(reg => reg !== registry);
+        }
+
+        if (registry !== 'hyperswarm' && this.supportedRegistries.includes('hyperswarm')) {
+            const queueSize = await this.db.queueOperation('hyperswarm', operation);
+
+            if (queueSize >= this.maxQueueSize) {
+                this.supportedRegistries = this.supportedRegistries.filter(reg => reg !== 'hyperswarm');
+            }
         }
 
         return true;


### PR DESCRIPTION
New option `maxQueueSize` added to Gatekeeper to limit the number of events in a registry queue. If a mediator stops draining its queue for whatever reason, and the queue fills up, the associated registry will be removed from the supported registry list until the mediator starts up again. While the registry is removed, createDID and updateDID will return an InvalidOperation error.

The monodb and sqlite db adapters were fixed to clear all queues in resetDb.

Also resolves #607 