### PR TITLE
fix: swagger workflow should use main branch

### DIFF
--- a/.github/workflows/swagger-jsdoc.yml
+++ b/.github/workflows/swagger-jsdoc.yml
@@ -10,6 +10,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 0
 
       - name: Use Node 18.18.2


### PR DESCRIPTION
- Fixes an issue where git in the swagger workflow running on a tag throws an error due to the being in a detached state.