### PR TITLE
feat: Enables web wallet to transfer asset

### DIFF
--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -572,11 +572,11 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
     async function refreshGroup(groupName) {
         try {
-            const asset = await keymaster.resolveAsset(groupName);
+            const docs = await keymaster.resolveDID(groupName);
 
             setSelectedGroupName(groupName);
-            setSelectedGroup(asset.group);
-            setSelectedGroupOwned(asset.isOwned);
+            setSelectedGroup(docs.didDocumentData.group);
+            setSelectedGroupOwned(docs.didDocumentMetadata.isOwned);
             setMemberDID('');
             setMemberDocs('');
         } catch (error) {
@@ -635,12 +635,13 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
     async function selectSchema(schemaName) {
         try {
-            const asset = await keymaster.resolveAsset(schemaName);
+            const docs = await keymaster.resolveDID(schemaName);
+            const schema = docs.didDocumentData.schema;
 
             setSelectedSchemaName(schemaName);
-            setSelectedSchemaOwned(asset.isOwned);
-            setSelectedSchema(asset.schema);
-            setSchemaString(JSON.stringify(asset.schema, null, 4));
+            setSelectedSchemaOwned(docs.didDocumentMetadata.isOwned);
+            setSelectedSchema(schema);
+            setSchemaString(JSON.stringify(schema, null, 4));
         } catch (error) {
             showError(error);
         }
@@ -1115,13 +1116,13 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
             const docs = await keymaster.resolveDID(imageName);
             const versions = docs.didDocumentMetadata.version;
-            const asset = await keymaster.resolveAsset(imageName);
+            const image = docs.didDocumentData.image;
 
             setSelectedImageName(imageName);
             setSelectedImageDocs(docs);
-            setSelectedImage(asset.image);
-            setSelectedImageOwned(asset.isOwned);
-            setSelectedImageURL(`/api/v1/cas/data/${asset.image.cid}`)
+            setSelectedImage(image);
+            setSelectedImageOwned(docs.didDocumentMetadata.isOwned);
+            setSelectedImageURL(`/api/v1/cas/data/${image.cid}`)
             setImageVersion(versions);
             setImageVersionMax(versions);
             setImageVersions(Array.from({ length: versions }, (_, i) => i + 1));

--- a/services/keymaster/client/src/KeymasterUI.js
+++ b/services/keymaster/client/src/KeymasterUI.js
@@ -572,11 +572,11 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
     async function refreshGroup(groupName) {
         try {
-            const asset = await keymaster.resolveAsset(groupName);
+            const docs = await keymaster.resolveDID(groupName);
 
             setSelectedGroupName(groupName);
-            setSelectedGroup(asset.group);
-            setSelectedGroupOwned(asset.isOwned);
+            setSelectedGroup(docs.didDocumentData.group);
+            setSelectedGroupOwned(docs.didDocumentMetadata.isOwned);
             setMemberDID('');
             setMemberDocs('');
         } catch (error) {
@@ -635,12 +635,13 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
     async function selectSchema(schemaName) {
         try {
-            const asset = await keymaster.resolveAsset(schemaName);
+            const docs = await keymaster.resolveDID(schemaName);
+            const schema = docs.didDocumentData.schema;
 
             setSelectedSchemaName(schemaName);
-            setSelectedSchemaOwned(asset.isOwned);
-            setSelectedSchema(asset.schema);
-            setSchemaString(JSON.stringify(asset.schema, null, 4));
+            setSelectedSchemaOwned(docs.didDocumentMetadata.isOwned);
+            setSelectedSchema(schema);
+            setSchemaString(JSON.stringify(schema, null, 4));
         } catch (error) {
             showError(error);
         }
@@ -1115,13 +1116,13 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
             const docs = await keymaster.resolveDID(imageName);
             const versions = docs.didDocumentMetadata.version;
-            const asset = await keymaster.resolveAsset(imageName);
+            const image = docs.didDocumentData.image;
 
             setSelectedImageName(imageName);
             setSelectedImageDocs(docs);
-            setSelectedImage(asset.image);
-            setSelectedImageOwned(asset.isOwned);
-            setSelectedImageURL(`/api/v1/cas/data/${asset.image.cid}`)
+            setSelectedImage(image);
+            setSelectedImageOwned(docs.didDocumentMetadata.isOwned);
+            setSelectedImageURL(`/api/v1/cas/data/${image.cid}`)
             setImageVersion(versions);
             setImageVersionMax(versions);
             setImageVersions(Array.from({ length: versions }, (_, i) => i + 1));

--- a/services/mediators/hyperswarm/src/hyperswarm-mediator.ts
+++ b/services/mediators/hyperswarm/src/hyperswarm-mediator.ts
@@ -359,12 +359,8 @@ function newBatch(batch: Operation[]): boolean {
 }
 
 async function addPeer(did: string): Promise<void> {
-    const asset = await keymaster.resolveAsset(did) as { node: NodeInfo };
-
-    if (!asset?.node?.ipfs) {
-        return;
-    }
-
+    const docs = await keymaster.resolveDID(did);
+    const asset = docs.didDocumentData as { node: NodeInfo };
     const { id, addresses } = asset.node.ipfs;
 
     if (!id || !addresses) {

--- a/tests/keymaster.test.ts
+++ b/tests/keymaster.test.ts
@@ -1025,24 +1025,9 @@ describe('resolveAsset', () => {
         const did = await keymaster.createAsset(mockAsset);
         const asset = await keymaster.resolveAsset(did);
 
-        expect(asset).toStrictEqual({ ...mockAsset, isOwned: true });
+        expect(asset).toStrictEqual(mockAsset);
     });
-
-    it('should return isOwned false when controller not in wallet', async () => {
-        mockFs({});
-
-        await keymaster.createId('Alice');
-        await keymaster.createId('Bob');
-        const mockAsset = { name: 'mockAnchor' };
-        const did = await keymaster.createAsset(mockAsset);
-
-        await keymaster.setCurrentId('Alice');
-        await keymaster.removeId('Bob');
-        const asset = await keymaster.resolveAsset(did);
-
-        expect(asset).toStrictEqual({ ...mockAsset, isOwned: false });
-    });
-
+    
     it('should return empty asset on invalid DID', async () => {
         mockFs({});
 
@@ -4100,7 +4085,7 @@ describe('getGroup', () => {
 
         const group = await keymaster.getGroup(groupDid);
 
-        expect(group).toStrictEqual({ ...oldGroup, isOwned: true });
+        expect(group).toStrictEqual(oldGroup);
     });
 
     it('should return null if non-group DID specified', async () => {
@@ -4437,7 +4422,7 @@ describe('getPoll', () => {
         const did = await keymaster.createAsset(template);
         const poll = await keymaster.getPoll(did);
 
-        expect(poll).toStrictEqual({ ...template, isOwned: true });
+        expect(poll).toStrictEqual(template);
     });
 
     it('should return null if non-poll DID specified', async () => {
@@ -4958,7 +4943,7 @@ describe('getSchema', () => {
         const did = await keymaster.createAsset(mockSchema);
         const schema = await keymaster.getSchema(did);
 
-        expect(schema).toStrictEqual({ ...mockSchema, isOwned: true });
+        expect(schema).toStrictEqual(mockSchema);
     });
 
     it('should throw an exception on get invalid schema', async () => {

--- a/tests/keymaster.test.ts
+++ b/tests/keymaster.test.ts
@@ -1027,7 +1027,7 @@ describe('resolveAsset', () => {
 
         expect(asset).toStrictEqual(mockAsset);
     });
-    
+
     it('should return empty asset on invalid DID', async () => {
         mockFs({});
 
@@ -1837,6 +1837,24 @@ describe('updateDID', () => {
         expect(ok).toBe(true);
         expect(doc2.didDocumentData).toStrictEqual(dataUpdated);
         expect(doc2.didDocumentMetadata!.version).toBe(2);
+    });
+
+    it('should not update an asset DID if no changes', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const mockAnchor = { name: 'mockAnchor', val: 1234 };
+        const dataDid = await keymaster.createAsset(mockAnchor);
+        const doc = await keymaster.resolveDID(dataDid);
+
+        // Changing the order should be ignored
+        doc.didDocumentData = { val: 1234, name: 'mockAnchor' };
+        const ok = await keymaster.updateDID(doc);
+        const doc2 = await keymaster.resolveDID(dataDid);
+
+        expect(ok).toBe(true);
+        expect(doc2.didDocumentData).toStrictEqual(mockAnchor);
+        expect(doc2.didDocumentMetadata!.version).toBe(1);
     });
 
     it('should update an asset DID when current ID is not owner ID', async () => {


### PR DESCRIPTION
This PR enables the web wallet to transfer assets by updating the asset resolution logic, modifying test expectations to remove the isOwned field, and adding a transfer workflow in the UI.

-    Replaces resolveAsset calls with resolveDID to align with the updated ownership model
-    Updates tests and UI functions to remove isOwned augmentation from resolved documents
-    Introduces a new transferName function for asset transfers in the UI

Also refactors keymaster updateDID method to return immediately if no changes to the DID document are detected.
