### PR TITLE
feat: Changed updateAsset to merge data

### DIFF
--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -1097,8 +1097,12 @@ export default class Keymaster implements KeymasterInterface {
         data: Record<string, unknown>
     ): Promise<boolean> {
         const doc = await this.resolveDID(did);
+        const currentData = doc.didDocumentData || {};
 
-        doc.didDocumentData = data;
+        doc.didDocumentData = {
+            ...currentData,
+            ...data
+        };
 
         return this.updateDID(doc);
     }

--- a/tests/keymaster.test.ts
+++ b/tests/keymaster.test.ts
@@ -1083,6 +1083,20 @@ describe('updateAsset', () => {
         expect(ok).toBe(true);
         expect(asset).toStrictEqual({ key1: 'val1', key2: 'val2' });
     });
+
+    it('should remove a property when updated to be undefined ', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const mockAsset1 = { key1: 'val1', key2: 'val2' };
+        const mockAsset2 = { key2: undefined };
+        const did = await keymaster.createAsset(mockAsset1);
+        const ok = await keymaster.updateAsset(did, mockAsset2);
+        const asset = await keymaster.resolveAsset(did);
+
+        expect(ok).toBe(true);
+        expect(asset).toStrictEqual({ key1: 'val1' });
+    });
 });
 
 describe('rotateKeys', () => {

--- a/tests/keymaster.test.ts
+++ b/tests/keymaster.test.ts
@@ -1051,6 +1051,40 @@ describe('resolveAsset', () => {
     });
 });
 
+describe('updateAsset', () => {
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should update an asset', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const mockAsset1 = { name: 'original' };
+        const mockAsset2 = { name: 'updated' };
+        const did = await keymaster.createAsset(mockAsset1);
+        const ok = await keymaster.updateAsset(did, mockAsset2);
+        const asset = await keymaster.resolveAsset(did);
+
+        expect(ok).toBe(true);
+        expect(asset).toStrictEqual(mockAsset2);
+    });
+
+    it('should update an asset with merged data', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const mockAsset1 = { key1: 'val1' };
+        const mockAsset2 = { key2: 'val2' };
+        const did = await keymaster.createAsset(mockAsset1);
+        const ok = await keymaster.updateAsset(did, mockAsset2);
+        const asset = await keymaster.resolveAsset(did);
+
+        expect(ok).toBe(true);
+        expect(asset).toStrictEqual({ key1: 'val1', key2: 'val2' });
+    });
+});
+
 describe('rotateKeys', () => {
 
     afterEach(() => {


### PR DESCRIPTION
This PR updates the updateAsset functionality to merge new data into the existing asset data rather than replacing it entirely.

-    Adds tests to verify the merging behavior and removal of properties when updated to undefined.
-    Modifies the updateAsset implementation to merge existing data with new changes.
