### PR TITLE
fix: JSDoc workflow ignore empty commit

### DIFF
--- a/.github/workflows/swagger-jsdoc.yml
+++ b/.github/workflows/swagger-jsdoc.yml
@@ -34,6 +34,6 @@ jobs:
           if git diff-index --quiet HEAD --; then
             echo "No changes to commit"
           else
-            git commit -m "chore: update generated OpenAPI docs"
+            git commit -m "chore: update generated OpenAPI docs" || true
             git push
           fi


### PR DESCRIPTION
- In the JSDoc workflow if there is nothing to commit then do not return an error.