### PR TITLE
fix: Keymaster waits for node ID to resolve

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
     environment:
       - KC_KEYMASTER_PORT=4226
       - KC_GATEKEEPER_URL=http://gatekeeper:4224
+      - KC_NODE_ID=${KC_NODE_ID}
       - KC_KEYMASTER_DB=${KC_KEYMASTER_DB}
       - KC_ENCRYPTED_PASSPHRASE=${KC_ENCRYPTED_PASSPHRASE}
       - KC_WALLET_CACHE=${KC_WALLET_CACHE}

--- a/services/keymaster/server/src/config.js
+++ b/services/keymaster/server/src/config.js
@@ -5,6 +5,7 @@ dotenv.config();
 const config = {
     gatekeeperURL: process.env.KC_GATEKEEPER_URL || 'http://localhost:4224',
     keymasterPort: process.env.KC_KEYMASTER_PORT ? parseInt(process.env.KC_KEYMASTER_PORT) : 4226,
+    nodeID: process.env.KC_NODE_ID || '',
     db: process.env.KC_KEYMASTER_DB || 'json',
     keymasterPassphrase: process.env.KC_ENCRYPTED_PASSPHRASE,
     walletCache: process.env.KC_WALLET_CACHE ? process.env.KC_WALLET_CACHE === 'true' : false,

--- a/services/keymaster/server/src/keymaster-api.ts
+++ b/services/keymaster/server/src/keymaster-api.ts
@@ -4455,18 +4455,17 @@ process.on('unhandledRejection', (reason, promise) => {
     //console.error('Unhandled rejection caught');
 });
 
-async function waitForCurrentId() {
+async function waitForNodeId() {
     let isReady = false;
-    const currentId = await keymaster.getCurrentId();
 
-    if (!currentId) {
-        return;
+    if (!config.nodeID) {
+        throw new Error('KC_NODE_ID is not set in the configuration.');
     }
 
     while (!isReady) {
         try {
-            console.log(`Resolving current ID: ${currentId}`);
-            const doc = await keymaster.resolveDID(currentId);
+            console.log(`Resolving node ID: ${config.nodeID}`);
+            const doc = await keymaster.resolveDID(config.nodeID);
             console.log(JSON.stringify(doc, null, 4));
             isReady = true;
         }
@@ -4526,10 +4525,10 @@ app.listen(port, async () => {
     console.log(`Keymaster server persisting to ${config.db}`);
 
     try {
-        await waitForCurrentId();
+        await waitForNodeId();
     }
     catch (error) {
-        console.error('Failed to resolve current ID:', error);
+        console.error('Failed to wait for node ID:', error);
     }
 
     serverReady = true;

--- a/services/mediators/hyperswarm/src/hyperswarm-mediator.ts
+++ b/services/mediators/hyperswarm/src/hyperswarm-mediator.ts
@@ -360,21 +360,27 @@ function newBatch(batch: Operation[]): boolean {
 
 async function addPeer(did: string): Promise<void> {
     const docs = await keymaster.resolveDID(did);
-    const asset = docs.didDocumentData as { node: NodeInfo };
-    const { id, addresses } = asset.node.ipfs;
+    const data = docs.didDocumentData as { node: NodeInfo };
+
+    if (!data?.node || !data.node.ipfs) {
+        return;
+    }
+
+    const { id, addresses } = data.node.ipfs;
 
     if (!id || !addresses) {
         return;
     }
 
     if (id === nodeInfo.ipfs.id) {
+        // A node should never add itself as a peer node
         return;
     }
 
     await ipfs.addPeeringPeer(id, addresses);
 
     knownNodes[did] = {
-        name: asset.node.name,
+        name: data.node.name,
         ipfs: {
             id,
             addresses,


### PR DESCRIPTION
This PR fixes issues with the Keymaster service by ensuring that the node ID is properly resolved before proceeding. Key changes include:

-    Updating the peer addition logic in hyperswarm-mediator to validate structure before using the resolved data.
-    Renaming and updating the waiting function in keymaster-api to use config.nodeID for resolution.
-    Introducing a new configuration property (nodeID) and propagating it to docker-compose.
