### PR TITLE
feat: Web wallet checks ownership of asset before updating

### DIFF
--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -1040,7 +1040,7 @@ export default class Keymaster implements KeymasterInterface {
         return this.gatekeeper.resolveDID(actualDid, options);
     }
 
-    async isOwned(did: string): Promise<boolean> {
+    async idInWallet(did: string): Promise<boolean> {
         try {
             await this.fetchIdInfo(did);
             return true;
@@ -1057,7 +1057,7 @@ export default class Keymaster implements KeymasterInterface {
             return {};
         }
 
-        const isOwned = await this.isOwned(doc.didDocument.controller);
+        const isOwned = await this.idInWallet(doc.didDocument.controller);
 
         return {
             ...doc.didDocumentData,

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -1040,14 +1040,29 @@ export default class Keymaster implements KeymasterInterface {
         return this.gatekeeper.resolveDID(actualDid, options);
     }
 
-    async resolveAsset(did: string): Promise<unknown | null> {
+    async isOwned(did: string): Promise<boolean> {
+        try {
+            await this.fetchIdInfo(did);
+            return true;
+        }
+        catch (error) {
+            return false;
+        }
+    }
+
+    async resolveAsset(did: string): Promise<any> {
         const doc = await this.resolveDID(did);
 
-        if (doc.didDocumentData && !doc.didDocumentMetadata?.deactivated) {
-            return doc.didDocumentData;
+        if (!doc?.didDocument?.controller || !doc?.didDocumentData || doc.didDocumentMetadata?.deactivated) {
+            return {};
         }
 
-        return null;
+        const isOwned = await this.isOwned(doc.didDocument.controller);
+
+        return {
+            ...doc.didDocumentData,
+            isOwned,
+        };
     }
 
     async updateAsset(

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -37,6 +37,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
     const [groupName, setGroupName] = useState('');
     const [selectedGroupName, setSelectedGroupName] = useState('');
     const [selectedGroup, setSelectedGroup] = useState('');
+    const [selectedGroupOwned, setSelectedGroupOwned] = useState(false);
     const [memberDID, setMemberDID] = useState('');
     const [memberDocs, setMemberDocs] = useState('');
     const [schemaList, setSchemaList] = useState(null);
@@ -571,8 +572,11 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
     async function refreshGroup(groupName) {
         try {
-            const group = await keymaster.getGroup(groupName);
-            setSelectedGroup(group);
+            const asset = await keymaster.resolveAsset(groupName);
+
+            setSelectedGroupName(groupName);
+            setSelectedGroup(asset.group);
+            setSelectedGroupOwned(asset.isOwned);
             setMemberDID('');
             setMemberDocs('');
         } catch (error) {
@@ -1569,7 +1573,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                     value={selectedGroupName}
                                                     fullWidth
                                                     displayEmpty
-                                                    onChange={(event) => setSelectedGroupName(event.target.value)}
+                                                    onChange={(event) => refreshGroup(event.target.value)}
                                                 >
                                                     <MenuItem value="" disabled>
                                                         Select group
@@ -1580,14 +1584,6 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                         </MenuItem>
                                                     ))}
                                                 </Select>
-                                            </Grid>
-                                            <Grid item>
-                                                <Button variant="contained" color="primary" onClick={() => refreshGroup(selectedGroupName)} disabled={!selectedGroupName}>
-                                                    Edit Group
-                                                </Button>
-                                            </Grid>
-                                            <Grid item>
-                                                {selectedGroup && `Editing: ${selectedGroup.name}`}
                                             </Grid>
                                         </Grid>
                                     }
@@ -1613,9 +1609,13 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                             </Button>
                                                         </TableCell>
                                                         <TableCell>
-                                                            <Button variant="contained" color="primary" onClick={() => addMember(memberDID)} disabled={!memberDID}>
-                                                                Add
-                                                            </Button>
+                                                            <Tooltip title={!selectedGroupOwned ? "You must own the group to edit." : ""}>
+                                                                <span>
+                                                                    <Button variant="contained" color="primary" onClick={() => addMember(memberDID)} disabled={!memberDID || !selectedGroupOwned}>
+                                                                        Add
+                                                                    </Button>
+                                                                </span>
+                                                            </Tooltip>
                                                         </TableCell>
                                                     </TableRow>
                                                     {selectedGroup.members.map((did, index) => (
@@ -1631,9 +1631,13 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                                 </Button>
                                                             </TableCell>
                                                             <TableCell>
-                                                                <Button variant="contained" color="primary" onClick={() => removeMember(did)}>
-                                                                    Remove
-                                                                </Button>
+                                                                <Tooltip title={!selectedGroupOwned ? "You must own the group to edit." : ""}>
+                                                                    <span>
+                                                                        <Button variant="contained" color="primary" onClick={() => removeMember(did)} disabled={!selectedGroupOwned}>
+                                                                            Remove
+                                                                        </Button>
+                                                                    </span>
+                                                                </Tooltip>
                                                             </TableCell>
                                                         </TableRow>
                                                     ))}

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -77,7 +77,9 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
     const [imageList, setImageList] = useState(null);
     const [selectedImageName, setSelectedImageName] = useState('');
     const [selectedImage, setSelectedImage] = useState('');
+    const [selectedImageOwned, setSelectedImageOwned] = useState(false);
     const [selectedImageDocs, setSelectedImageDocs] = useState('');
+    const [selectedImageURL, setSelectedImageURL] = useState('');
     const [imageVersion, setImageVersion] = useState(1);
     const [imageVersionMax, setImageVersionMax] = useState(1);
     const [imageVersions, setImageVersions] = useState([]);
@@ -1103,12 +1105,17 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
     async function selectImage(imageName) {
         try {
+            setSelectedImageURL('');
+
             const docs = await keymaster.resolveDID(imageName);
             const versions = docs.didDocumentMetadata.version;
+            const asset = await keymaster.resolveAsset(imageName);
 
             setSelectedImageName(imageName);
             setSelectedImageDocs(docs);
-            setSelectedImage(docs.didDocumentData.image);
+            setSelectedImage(asset.image);
+            setSelectedImageOwned(asset.isOwned);
+            setSelectedImageURL(`/api/v1/cas/data/${asset.image.cid}`)
             setImageVersion(versions);
             setImageVersionMax(versions);
             setImageVersions(Array.from({ length: versions }, (_, i) => i + 1));
@@ -1119,10 +1126,14 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
     async function selectImageVersion(version) {
         try {
+            setSelectedImageURL('');
+
             const docs = await keymaster.resolveDID(selectedImageName, { atVersion: version });
+            const image = docs.didDocumentData.image;
 
             setSelectedImageDocs(docs);
-            setSelectedImage(docs.didDocumentData.image);
+            setSelectedImage(image);
+            setSelectedImageURL(`/api/v1/cas/data/${image.cid}`)
             setImageVersion(version);
         } catch (error) {
             showError(error);
@@ -1682,7 +1693,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                         variant="contained"
                                                         color="primary"
                                                         onClick={() => document.getElementById('imageUpdate').click()}
-                                                        disabled={!selectedImageName}
+                                                        disabled={!selectedImageName || !selectedImageOwned}
                                                     >
                                                         Update image...
                                                     </Button>
@@ -1736,7 +1747,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                     </Grid>
                                                     <br />
                                                     <div className="left-pane">
-                                                        <img src={`/api/v1/cas/data/${selectedImage.cid}`} alt={selectedImage.cid} style={{ width: '100%', height: 'auto' }} />
+                                                        <img src={selectedImageURL} alt={selectedImageName} style={{ width: '100%', height: 'auto' }} />
                                                     </div>
                                                     <div className="right-pane">
                                                         <TableContainer>

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { Box, Button, Grid, MenuItem, Paper, Select, Tab, TableContainer, Tabs } from '@mui/material';
-import { Table, TableBody, TableRow, TableCell, TextField, Typography } from '@mui/material';
+import { Box, Button, Grid, MenuItem, Paper, Select, Tab, Tabs, TableContainer } from '@mui/material';
+import { Table, TableBody, TableRow, TableCell, TextField, Tooltip, Typography } from '@mui/material';
 import axios from 'axios';
 import { Buffer } from 'buffer';
 import './App.css';
@@ -1689,14 +1689,18 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                     </Select>
                                                 </Grid>
                                                 <Grid item>
-                                                    <Button
-                                                        variant="contained"
-                                                        color="primary"
-                                                        onClick={() => document.getElementById('imageUpdate').click()}
-                                                        disabled={!selectedImageName || !selectedImageOwned}
-                                                    >
-                                                        Update image...
-                                                    </Button>
+                                                    <Tooltip title={!selectedImageOwned ? "You must own the image to update." : ""}>
+                                                        <span>
+                                                            <Button
+                                                                variant="contained"
+                                                                color="primary"
+                                                                onClick={() => document.getElementById('imageUpdate').click()}
+                                                                disabled={!selectedImageName || !selectedImageOwned}
+                                                            >
+                                                                Update image...
+                                                            </Button>
+                                                        </span>
+                                                    </Tooltip>
                                                     <input
                                                         type="file"
                                                         id="imageUpdate"


### PR DESCRIPTION
Changed web wallet to disable edit buttons for assets that are not owned by the user.

To enable this, the Keymaster.resolveAsset() method was changed to include a new flag `isOwned` in the return data that checks if the asset's controller is one of the IDs in the wallet.