### PR TITLE
feat: Added name to createAsset options

### DIFF
--- a/doc/keymaster-api.json
+++ b/doc/keymaster-api.json
@@ -3996,29 +3996,13 @@
                         "format": "date-time",
                         "description": "Expiration date/time for an ephemeral asset. Omit for a permanent asset."
                       },
-                      "retries": {
-                        "type": "integer",
-                        "default": 0,
-                        "description": "Number of times to retry creation if not successful at first."
-                      },
-                      "delay": {
-                        "type": "integer",
-                        "default": 1000,
-                        "description": "Milliseconds to wait between retries."
-                      },
-                      "encryptForSender": {
-                        "type": "boolean",
-                        "default": true,
-                        "description": "Whether to include an encrypted copy for the creator (sender)."
-                      },
-                      "includeHash": {
-                        "type": "boolean",
-                        "default": false,
-                        "description": "Whether to embed a hash of the `data` in the asset for verification."
-                      },
                       "controller": {
                         "type": "string",
                         "description": "Specific ID or DID to act as the asset’s controller. Defaults to the current ID."
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "A human-readable name for the asset."
                       }
                     }
                   }

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -614,7 +614,7 @@ export default class Keymaster implements KeymasterInterface {
         data: unknown,
         options: CreateAssetOptions = {}
     ): Promise<string> {
-        let { registry = this.defaultRegistry, controller, validUntil } = options;
+        let { registry = this.defaultRegistry, controller, validUntil, name } = options;
 
         if (validUntil) {
             const validate = new Date(validUntil);
@@ -622,6 +622,11 @@ export default class Keymaster implements KeymasterInterface {
             if (isNaN(validate.getTime())) {
                 throw new InvalidParameterError('options.validUntil');
             }
+        }
+
+        if (name) {
+            const wallet = await this.loadWallet();
+            this.validateName(name, wallet);
         }
 
         if (!data) {
@@ -649,6 +654,10 @@ export default class Keymaster implements KeymasterInterface {
         // Keep assets that will be garbage-collected out of the owned list
         if (!validUntil) {
             await this.addToOwned(did);
+        }
+
+        if (name) {
+            await this.addName(name, did);
         }
 
         return did;

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -1605,7 +1605,7 @@ export default class Keymaster implements KeymasterInterface {
 
     async createChallenge(
         challenge: Challenge = {},
-        options: { registry?: string; validUntil?: string } = {}
+        options: CreateAssetOptions = {}
     ): Promise<string> {
 
         if (!challenge || typeof challenge !== 'object' || Array.isArray(challenge)) {
@@ -1864,7 +1864,7 @@ export default class Keymaster implements KeymasterInterface {
             members: options.members || []
         };
 
-        return this.createAsset({ group }, options);
+        return this.createAsset({ group }, { ...options, name });
     }
 
     async getGroup(id: string): Promise<Group | null> {

--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -52,7 +52,8 @@ export interface FixWalletResult {
 export interface CreateAssetOptions {
     registry?: string;
     controller?: string;
-    validUntil?: string
+    validUntil?: string;
+    name?: string;
 }
 
 export interface EncryptOptions {

--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -56,11 +56,9 @@ export interface CreateAssetOptions {
     name?: string;
 }
 
-export interface EncryptOptions {
+export interface EncryptOptions extends CreateAssetOptions {
     encryptForSender?: boolean;
     includeHash?: boolean;
-    registry?: string;
-    validUntil?: string;
 }
 
 export interface Group {
@@ -88,12 +86,10 @@ export interface VerifiableCredential {
     signature?: Signature;
 }
 
-export interface IssueCredentialsOptions {
+export interface IssueCredentialsOptions extends EncryptOptions {
     schema?: string;
     subject?: string;
-    registry?: string;
     validFrom?: string;
-    validUntil?: string;
     credential?: Record<string, unknown>;
 }
 

--- a/scripts/keychain-cli.js
+++ b/scripts/keychain-cli.js
@@ -189,12 +189,7 @@ program
     .action(async () => {
         try {
             const ok = await keymaster.backupId();
-            if (ok) {
-                console.log(UPDATE_OK);
-            }
-            else {
-                console.log(UPDATE_FAILED);
-            }
+            console.log(ok ? UPDATE_OK : UPDATE_FAILED);
         }
         catch (error) {
             console.error(error.error || error);
@@ -401,12 +396,7 @@ program
     .action(async (file, name) => {
         try {
             const challenge = file ? JSON.parse(fs.readFileSync(file).toString()) : undefined;
-            const did = await keymaster.createChallenge(challenge);
-
-            if (name) {
-                await keymaster.addName(name, did);
-            }
-
+            const did = await keymaster.createChallenge(challenge, { name });
             console.log(did);
         }
         catch (error) {
@@ -420,12 +410,7 @@ program
     .action(async (credentialDID, name) => {
         try {
             const challenge = { credentials: [{ schema: credentialDID }] };
-            const did = await keymaster.createChallenge(challenge);
-
-            if (name) {
-                await keymaster.addName(name, did);
-            }
-
+            const did = await keymaster.createChallenge(challenge, { name });
             console.log(did);
         }
         catch (error) {
@@ -452,12 +437,7 @@ program
     .action(async (file, registry, name) => {
         try {
             const vc = JSON.parse(fs.readFileSync(file).toString());
-            const did = await keymaster.issueCredential(vc, { registry });
-
-            if (name) {
-                await keymaster.addName(name, did);
-            }
-
+            const did = await keymaster.issueCredential(vc, { registry, name });
             console.log(did);
         }
         catch (error) {
@@ -471,7 +451,6 @@ program
     .action(async () => {
         try {
             const response = await keymaster.listIssued();
-
             console.log(JSON.stringify(response, null, 4));
         }
         catch (error) {
@@ -485,12 +464,7 @@ program
     .action(async (did) => {
         try {
             const ok = await keymaster.revokeCredential(did);
-            if (ok) {
-                console.log(UPDATE_OK);
-            }
-            else {
-                console.log(UPDATE_FAILED);
-            }
+            console.log(ok ? UPDATE_OK : UPDATE_FAILED);
         }
         catch (error) {
             console.error(error.error || error);
@@ -676,7 +650,6 @@ program
         try {
             const did = await keymaster.createGroup(name);
             console.log(did);
-            await keymaster.addName(name, did);
         }
         catch (error) {
             console.error(error.error || error);
@@ -754,12 +727,7 @@ program
     .action(async (file, name) => {
         try {
             const schema = JSON.parse(fs.readFileSync(file).toString());
-            const did = await keymaster.createSchema(schema);
-
-            if (name) {
-                await keymaster.addName(name, did);
-            }
-
+            const did = await keymaster.createSchema(schema, { name });
             console.log(did);
         }
         catch (error) {
@@ -958,12 +926,7 @@ program
     .action(async (file, name) => {
         try {
             const poll = JSON.parse(fs.readFileSync(file).toString());
-            const did = await keymaster.createPoll(poll);
-
-            if (name) {
-                await keymaster.addName(name, did);
-            }
-
+            const did = await keymaster.createPoll(poll, { name });
             console.log(did);
         }
         catch (error) {
@@ -1003,12 +966,7 @@ program
     .action(async (ballot) => {
         try {
             const ok = await keymaster.updatePoll(ballot);
-            if (ok) {
-                console.log(UPDATE_OK);
-            }
-            else {
-                console.log(UPDATE_FAILED);
-            }
+            console.log(ok ? UPDATE_OK : UPDATE_FAILED);
         }
         catch (error) {
             console.error(error.error || error);
@@ -1021,12 +979,7 @@ program
     .action(async (poll) => {
         try {
             const ok = await keymaster.publishPoll(poll);
-            if (ok) {
-                console.log(UPDATE_OK);
-            }
-            else {
-                console.log(UPDATE_FAILED);
-            }
+            console.log(ok ? UPDATE_OK : UPDATE_FAILED);
         }
         catch (error) {
             console.error(error.error || error);
@@ -1039,12 +992,7 @@ program
     .action(async (poll) => {
         try {
             const ok = await keymaster.publishPoll(poll, { reveal: true });
-            if (ok) {
-                console.log(UPDATE_OK);
-            }
-            else {
-                console.log(UPDATE_FAILED);
-            }
+            console.log(ok ? UPDATE_OK : UPDATE_FAILED);
         }
         catch (error) {
             console.error(error.error || error);
@@ -1057,12 +1005,7 @@ program
     .action(async (poll) => {
         try {
             const ok = await keymaster.unpublishPoll(poll);
-            if (ok) {
-                console.log(UPDATE_OK);
-            }
-            else {
-                console.log(UPDATE_FAILED);
-            }
+            console.log(ok ? UPDATE_OK : UPDATE_FAILED);
         }
         catch (error) {
             console.error(error.error || error);

--- a/services/keymaster/server/src/keymaster-api.ts
+++ b/services/keymaster/server/src/keymaster-api.ts
@@ -3323,25 +3323,13 @@ v1router.post('/schemas/:id/template', async (req, res) => {
  *                     type: string
  *                     format: date-time
  *                     description: Expiration date/time for an ephemeral asset. Omit for a permanent asset.
- *                   retries:
- *                     type: integer
- *                     default: 0
- *                     description: Number of times to retry creation if not successful at first.
- *                   delay:
- *                     type: integer
- *                     default: 1000
- *                     description: Milliseconds to wait between retries.
- *                   encryptForSender:
- *                     type: boolean
- *                     default: true
- *                     description: Whether to include an encrypted copy for the creator (sender).
- *                   includeHash:
- *                     type: boolean
- *                     default: false
- *                     description: Whether to embed a hash of the `data` in the asset for verification.
  *                   controller:
  *                     type: string
  *                     description: Specific ID or DID to act as the asset’s controller. Defaults to the current ID.
+ *                   name:
+ *                     type: string
+ *                     description: A human-readable name for the asset.
+
  *     responses:
  *       200:
  *         description: The DID of the newly created asset.

--- a/tests/keymaster.test.ts
+++ b/tests/keymaster.test.ts
@@ -1440,6 +1440,20 @@ describe('createAsset', () => {
         expect(doc.didDocumentData).toStrictEqual(mockAnchor);
     });
 
+    it('should create asset with specified name', async () => {
+        mockFs({});
+
+        const ownerDid = await keymaster.createId('Bob');
+        const mockAnchor = { name: 'mockAnchor' };
+        const mockName = 'mockName'
+        const dataDid = await keymaster.createAsset(mockAnchor, { name: mockName });
+        const doc = await keymaster.resolveDID(mockName);
+
+        expect(doc.didDocument!.id).toBe(dataDid);
+        expect(doc.didDocument!.controller).toBe(ownerDid);
+        expect(doc.didDocumentData).toStrictEqual(mockAnchor);
+    });
+
     it('should throw an exception if no ID selected', async () => {
         mockFs({});
 
@@ -1454,6 +1468,18 @@ describe('createAsset', () => {
     });
 
     it('should throw an exception for an empty string anchor', async () => {
+        mockFs({});
+
+        try {
+            await keymaster.createId('Bob');
+            await keymaster.createAsset({}, { name: 'Bob' });
+            throw new ExpectedExceptionError();
+        } catch (error: any) {
+            expect(error.message).toBe('Invalid parameter: name already used');
+        }
+    });
+
+    it('should throw an exception for an invalid name', async () => {
         mockFs({});
 
         try {


### PR DESCRIPTION
Refactored createAsset method so that names can be validated (if provided) before assets are created. If a valid name is provided, the new asset will be added to the wallet names list.