### PR TITLE
feat: Adds clone-asset command

### DIFF
--- a/doc/keymaster-api.json
+++ b/doc/keymaster-api.json
@@ -4280,6 +4280,83 @@
         }
       }
     },
+    "/assets/{id}/clone": {
+      "post": {
+        "summary": "Clone an existing asset.",
+        "description": "Creates a new asset by cloning the data of an existing asset identified by its DID or name. The cloned asset will include a reference to the original asset in its metadata.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The DID or name of the asset to clone."
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "options": {
+                    "type": "object",
+                    "description": "Additional parameters for cloning the asset.",
+                    "properties": {
+                      "registry": {
+                        "type": "string",
+                        "description": "The registry in which to create the cloned asset (e.g., \"local\", \"hyperswarm\")."
+                      },
+                      "validUntil": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Expiration timestamp for the cloned asset."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The DID of the newly created cloned asset.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "did": {
+                      "type": "string",
+                      "description": "The DID of the cloned asset."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/templates/poll": {
       "get": {
         "summary": "Retrieve a boilerplate poll template.",

--- a/packages/keymaster/src/keymaster-client.ts
+++ b/packages/keymaster/src/keymaster-client.ts
@@ -429,6 +429,19 @@ export default class KeymasterClient implements KeymasterInterface {
         }
     }
 
+    async cloneAsset(
+        id: string,
+        options?: CreateAssetOptions
+    ): Promise<string> {
+        try {
+            const response = await axios.post(`${this.API}/assets/${id}/clone`, { options });
+            return response.data.did;
+        }
+        catch (error) {
+            throwError(error);
+        }
+    }
+
     async listAssets(): Promise<string[]> {
         try {
             const response = await axios.get(`${this.API}/assets`);

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -654,6 +654,24 @@ export default class Keymaster implements KeymasterInterface {
         return did;
     }
 
+    async cloneAsset(
+        id: string,
+        options: CreateAssetOptions = {}
+    ): Promise<string> {
+        const assetDoc = await this.resolveDID(id);
+
+        if (assetDoc.mdip?.type !== 'asset') {
+            throw new InvalidParameterError('id');
+        }
+
+        const assetData = assetDoc.didDocumentData || {};
+
+        // Add a cloned property to track the origin
+        (assetData as Record<string, unknown>).cloned = assetDoc.didDocument!.id;
+
+        return this.createAsset(assetData, options);
+    }
+
     async createImage(
         buffer: Buffer,
         options: CreateAssetOptions = {}

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -665,11 +665,9 @@ export default class Keymaster implements KeymasterInterface {
         }
 
         const assetData = assetDoc.didDocumentData || {};
+        const cloneData = { ...assetData, cloned: assetDoc.didDocument!.id };
 
-        // Add a cloned property to track the origin
-        (assetData as Record<string, unknown>).cloned = assetDoc.didDocument!.id;
-
-        return this.createAsset(assetData, options);
+        return this.createAsset(cloneData, options);
     }
 
     async createImage(

--- a/scripts/keychain-cli.js
+++ b/scripts/keychain-cli.js
@@ -895,6 +895,30 @@ program
     });
 
 program
+    .command('transfer-asset <id> <controller>')
+    .description('Transfer asset to a new controller')
+    .action(async (id, controller) => {
+        try {
+            const ok = await keymaster.transferAsset(id, controller);
+            console.log(ok ? UPDATE_OK : UPDATE_FAILED);
+        } catch (error) {
+            console.error(error.error || error);
+        }
+    });
+
+program
+    .command('clone-asset <id>')
+    .description('Clone an asset')
+    .action(async (id) => {
+        try {
+            const did = await keymaster.cloneAsset(id);
+            console.log(did);
+        } catch (error) {
+            console.error(error.error || error);
+        }
+    });
+
+program
     .command('set-property <id> <key> [value]')
     .description('Assign a key-value pair to an asset')
     .action(async (id, key, value) => {
@@ -1117,18 +1141,6 @@ program
             console.timeEnd('total');
         }
         catch (error) {
-            console.error(error.error || error);
-        }
-    });
-
-program
-    .command('transfer-asset <id> <controller>')
-    .description('Transfer asset to a new controller')
-    .action(async (id, controller) => {
-        try {
-            const ok = await keymaster.transferAsset(id, controller);
-            console.log(ok ? UPDATE_OK : UPDATE_FAILED);
-        } catch (error) {
             console.error(error.error || error);
         }
     });

--- a/services/keymaster/server/src/keymaster-api.ts
+++ b/services/keymaster/server/src/keymaster-api.ts
@@ -3557,6 +3557,60 @@ v1router.post('/assets/:id/transfer', async (req, res) => {
     }
 });
 
+/**
+ * @swagger
+ * /assets/{id}/clone:
+ *   post:
+ *     summary: Clone an existing asset.
+ *     description: >
+ *       Creates a new asset by cloning the data of an existing asset identified by its DID or name.
+ *       The cloned asset will include a reference to the original asset in its metadata.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The DID or name of the asset to clone.
+ *     requestBody:
+ *       required: false
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               options:
+ *                 type: object
+ *                 description: Additional parameters for cloning the asset.
+ *                 properties:
+ *                   registry:
+ *                     type: string
+ *                     description: The registry in which to create the cloned asset (e.g., "local", "hyperswarm").
+ *                   validUntil:
+ *                     type: string
+ *                     format: date-time
+ *                     description: Expiration timestamp for the cloned asset.
+ *     responses:
+ *       200:
+ *         description: The DID of the newly created cloned asset.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 did:
+ *                   type: string
+ *                   description: The DID of the cloned asset.
+ *       500:
+ *         description: Internal server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ */
 v1router.post('/assets/:id/clone', async (req, res) => {
     try {
         const { options } = req.body;

--- a/services/keymaster/server/src/keymaster-api.ts
+++ b/services/keymaster/server/src/keymaster-api.ts
@@ -3557,6 +3557,16 @@ v1router.post('/assets/:id/transfer', async (req, res) => {
     }
 });
 
+v1router.post('/assets/:id/clone', async (req, res) => {
+    try {
+        const { options } = req.body;
+        const did = await keymaster.cloneAsset(req.params.id, options);
+        res.json({ did });
+    } catch (error: any) {
+        res.status(500).send({ error: error.toString() });
+    }
+});
+
 /**
  * @swagger
  * /templates/poll:

--- a/tests/keymaster-client.test.ts
+++ b/tests/keymaster-client.test.ts
@@ -1096,6 +1096,70 @@ describe('updateAsset', () => {
     });
 });
 
+describe('cloneAsset', () => {
+    const mockDID = 'did:example:123456789abcd';
+    const cloneDID = 'did:example:123456789clone';
+
+    it('should clone asset', async () => {
+        nock(KeymasterURL)
+            .post(`${Endpoints.assets}/${mockDID}/clone`)
+            .reply(200, { did: cloneDID });
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const did = await keymaster.cloneAsset(mockDID);
+
+        expect(did).toBe(cloneDID);
+    });
+
+    it('should throw exception on cloneAsset server error', async () => {
+        nock(KeymasterURL)
+            .post(`${Endpoints.assets}/${mockDID}/clone`)
+            .reply(500, ServerError);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+
+        try {
+            await keymaster.cloneAsset(mockDID);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(ServerError.message);
+        }
+    });
+});
+
+describe('transferAsset', () => {
+    const mockDID = 'did:example:123456789abcd';
+    const controller = 'did:example:controller';
+
+    it('should clone asset', async () => {
+        nock(KeymasterURL)
+            .post(`${Endpoints.assets}/${mockDID}/transfer`)
+            .reply(200, { ok: true });
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const ok = await keymaster.transferAsset(mockDID, controller);
+
+        expect(ok).toBe(true);
+    });
+
+    it('should throw exception on cloneAsset server error', async () => {
+        nock(KeymasterURL)
+            .post(`${Endpoints.assets}/${mockDID}/transfer`)
+            .reply(500, ServerError);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+
+        try {
+            await keymaster.transferAsset(mockDID, controller);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(ServerError.message);
+        }
+    });
+});
+
 describe('createChallenge', () => {
     const mockDID = 'did:mock:challenge';
 

--- a/tests/keymaster-client.test.ts
+++ b/tests/keymaster-client.test.ts
@@ -971,7 +971,7 @@ describe('resolveDID', () => {
 
 describe('createAsset', () => {
     const mockAsset = { id: 'asset1', data: 'some data' };
-    const mockDID = 'did:example:123456789abcd';
+    const mockDID = 'did:example:1234567890abcd';
 
     it('should create asset', async () => {
         nock(KeymasterURL)
@@ -1097,7 +1097,7 @@ describe('updateAsset', () => {
 });
 
 describe('cloneAsset', () => {
-    const mockDID = 'did:example:123456789abcd';
+    const mockDID = 'did:example:123456789abcdef';
     const cloneDID = 'did:example:123456789clone';
 
     it('should clone asset', async () => {
@@ -1132,7 +1132,7 @@ describe('transferAsset', () => {
     const mockDID = 'did:example:123456789abcd';
     const controller = 'did:example:controller';
 
-    it('should clone asset', async () => {
+    it('should transfer asset', async () => {
         nock(KeymasterURL)
             .post(`${Endpoints.assets}/${mockDID}/transfer`)
             .reply(200, { ok: true });
@@ -1143,7 +1143,7 @@ describe('transferAsset', () => {
         expect(ok).toBe(true);
     });
 
-    it('should throw exception on cloneAsset server error', async () => {
+    it('should throw exception on transferAsset server error', async () => {
         nock(KeymasterURL)
             .post(`${Endpoints.assets}/${mockDID}/transfer`)
             .reply(500, ServerError);


### PR DESCRIPTION
This pull request introduces a new "clone-asset" feature that allows users to clone existing assets in the system. Key changes include:

-    Addition of new tests for cloneAsset functionality in both keymaster and keymaster-client test files.
-    Implementation of the cloneAsset API endpoint and corresponding service logic in Keymaster and KeymasterClient.
-    Integration of new CLI commands to access both cloneAsset and transferAsset functionalities.
