### PR TITLE
fix: Default registry in docker file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - ./data:/app/gatekeeper/data
     user: "${KC_UID}:${KC_GID}"
     ports:
-      - 4224:4224
+      - ${KC_GATEKEEPER_PORT}:4224
     depends_on:
       - mongodb
       - redis
@@ -45,13 +45,14 @@ services:
       - KC_KEYMASTER_DB=${KC_KEYMASTER_DB}
       - KC_ENCRYPTED_PASSPHRASE=${KC_ENCRYPTED_PASSPHRASE}
       - KC_WALLET_CACHE=${KC_WALLET_CACHE}
+      - KC_DEFAULT_REGISTRY=${KC_DEFAULT_REGISTRY}
       - KC_MONGODB_URL=mongodb://mongodb:27017
       - KC_REDIS_URL=redis://redis:6379
     volumes:
       - ./data:/app/keymaster/data
     user: "${KC_UID}:${KC_GID}"
     ports:
-      - 4226:4226
+      - ${KC_KEYMASTER_PORT}:4226
     depends_on:
       - gatekeeper
 
@@ -72,7 +73,7 @@ services:
       - gatekeeper
 
   tftc-node:
-    image: keychainmdip/feathercoin:v0.19.1
+    image: keychainmdip/feathercoin:v0.19.2
     volumes:
       - ./data/tftc:/root/.feathercoin
 

--- a/sample.env
+++ b/sample.env
@@ -21,7 +21,7 @@ KC_DEFAULT_REGISTRY=hyperswarm
 
 # CLI
 KC_GATEKEEPER_URL=http://localhost:4224
-# KC_KEYMASTER_URL=http://localhost:4226
+KC_KEYMASTER_URL=http://localhost:4226
 
 # Hyperswarm
 KC_HYPR_EXPORT_INTERVAL=2


### PR DESCRIPTION
Also now uses `KC_GATEKEEPER_PORT` and `KC_KEYMASTER_PORT` to make it easier to run multiple nodes on the same machine, simply make sure each node uses a different port e.g. 14224, 24224, 34224 to run 3 gatekeepers on the same machine.