### PR TITLE
feat: complete identity tab in Chrome browser extension

### DIFF
--- a/browser/chrome-extension/src/browser/BrowserContent.tsx
+++ b/browser/chrome-extension/src/browser/BrowserContent.tsx
@@ -26,8 +26,9 @@ import SchemaTab from "./components/SchemaTab";
 function BrowserContent() {
     const [menuOpen, setMenuOpen] = useState<boolean>(false);
     const [didRun, setDidRun] = useState<boolean>(false);
+    const [refresh, setRefresh] = useState<number>(0);
     const { currentId, isBrowser } = useWalletContext();
-    const { jsonViewerOptions, setJsonViewerOptions } = useUIContext();
+    const { openBrowser, setOpenBrowser } = useUIContext();
     const { darkMode } = useThemeContext();
 
     const theme = createTheme({
@@ -37,7 +38,7 @@ function BrowserContent() {
     });
 
     const [paramTab, setParamTab] = useState<string>("");
-    const [activeSubTab, setSubActiveTab] = useState<string>("");
+    const [activeSubTab, setActiveSubTab] = useState<string>("");
     const [activeTab, setActiveTab] = useState<string>("identities");
 
     useEffect(() => {
@@ -55,7 +56,7 @@ function BrowserContent() {
         }
 
         setActiveTab(initialTab);
-        setSubActiveTab(urlSubTab);
+        setActiveSubTab(urlSubTab);
 
         if (!urlDid && !urlDoc) {
             return;
@@ -70,7 +71,7 @@ function BrowserContent() {
             }
         }
 
-        setJsonViewerOptions({
+        setOpenBrowser({
             title: urlTitle,
             did: urlDid,
             tab: urlTab,
@@ -82,19 +83,20 @@ function BrowserContent() {
     }, [])
 
     useEffect(() => {
-        if (!isBrowser || !jsonViewerOptions) {
+        if (!isBrowser || !openBrowser) {
             return;
         }
 
-        const { tab, subTab } = jsonViewerOptions;
+        const { tab, subTab } = openBrowser;
         const useTab = tab === "credentials" && !currentId ? "identities" : tab || "viewer";
         setActiveTab(useTab);
         if (subTab) {
-            setSubActiveTab(subTab);
+            setActiveSubTab(subTab);
+            setRefresh(r => r + 1);
         }
 
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [jsonViewerOptions])
+    }, [openBrowser])
 
     // Set active tab once current ID is loaded as the paramTab value
     // is only available after the current ID is present.
@@ -197,7 +199,7 @@ function BrowserContent() {
                             </TabPanel>
                             {currentId && (
                                 <TabPanel value="credentials" sx={{ p: 0 }}>
-                                    <CredentialsTab subTab={activeSubTab} />
+                                    <CredentialsTab subTab={activeSubTab} refresh={refresh} />
                                 </TabPanel>
                             )}
                             {currentId && (

--- a/browser/chrome-extension/src/browser/browser.tsx
+++ b/browser/chrome-extension/src/browser/browser.tsx
@@ -2,19 +2,19 @@ import React, { useState } from "react";
 import ReactDOM from "react-dom/client";
 import BrowserContent from "./BrowserContent";
 import { ContextProviders } from "../shared/contexts/ContextProviders";
-import type { openJSONViewerOptions } from "../shared/contexts/UIContext";
+import type { openBrowserValues } from "../shared/contexts/UIContext";
 import "../shared/extension.css";
 import { RefreshMode } from '../shared/contexts/UIContext';
 
 const BrowserUI = () => {
-    const [jsonViewerOptions, setJsonViewerOptions] = useState<openJSONViewerOptions | null>(null);
+    const [openBrowser, setOpenBrowser] = useState<openBrowserValues | null>(null);
     const [browserRefresh, setBrowserRefresh] = useState<RefreshMode>(RefreshMode.NONE);
 
     chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         if (request.type === "PING_JSON_VIEWER") {
             sendResponse({ ack: true });
         } else if (request.type === "LOAD_JSON") {
-            setJsonViewerOptions(request.payload);
+            setOpenBrowser(request.payload);
         } else if (request.type === "BROWSER_REFRESH") {
             setBrowserRefresh(RefreshMode.WALLET);
         } else if (request.type === "BROWSER_THEME") {
@@ -25,8 +25,8 @@ const BrowserUI = () => {
     return (
         <ContextProviders
             isBrowser
-            jsonViewerOptions={jsonViewerOptions}
-            setJsonViewerOptions={setJsonViewerOptions}
+            openBrowser={openBrowser}
+            setOpenBrowser={setOpenBrowser}
             browserRefresh={browserRefresh}
             setBrowserRefresh={setBrowserRefresh}
         >

--- a/browser/chrome-extension/src/browser/components/CredentialsTab.tsx
+++ b/browser/chrome-extension/src/browser/components/CredentialsTab.tsx
@@ -1,12 +1,16 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Box, Stack, Tab, Tabs } from "@mui/material";
 import { TabContext, TabPanel } from "@mui/lab";
 import IssueTab from "./IssueTab";
 import IssuedTab from "./IssuedTab";
 import HeldTab from "../../shared/HeldTab";
 
-function CredentialsTab({ subTab }: {subTab: string}) {
-    const [credentialTab, setCredentialTab] = useState(subTab || "held");
+function CredentialsTab({ subTab, refresh }: {subTab: string, refresh: number}) {
+    const [credentialTab, setCredentialTab] = useState("held");
+
+    useEffect(() => {
+        setCredentialTab(subTab || "held");
+    }, [subTab, refresh])
 
     async function handleChange(event: React.SyntheticEvent, newValue: string) {
         setCredentialTab(newValue);

--- a/browser/chrome-extension/src/browser/components/GroupsTab.tsx
+++ b/browser/chrome-extension/src/browser/components/GroupsTab.tsx
@@ -6,13 +6,13 @@ import { useUIContext } from "../../shared/contexts/UIContext";
 import { ContentCopy } from "@mui/icons-material";
 import WarningModal from "../../shared/WarningModal";
 import JsonViewer from "./JsonViewer";
+import DisplayDID from "../../shared/DisplayDID";
 
 const GroupsTab = () => {
     const {
         keymaster,
         registries,
         setError,
-        handleCopyDID,
     } = useWalletContext();
     const {
         groupList,
@@ -20,7 +20,8 @@ const GroupsTab = () => {
     } = useCredentialsContext();
     const {
         refreshNames,
-        setJsonViewerOptions,
+        handleCopyDID,
+        setOpenBrowser,
     } = useUIContext();
 
     const [registry, setRegistry] = useState<string>('hyperswarm');
@@ -62,7 +63,7 @@ const GroupsTab = () => {
             const group = await keymaster.getGroup(groupName);
             setSelectedGroup(group);
             setMemberDID('');
-            setJsonViewerOptions({
+            setOpenBrowser({
                 title: "",
                 did: "",
                 tab: "groups",
@@ -79,7 +80,7 @@ const GroupsTab = () => {
     async function resolveMember(did: string) {
         try {
             setJsonDID(did);
-            setJsonViewerOptions({
+            setOpenBrowser({
                 title: "",
                 did,
                 tab: "groups",
@@ -107,7 +108,7 @@ const GroupsTab = () => {
         }
         if (removeDID === jsonDID) {
             setJsonDID('');
-            setJsonViewerOptions({
+            setOpenBrowser({
                 title: "",
                 did: "",
                 tab: "groups",
@@ -264,48 +265,25 @@ const GroupsTab = () => {
                         </Box>
                         {selectedGroup.members.map((did: string, index: number) => (
                             <Box key={index} display="flex" flexDirection="row" alignItems="center" sx={{ mb: 2 }}>
-                                <Tooltip title={did}>
-                                    <Typography
-                                        noWrap
-                                        sx={{
-                                            fontSize: '1.5em',
-                                            fontFamily: "Courier, monospace",
-                                            whiteSpace: 'nowrap',
-                                            overflow: 'hidden',
-                                            textOverflow: 'ellipsis'
-                                        }}
+                                <DisplayDID did={did} />
+                                <Box display="flex" flexDirection="row" sx={{ gap: 0 }}>
+                                    <Button
+                                        variant="contained"
+                                        color="primary"
+                                        onClick={() => resolveMember(did)}
+                                        className="button-left"
                                     >
-                                        {did}
-                                    </Typography>
-                                </Tooltip>
-                                <Tooltip title="Copy DID">
-                                    <IconButton
-                                        onClick={() => handleCopyDID(did)}
-                                        size="small"
-                                        sx={{
-                                            px: 0.5,
-                                            ml: 1,
-                                        }}
+                                        Resolve
+                                    </Button>
+                                    <Button
+                                        variant="contained"
+                                        color="primary"
+                                        onClick={() => handleRemoveMember(did)}
+                                        className="button-right"
                                     >
-                                        <ContentCopy fontSize="small" />
-                                    </IconButton>
-                                </Tooltip>
-                                <Button
-                                    variant="contained"
-                                    color="primary"
-                                    onClick={() => resolveMember(did)}
-                                    className="button-left"
-                                >
-                                    Resolve
-                                </Button>
-                                <Button
-                                    variant="contained"
-                                    color="primary"
-                                    onClick={() => handleRemoveMember(did)}
-                                    className="button-right"
-                                >
-                                    Remove
-                                </Button>
+                                        Remove
+                                    </Button>
+                                </Box>
                             </Box>
                         ))}
                         <JsonViewer browserTab="groups" />

--- a/browser/chrome-extension/src/browser/components/IssueTab.tsx
+++ b/browser/chrome-extension/src/browser/components/IssueTab.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useWalletContext } from "../../shared/contexts/WalletProvider";
 import { useCredentialsContext } from "../../shared/contexts/CredentialsProvider";
+import { useUIContext } from "../../shared/contexts/UIContext";
 import CredentialForm from "./CredentialForm";
 import {
     Box,
@@ -16,7 +17,6 @@ import { ContentCopy } from "@mui/icons-material";
 
 function IssueTab() {
     const {
-        handleCopyDID,
         keymaster,
         registries,
         registry,
@@ -36,6 +36,9 @@ function IssueTab() {
         setCredentialSubject,
         setIssuedList,
     } = useCredentialsContext();
+    const {
+        handleCopyDID,
+    } = useUIContext();
 
     const [schemaObject, setSchemaObject] = useState(null);
     const [isFormValid, setIsFormValid] = useState<boolean>(false);

--- a/browser/chrome-extension/src/browser/components/IssuedTab.tsx
+++ b/browser/chrome-extension/src/browser/components/IssuedTab.tsx
@@ -3,16 +3,15 @@ import {
     Box,
     Button,
     TextField,
-    Typography,
 } from "@mui/material";
 import { useWalletContext } from "../../shared/contexts/WalletProvider";
 import { useCredentialsContext } from "../../shared/contexts/CredentialsProvider";
 import { useUIContext } from "../../shared/contexts/UIContext";
 import WarningModal from "../../shared/WarningModal";
 import JsonViewer from "./JsonViewer";
+import DisplayDID from "../../shared/DisplayDID";
 
 function IssuedTab() {
-    const FONT_FAMILY = "Courier, monospace";
     const {
         keymaster,
         setError,
@@ -30,13 +29,13 @@ function IssuedTab() {
         setSelectedIssued,
     } = useCredentialsContext();
     const {
-        setJsonViewerOptions
+        setOpenBrowser
     } = useUIContext();
     const [open, setOpen] = useState(false);
     const [revokeDID, setRevokeDID] = useState("");
 
     async function resolveIssued(did: string) {
-        setJsonViewerOptions({
+        setOpenBrowser({
             title: "",
             did,
             tab: "credentials",
@@ -79,7 +78,7 @@ function IssuedTab() {
                 setIssuedEdit(false);
                 setIssuedString("");
                 setIssuedStringOriginal("");
-                setJsonViewerOptions({
+                setOpenBrowser({
                     title: "",
                     did: "",
                     tab: "credentials",
@@ -123,9 +122,7 @@ function IssuedTab() {
                             alignItems: "center",
                         }}
                     >
-                        <Typography style={{ fontSize: '1.5em', fontFamily: FONT_FAMILY }}>
-                            {did}
-                        </Typography>
+                        <DisplayDID did={did} />
                         <Box className="flex-row" sx={{ width: '80%'}}>
                             <Button
                                 variant="contained"
@@ -168,9 +165,7 @@ function IssuedTab() {
                 ))}
             </Box>
             {selectedIssued && <>
-                <Typography style={{ fontSize: '1.5em', fontFamily: FONT_FAMILY }}>
-                    {selectedIssued}
-                </Typography>
+                <DisplayDID did={selectedIssued} />
                 {(issuedEdit && issuedString) ? (
                     <TextField
                         value={issuedString}
@@ -183,7 +178,7 @@ function IssuedTab() {
                             input: {
                                 style: {
                                     fontSize: "1em",
-                                    fontFamily: FONT_FAMILY,
+                                    fontFamily: "Courier, monospace",
                                 },
                             }
                         }}

--- a/browser/chrome-extension/src/browser/components/JsonViewer.tsx
+++ b/browser/chrome-extension/src/browser/components/JsonViewer.tsx
@@ -22,7 +22,7 @@ function JsonViewer({browserTab, browserSubTab, showResolveField = false}: {brow
     const [currentDid, setCurrentDid] = useState<string>("");
     const [currentTitle, setCurrentTitle] = useState<string>("");
     const { keymaster, setError } = useWalletContext();
-    const { jsonViewerOptions, setJsonViewerOptions } = useUIContext();
+    const { openBrowser, setOpenBrowser } = useUIContext();
 
     useEffect(() => {
         const stored = sessionStorage.getItem(storageKey);
@@ -67,11 +67,11 @@ function JsonViewer({browserTab, browserSubTab, showResolveField = false}: {brow
     ]);
 
     useEffect(() => {
-        if (!jsonViewerOptions) {
+        if (!openBrowser) {
             return;
         }
 
-        const {title, did, tab, subTab, contents} = jsonViewerOptions;
+        const {title, did, tab, subTab, contents} = openBrowser;
 
         if (tab !== browserTab || (subTab && subTab !== browserSubTab)) {
             return;
@@ -102,13 +102,13 @@ function JsonViewer({browserTab, browserSubTab, showResolveField = false}: {brow
 
         setFormDid(did);
         setCurrentTitle(title);
-        setJsonViewerOptions(null);
+        setOpenBrowser(null);
 
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [jsonViewerOptions]);
+    }, [openBrowser]);
 
     async function handleResolveDID(did?: string) {
-        setJsonViewerOptions({
+        setOpenBrowser({
             title: "",
             did: did || formDid,
             tab: browserTab === "wallet" ? "viewer" : browserTab,

--- a/browser/chrome-extension/src/browser/components/SchemaTab.tsx
+++ b/browser/chrome-extension/src/browser/components/SchemaTab.tsx
@@ -7,13 +7,13 @@ import { ContentCopy } from "@mui/icons-material";
 
 const SchemaTab = ()=> {
     const {
-        handleCopyDID,
         keymaster,
         registries,
         setError,
         setSuccess,
     } = useWalletContext();
     const {
+        handleCopyDID,
         refreshNames,
     } = useUIContext();
     const {

--- a/browser/chrome-extension/src/browser/components/WalletTab.tsx
+++ b/browser/chrome-extension/src/browser/components/WalletTab.tsx
@@ -28,7 +28,7 @@ const WalletTab = () => {
     const [showFixModal, setShowFixModal] = useState<boolean>(false);
     const [checkResultMessage, setCheckResultMessage] = useState<string>("");
     const { setError, setSuccess, keymaster, initialiseWallet } = useWalletContext();
-    const { setJsonViewerOptions } = useUIContext();
+    const { setOpenBrowser } = useUIContext();
 
     const storageKey = "jsonViewerState-wallet-noSubTab";
 
@@ -54,7 +54,7 @@ const WalletTab = () => {
 
     function clearJsonWallet() {
         setJsonViewerOpen(false);
-        setJsonViewerOptions({
+        setOpenBrowser({
             title: "",
             did: "",
             tab: "wallet",
@@ -192,7 +192,7 @@ const WalletTab = () => {
         try {
             const wallet = await keymaster.loadWallet();
             setJsonViewerOpen(true);
-            setJsonViewerOptions({
+            setOpenBrowser({
                 title: "",
                 did: "",
                 tab: "wallet",

--- a/browser/chrome-extension/src/popup/PopupContent.tsx
+++ b/browser/chrome-extension/src/popup/PopupContent.tsx
@@ -35,6 +35,7 @@ const PopupContent = () => {
         currentId,
     } = useWalletContext();
     const {
+        openBrowserWindow,
         selectedTab,
         setSelectedTab,
     } = useUIContext();
@@ -59,7 +60,7 @@ const PopupContent = () => {
 
     function handleMenuClick(tab?: string) {
         handleMenuClose();
-        chrome.tabs.create({ url: "browser.html" + (tab ? `?tab=${tab}` : "") });
+        openBrowserWindow({ tab });
     }
 
     return (
@@ -126,7 +127,7 @@ const PopupContent = () => {
                         horizontal: "right",
                     }}
                 >
-                    <MenuItem onClick={() => handleMenuClick()}>Open Browser</MenuItem>
+                    <MenuItem onClick={() => handleMenuClick("identities")}>Open Browser</MenuItem>
                     <MenuItem onClick={() => handleMenuClick("groups")}>Groups</MenuItem>
                     <MenuItem onClick={() => handleMenuClick("schemas")}>Schemas</MenuItem>
                     <MenuItem onClick={() => handleMenuClick("wallet")}>Wallet</MenuItem>
@@ -179,7 +180,6 @@ const PopupContent = () => {
                 )}
             </Stack>
         </TabContext>
-
     );
 };
 

--- a/browser/chrome-extension/src/popup/components/AuthTab.tsx
+++ b/browser/chrome-extension/src/popup/components/AuthTab.tsx
@@ -24,7 +24,7 @@ function AuthTab() {
         setDisableSendResponse,
     } = useAuthContext();
     const {
-        openJSONViewer,
+        openBrowserWindow,
     } = useUIContext();
 
     async function newChallenge() {
@@ -41,7 +41,7 @@ function AuthTab() {
         try {
             const contents = await keymaster.resolveAsset(did);
             await setAuthDID(did);
-            openJSONViewer({ title: "Resolve Challenge", did, contents });
+            openBrowserWindow({ title: "Resolve Challenge", did, contents });
         } catch (error) {
             setError(error.error || error.message || String(error));
         }
@@ -76,7 +76,7 @@ function AuthTab() {
         try {
             const contents = await keymaster.decryptJSON(did);
             await setAuthDID(did);
-            openJSONViewer({ title: "Decrypt Response", did, contents });
+            openBrowserWindow({ title: "Decrypt Response", did, contents });
         } catch (error) {
             setError(error.error || error.message || String(error));
         }

--- a/browser/chrome-extension/src/popup/components/DIDsTab.tsx
+++ b/browser/chrome-extension/src/popup/components/DIDsTab.tsx
@@ -17,7 +17,6 @@ function DIDsTab() {
     const [open, setOpen] = useState(false);
     const [removeDID, setRemoveDID] = useState("");
     const {
-        handleCopyDID,
         isBrowser,
         keymaster,
         setError,
@@ -30,7 +29,8 @@ function DIDsTab() {
         setAliasName,
     } = useCredentialsContext();
     const {
-        openJSONViewer,
+        handleCopyDID,
+        openBrowserWindow,
         refreshNames,
     } = useUIContext();
 
@@ -114,7 +114,7 @@ function DIDsTab() {
                 <Button
                     variant="contained"
                     color="primary"
-                    onClick={() => openJSONViewer({ title: aliasName, did: aliasDID })}
+                    onClick={() => openBrowserWindow({ title: aliasName, did: aliasDID })}
                     className="button large bottom"
                     disabled={!aliasDID}
                 >
@@ -175,7 +175,7 @@ function DIDsTab() {
                                     </IconButton>
                                     <IconButton
                                         onClick={() =>
-                                            openJSONViewer({ title: name, did })
+                                            openBrowserWindow({ title: name, did })
                                         }
                                         size="small"
                                     >

--- a/browser/chrome-extension/src/shared/DisplayDID.tsx
+++ b/browser/chrome-extension/src/shared/DisplayDID.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import {
+    Box,
+    IconButton,
+    Tooltip,
+    Typography
+} from "@mui/material";
+import { ContentCopy } from "@mui/icons-material";
+import { useUIContext } from "./contexts/UIContext";
+
+const DisplayDID = ({ did }: { did: string }) => {
+    const {
+        handleCopyDID,
+    } = useUIContext();
+
+    return (
+        <Box
+            display="flex"
+            overflow="hidden"
+            alignItems="center"
+        >
+            <Tooltip title={did}>
+                <Typography
+                    noWrap
+                    sx={{
+                        fontSize: '1.5em',
+                        fontFamily: "Courier, monospace",
+                        whiteSpace: 'nowrap',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        minWidth: 0,
+                        flex: 1,
+                    }}
+                >
+                    {did}
+                </Typography>
+            </Tooltip>
+
+            <Tooltip title="Copy DID">
+                <IconButton
+                    onClick={() => handleCopyDID(did)}
+                    size="small"
+                    sx={{
+                        px: 0.5,
+                        ml: 1,
+                    }}
+                >
+                    <ContentCopy fontSize="small" />
+                </IconButton>
+            </Tooltip>
+        </Box>
+    );
+};
+
+export default DisplayDID;

--- a/browser/chrome-extension/src/shared/DropDownID.tsx
+++ b/browser/chrome-extension/src/shared/DropDownID.tsx
@@ -16,7 +16,6 @@ const DropDownID = () => {
     const {
         currentDID,
         currentId,
-        handleCopyDID,
         idList,
         isBrowser,
         keymaster,
@@ -24,7 +23,8 @@ const DropDownID = () => {
         setSelectedId,
     } = useWalletContext();
     const {
-        openJSONViewer,
+        handleCopyDID,
+        openBrowserWindow,
         resetCurrentID,
     } = useUIContext();
 
@@ -79,7 +79,7 @@ const DropDownID = () => {
                         <Tooltip title="Resolve DID">
                             <IconButton
                                 onClick={() =>
-                                    openJSONViewer({ title: currentId, did: currentDID })
+                                    openBrowserWindow({ title: currentId, did: currentDID })
                                 }
                                 size="small"
                                 sx={{

--- a/browser/chrome-extension/src/shared/HeldTab.tsx
+++ b/browser/chrome-extension/src/shared/HeldTab.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Box, Button, TextField, Typography } from "@mui/material";
+import { Box, Button, TextField } from "@mui/material";
 import { OpenInNew } from "@mui/icons-material";
 import WarningModal from "./WarningModal";
 import { useWalletContext } from "./contexts/WalletProvider";
@@ -7,6 +7,7 @@ import { useCredentialsContext } from "./contexts/CredentialsProvider";
 import { useUIContext } from "./contexts/UIContext";
 import JsonViewer from "../browser/components/JsonViewer";
 import { requestBrowserRefresh } from "./sharedScripts";
+import DisplayDID from "./DisplayDID";
 
 function HeldTab() {
     const [open, setOpen] = useState<boolean>(false);
@@ -26,8 +27,8 @@ function HeldTab() {
         setHeldDID,
     } = useCredentialsContext();
     const {
-        setJsonViewerOptions,
-        openJSONViewer,
+        setOpenBrowser,
+        openBrowserWindow,
         refreshHeld,
     } = useUIContext();
 
@@ -147,12 +148,12 @@ function HeldTab() {
     }
 
     function openIssueTab(subTab: string) {
-        chrome.tabs.create({ url: "browser.html?tab=credentials&subTab=" + subTab });
+        openBrowserWindow({ tab: "credentials", subTab });
     }
 
     function displayJson(title: string, did: string, contents?: any) {
         if (isBrowser) {
-            setJsonViewerOptions({
+            setOpenBrowser({
                 title,
                 did,
                 contents,
@@ -160,7 +161,7 @@ function HeldTab() {
                 subTab: "held",
             });
         } else {
-            openJSONViewer({title, did, contents, tab: "credentials", subTab: "held"});
+            openBrowserWindow({title, did, contents, tab: "credentials", subTab: "held"});
         }
     }
 
@@ -252,7 +253,7 @@ function HeldTab() {
             <Box className="overflow-box" sx={{ mb: 2 }}>
                 {heldList.map((did) => (
                     <Box key={did} className="margin-bottom">
-                        <Typography className="did-mono">{did}</Typography>
+                        <DisplayDID did={did} />
 
                         <Box className="flex-box">
                             <Button

--- a/browser/chrome-extension/src/shared/IdentitiesTab.tsx
+++ b/browser/chrome-extension/src/shared/IdentitiesTab.tsx
@@ -3,18 +3,27 @@ import { useWalletContext } from "./contexts/WalletProvider";
 import { Box, Button, MenuItem, Select, TextField } from "@mui/material";
 import { useUIContext } from "./contexts/UIContext";
 import { requestBrowserRefresh } from "./sharedScripts";
+import WarningModal from "./WarningModal";
+import TextInputModal from "./TextInputModal";
 
 function IdentitiesTab() {
     const [name, setName] = useState("");
+    const [warningModal, setWarningModal] = useState<boolean>(false);
+    const [removeCalled, setRemoveCalled] = useState<boolean>(false);
+    const [renameModalOpen, setRenameModalOpen] = useState(false);
+    const [recoverModalOpen, setRecoverModalOpen] = useState(false);
     const {
+        currentId,
         isBrowser,
         registry,
         setRegistry,
         registries,
         setError,
+        setSuccess,
         keymaster,
     } = useWalletContext();
     const {
+        refreshAll,
         resetCurrentID,
     } = useUIContext();
 
@@ -30,48 +39,196 @@ function IdentitiesTab() {
         }
     };
 
+    function handleRenameId() {
+        setRenameModalOpen(true);
+    }
+
+    async function renameId(newName: string) {
+        setRenameModalOpen(false);
+        const name = newName.trim();
+        if (!name) {
+            setError("Name cannot be empty");
+            return;
+        }
+
+        try {
+            await keymaster.renameId(currentId, name);
+            await refreshAll();
+        } catch (error) {
+            setError(error.error || error.message || String(error));
+        }
+    }
+
+    const handleCloseWarningModal = () => {
+        setWarningModal(false);
+    };
+
+    function handleRemoveId() {
+        setWarningModal(true);
+        setRemoveCalled(false);
+    }
+
+    async function removeId() {
+        setWarningModal(false);
+        // Prevents multiple removals if confirm button spammed
+        if (removeCalled) {
+            return;
+        }
+        setRemoveCalled(true);
+        try {
+            await keymaster.removeId(currentId);
+            await refreshAll();
+        } catch (error) {
+            setError(error.error || error.message || String(error));
+        }
+    }
+
+    async function backupId() {
+        try {
+            const ok = await keymaster.backupId(currentId);
+
+            if (ok) {
+                setSuccess(`${currentId} backup succeeded`);
+            } else {
+                setError(`${currentId} backup failed`);
+            }
+        } catch (error) {
+            setError(error.error || error.message || String(error));
+        }
+    }
+
+    async function handleRecoverId() {
+        setRecoverModalOpen(true);
+    }
+
+    async function recoverId(did: string) {
+        setRecoverModalOpen(false);
+        if (!did) {
+            return;
+        }
+
+        try {
+            const response = await keymaster.recoverId(did);
+            await refreshAll();
+            setSuccess(response + " recovered");
+        } catch (error) {
+            setError(error.error || error.message || String(error));
+        }
+    }
+
     return (
-        <Box className="flex-box mt-2" sx={{ maxWidth: "400px" }}>
-            <TextField
-                label="Create ID"
-                variant="outlined"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                size="small"
-                className="text-field name"
-                slotProps={{
-                    htmlInput: {
-                        maxLength: 30,
-                    },
-                }}
+        <Box>
+            <WarningModal
+                title="Remove Identity"
+                warningText={`Are you sure you want to remove ${currentId}?`}
+                isOpen={warningModal}
+                onClose={handleCloseWarningModal}
+                onSubmit={removeId}
             />
 
-            <Select
-                value={
-                    registries.length > 0 && registries.includes(registry)
-                        ? registry
-                        : ""
-                }
-                onChange={(e) => setRegistry(e.target.value)}
-                size="small"
-                variant="outlined"
-                className="select-small"
-            >
-                {registries.map((r) => (
-                    <MenuItem key={r} value={r}>
-                        {r}
-                    </MenuItem>
-                ))}
-            </Select>
+            <TextInputModal
+                isOpen={renameModalOpen}
+                title="Rename Identity"
+                description={`Rename ${currentId} to`}
+                label="New Name"
+                confirmText="Rename"
+                onSubmit={renameId}
+                onClose={() => setRenameModalOpen(false)}
+            />
 
-            <Button
-                variant="contained"
-                onClick={handleCreateId}
-                size="small"
-                className="button-right"
-            >
-                Create
-            </Button>
+            <TextInputModal
+                isOpen={recoverModalOpen}
+                title="Recover Identity"
+                description="Please enter the DID"
+                label="DID"
+                confirmText="Recover"
+                onSubmit={recoverId}
+                onClose={() => setRecoverModalOpen(false)}
+            />
+
+            <Box className="flex-box mt-2" sx={{ ml: 1, maxWidth: "400px" }}>
+                <TextField
+                    label="Create ID"
+                    variant="outlined"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    size="small"
+                    className="text-field name"
+                    slotProps={{
+                        htmlInput: {
+                            maxLength: 30,
+                        },
+                    }}
+                />
+
+                <Select
+                    value={
+                        registries.length > 0 && registries.includes(registry)
+                            ? registry
+                            : ""
+                    }
+                    onChange={(e) => setRegistry(e.target.value)}
+                    size="small"
+                    variant="outlined"
+                    className="select-small"
+                >
+                    {registries.map((r) => (
+                        <MenuItem key={r} value={r}>
+                            {r}
+                        </MenuItem>
+                    ))}
+                </Select>
+
+                <Button
+                    variant="contained"
+                    onClick={handleCreateId}
+                    size="small"
+                    className="button-right"
+                >
+                    Create
+                </Button>
+            </Box>
+            <Box className="flex-box mt-2">
+                <Button
+                    className="mini-margin"
+                    variant="contained"
+                    color="primary"
+                    onClick={handleRenameId}
+                    sx={{ mr: 2 }}
+                >
+                    Rename
+                </Button>
+
+                <Button
+                    className="mini-margin"
+                    variant="contained"
+                    color="primary"
+                    onClick={handleRemoveId}
+                    sx={{ mr: 2 }}
+                >
+                    Remove
+                </Button>
+
+                <Button
+                    className="mini-margin"
+                    variant="contained"
+                    color="primary"
+                    onClick={backupId}
+                    sx={{ mr: 2 }}
+                >
+                    Backup
+                </Button>
+
+                <Button
+                    className="mini-margin"
+                    variant="contained"
+                    color="primary"
+                    onClick={handleRecoverId}
+                    sx={{ mr: 2 }}
+                >
+                    Recover
+                </Button>
+            </Box>
         </Box>
     );
 }

--- a/browser/chrome-extension/src/shared/TextInputModal.tsx
+++ b/browser/chrome-extension/src/shared/TextInputModal.tsx
@@ -1,0 +1,79 @@
+import React, { useState, useEffect } from "react";
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    Button,
+    DialogContentText,
+    TextField,
+} from "@mui/material";
+
+interface TextInputModalProps {
+    isOpen: boolean;
+    title: string;
+    description?: string;
+    label?: string;
+    confirmText?: string;
+    defaultValue?: string;
+    onSubmit: (value: string) => void;
+    onClose: () => void;
+}
+
+const TextInputModal: React.FC<TextInputModalProps> = (
+    {
+        isOpen,
+        title,
+        description,
+        label = "Name",
+        confirmText = "Confirm",
+        defaultValue = "",
+        onSubmit,
+        onClose,
+    }) => {
+    const [value, setValue] = useState(defaultValue);
+
+    useEffect(() => {
+        if (isOpen) {
+            setValue(defaultValue);
+        }
+    }, [isOpen, defaultValue]);
+
+    const handleConfirm = (e: React.FormEvent) => {
+        e.preventDefault();
+        onSubmit(value.trim());
+    };
+
+    return (
+        <Dialog open={isOpen} onClose={onClose}>
+            <form onSubmit={handleConfirm}>
+                <DialogTitle>{title}</DialogTitle>
+                <DialogContent>
+                    {description && (
+                        <DialogContentText>{description}</DialogContentText>
+                    )}
+                    <TextField
+                        autoFocus
+                        margin="dense"
+                        label={label}
+                        type="text"
+                        fullWidth
+                        variant="outlined"
+                        value={value}
+                        onChange={(e) => setValue(e.target.value)}
+                    />
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={onClose} color="primary">
+                        Cancel
+                    </Button>
+                    <Button type="submit" variant="contained" color="primary">
+                        {confirmText}
+                    </Button>
+                </DialogActions>
+            </form>
+        </Dialog>
+    );
+};
+
+export default TextInputModal;

--- a/browser/chrome-extension/src/shared/WarningModal.tsx
+++ b/browser/chrome-extension/src/shared/WarningModal.tsx
@@ -8,7 +8,15 @@ import {
     DialogContentText,
 } from "@mui/material";
 
-const WarningModal = ({ isOpen, title, warningText, onSubmit, onClose }) => {
+interface WarningModalProps {
+    isOpen: boolean;
+    title: string;
+    warningText: string;
+    onSubmit: () => void;
+    onClose: () => void;
+}
+
+const WarningModal: React.FC<WarningModalProps> = ({ isOpen, title, warningText, onSubmit, onClose }) => {
     if (!isOpen) return null;
 
     function handleSubmit(e) {

--- a/browser/chrome-extension/src/shared/contexts/ContextProviders.tsx
+++ b/browser/chrome-extension/src/shared/contexts/ContextProviders.tsx
@@ -3,7 +3,7 @@ import { WalletProvider } from "./WalletProvider";
 import { CredentialsProvider } from "./CredentialsProvider";
 import { AuthProvider } from "./AuthContext";
 import { MessageProvider } from "./MessageContext";
-import { RefreshMode, UIProvider, openJSONViewerOptions } from "./UIContext";
+import { RefreshMode, UIProvider, openBrowserValues } from "./UIContext";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
 import { Box } from "@mui/material";
 import { requestBrowserRefresh } from "../sharedScripts";
@@ -21,16 +21,16 @@ export function ContextProviders(
         children,
         isBrowser,
         pendingAuth,
-        jsonViewerOptions,
-        setJsonViewerOptions,
+        openBrowser,
+        setOpenBrowser,
         browserRefresh,
         setBrowserRefresh,
     }: {
         children: ReactNode,
         isBrowser: boolean,
         pendingAuth?: string,
-        jsonViewerOptions?: openJSONViewerOptions,
-        setJsonViewerOptions?: Dispatch<SetStateAction<openJSONViewerOptions | null>>,
+        openBrowser?: openBrowserValues,
+        setOpenBrowser?: Dispatch<SetStateAction<openBrowserValues | null>>,
         browserRefresh?: RefreshMode,
         setBrowserRefresh?: Dispatch<SetStateAction<RefreshMode>>,
     }) {
@@ -86,10 +86,10 @@ export function ContextProviders(
                                 <MessageProvider>
                                     <UIProvider
                                         pendingAuth={pendingAuth}
-                                        jsonViewerOptions={jsonViewerOptions}
+                                        openBrowser={openBrowser}
                                         browserRefresh={browserRefresh}
                                         setBrowserRefresh={setBrowserRefresh}
-                                        setJsonViewerOptions={setJsonViewerOptions}
+                                        setOpenBrowser={setOpenBrowser}
                                     >
                                         {children}
                                     </UIProvider>

--- a/browser/chrome-extension/src/shared/contexts/WalletProvider.tsx
+++ b/browser/chrome-extension/src/shared/contexts/WalletProvider.tsx
@@ -47,7 +47,6 @@ interface WalletContextValue {
     setManifest: Dispatch<SetStateAction<any>>;
     resolveDID: () => Promise<void>;
     initialiseWallet: () => Promise<void>;
-    handleCopyDID: (did: string) => void;
     storeState: (key: string, value: string | boolean) => Promise<void>;
     refreshWalletStored: (state: any) => Promise<void>;
     resetWalletState: () => void;
@@ -279,12 +278,6 @@ export function WalletProvider({ children, isBrowser }: { children: ReactNode, i
         }
     }
 
-    function handleCopyDID(did: string) {
-        navigator.clipboard.writeText(did).catch((err) => {
-            setError(err.message || String(err));
-        });
-    }
-
     const value: WalletContextValue = {
         currentId,
         setCurrentId,
@@ -305,7 +298,6 @@ export function WalletProvider({ children, isBrowser }: { children: ReactNode, i
         setSuccess,
         resolveDID,
         initialiseWallet,
-        handleCopyDID,
         storeState,
         resetWalletState,
         refreshWalletStored,

--- a/packages/keymaster/types/index.d.ts
+++ b/packages/keymaster/types/index.d.ts
@@ -131,6 +131,7 @@ declare module '@mdip/keymaster' {
         publishPoll(pollId: string, options?: { reveal?: boolean }): Promise<boolean>;
         recoverId(did: string): Promise<string>;
         recoverWallet(did?: string): Promise<any>;
+        renameId(id: string, name: string): Promise<any>;
         removeCredential(id: string): Promise<any>;
         removeGroupMember(groupId: string, memberId: string): Promise<boolean>;
         removeFromHeld(did: string): Promise<boolean>;


### PR DESCRIPTION
- Resolves https://github.com/KeychainMDIP/kc/issues/610
- When MDIP browser is open popup menu items, issued button and issue button no longer open new tabs but navigate the open tab.
- Introduce DisplayDID component to show a DID with copy button, DID will truncate, tooltip shows full DID. Used in groups, issued and issue tabs.