### PR TITLE
chore: Prepare v1.0 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14454,7 +14454,7 @@
     },
     "packages/cipher": {
       "name": "@mdip/cipher",
-      "version": "0.6.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@mdip/browser-hdkey": "^0.1.8",
@@ -14470,7 +14470,7 @@
     },
     "packages/common": {
       "name": "@mdip/common",
-      "version": "0.6.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@mdip/ipfs": "*"
@@ -14484,7 +14484,7 @@
     },
     "packages/gatekeeper": {
       "name": "@mdip/gatekeeper",
-      "version": "0.6.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@mdip/cipher": "*",
@@ -14501,7 +14501,7 @@
     },
     "packages/ipfs": {
       "name": "@mdip/ipfs",
-      "version": "0.6.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@helia/json": "^2.0.0",
@@ -14513,7 +14513,7 @@
     },
     "packages/keymaster": {
       "name": "@mdip/keymaster",
-      "version": "0.6.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@mdip/common": "*",

--- a/packages/cipher/package.json
+++ b/packages/cipher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdip/cipher",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "description": "MDIP cipher lib",
   "type": "module",
   "exports": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdip/common",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "description": "MDIP common",
   "type": "module",
   "exports": {

--- a/packages/gatekeeper/package.json
+++ b/packages/gatekeeper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdip/gatekeeper",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "description": "MDIP Gatekeeper",
   "type": "module",
   "exports": {

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdip/ipfs",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "description": "MDIP IPFS lib",
   "type": "module",
   "exports": {

--- a/packages/keymaster/package.json
+++ b/packages/keymaster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdip/keymaster",
-  "version": "0.6.0",
+  "version": "1.0.0",
   "description": "MDIP Keymaster",
   "type": "module",
   "exports": {

--- a/sample.env
+++ b/sample.env
@@ -25,7 +25,7 @@ KC_GATEKEEPER_URL=http://localhost:4224
 
 # Hyperswarm
 KC_HYPR_EXPORT_INTERVAL=2
-KC_MDIP_PROTOCOL=
+KC_MDIP_PROTOCOL=/MDIP/v1.0-public
 
 # Bitcoin testnet4 mediator
 KC_TBTC_HOST=localhost

--- a/services/mediators/hyperswarm/src/config.js
+++ b/services/mediators/hyperswarm/src/config.js
@@ -6,7 +6,7 @@ const config = {
     debug: process.env.KC_DEBUG ? process.env.KC_DEBUG === 'true' : false,
     gatekeeperURL: process.env.KC_GATEKEEPER_URL || 'http://localhost:4224',
     nodeName: process.env.KC_NODE_NAME || 'anon',
-    protocol: process.env.KC_MDIP_PROTOCOL || '/MDIP/v0.6-beta',
+    protocol: process.env.KC_MDIP_PROTOCOL || '/MDIP/v1.0-public',
     exportInterval: process.env.KC_HYPR_EXPORT_INTERVAL ? parseInt(process.env.KC_HYPR_EXPORT_INTERVAL) : 2,
 };
 


### PR DESCRIPTION
Updated package versions to `1.0.0`
Updated default hyperswarm network `KC_MDIP_PROTOCOL=/MDIP/v1.0-public`