### PR TITLE
fix: backup-id CLI command

### DIFF
--- a/packages/keymaster/src/keymaster-client.ts
+++ b/packages/keymaster/src/keymaster-client.ts
@@ -335,6 +335,9 @@ export default class KeymasterClient implements KeymasterInterface {
 
     async backupId(id?: string): Promise<boolean> {
         try {
+            if (!id) {
+                id = await this.getCurrentId();
+            }
             const response = await axios.post(`${this.API}/ids/${id}/backup`);
             return response.data.ok;
         }

--- a/tests/keymaster-client.test.ts
+++ b/tests/keymaster-client.test.ts
@@ -1,7 +1,7 @@
 import nock from 'nock';
 import KeymasterClient from '@mdip/keymaster/client';
 import { ExpectedExceptionError } from '@mdip/common/errors';
-import {Seed, WalletFile} from "@mdip/keymaster/types";
+import { Seed, WalletFile } from "@mdip/keymaster/types";
 
 const KeymasterURL = 'http://keymaster.org';
 const ServerError = { message: 'Server error' };
@@ -731,6 +731,22 @@ describe('backupId', () => {
 
         const keymaster = await KeymasterClient.create({ url: KeymasterURL });
         const ok = await keymaster.backupId(mockName);
+
+        expect(ok).toStrictEqual(true);
+    });
+
+    it('should backup current ID', async () => {
+
+        nock(KeymasterURL)
+            .get(Endpoints.ids_current)
+            .reply(200, { current: mockName });
+
+        nock(KeymasterURL)
+            .post(`${Endpoints.ids}/${mockName}/backup`)
+            .reply(200, { ok: true });
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const ok = await keymaster.backupId();
 
         expect(ok).toStrictEqual(true);
     });
@@ -1693,7 +1709,7 @@ describe('updateCredential', () => {
 });
 
 describe('listCredentials', () => {
-    const mockCredentials = [ 'cred1', 'cred2', 'cred3' ];
+    const mockCredentials = ['cred1', 'cred2', 'cred3'];
 
     it('should list credentials', async () => {
         nock(KeymasterURL)
@@ -1880,7 +1896,7 @@ describe('unpublishCredential', () => {
 });
 
 describe('listIssued', () => {
-    const mockCredentials = [ 'cred1', 'cred2', 'cred3' ];
+    const mockCredentials = ['cred1', 'cred2', 'cred3'];
 
     it('should list issued credentials', async () => {
         nock(KeymasterURL)


### PR DESCRIPTION
This PR fixes the backup-id CLI command by refining the parameter handling and backup process.

-    Renames the parameter in backupId to improve clarity
-    Updates the backup process by fetching ID info based on either the provided value or the current wallet state
-    Adds a fallback in the client implementation to retrieve the current ID when none is provided
