### PR TITLE
feat: Adds document assets to keymaster

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Commands:
   check-wallet                               Validate DIDs in wallet
   clone-asset [options] <id>                 Clone an asset
   create-asset [options]                     Create an empty asset
+  create-asset-document [options] <file>     Create an asset from a document file
   create-asset-image [options] <file>        Create an asset from an image file
   create-asset-json [options] <file>         Create an asset from a JSON file
   create-challenge [options] [file]          Create a challenge (optionally from a file)
@@ -145,6 +146,7 @@ Commands:
   transfer-asset <id> <controller>           Transfer asset to a new controller
   unpublish-credential <did>                 Remove a credential from the current user manifest
   unpublish-poll <poll>                      Remove results from poll
+  update-asset-document <id> <file>          Update an asset from a document file
   update-asset-image <id> <file>             Update an asset from an image file
   update-asset-json <id> <file>              Update an asset from a JSON file
   update-poll <ballot>                       Add a ballot to the poll

--- a/browser/chrome-extension/src/browser/components/ImageTab.tsx
+++ b/browser/chrome-extension/src/browser/components/ImageTab.tsx
@@ -3,7 +3,7 @@ import {Box, Button, MenuItem, Select} from "@mui/material";
 import {useWalletContext} from "../../shared/contexts/WalletProvider";
 import {useUIContext} from "../../shared/contexts/UIContext";
 import {useCredentialsContext} from "../../shared/contexts/CredentialsProvider";
-import { Image } from "@mdip/keymaster";
+import { ImageAsset } from "@mdip/keymaster/types";
 import { MdipDocument } from "@mdip/gatekeeper/types";
 import GatekeeperClient from "@mdip/gatekeeper/client";
 
@@ -24,7 +24,7 @@ const ImageTab = () => {
     } = useCredentialsContext();
     const [registry, setRegistry] = useState<string>('hyperswarm');
     const [selectedImageName, setSelectedImageName] = useState<string>('');
-    const [selectedImage, setSelectedImage] = useState<Image | null>(null);
+    const [selectedImage, setSelectedImage] = useState<ImageAsset | null>(null);
     const [selectedImageDocs, setSelectedImageDocs] = useState<MdipDocument | null>(null);
     const [selectedImageDataUrl, setSelectedImageDataUrl] = useState<string>("");
 

--- a/doc/keychain/clients/cli/README.md
+++ b/doc/keychain/clients/cli/README.md
@@ -94,6 +94,7 @@ Commands:
   check-wallet                               Validate DIDs in wallet
   clone-asset [options] <id>                 Clone an asset
   create-asset [options]                     Create an empty asset
+  create-asset-document [options] <file>     Create an asset from a document file
   create-asset-image [options] <file>        Create an asset from an image file
   create-asset-json [options] <file>         Create an asset from a JSON file
   create-challenge [options] [file]          Create a challenge (optionally from a file)
@@ -152,6 +153,7 @@ Commands:
   transfer-asset <id> <controller>           Transfer asset to a new controller
   unpublish-credential <did>                 Remove a credential from the current user manifest
   unpublish-poll <poll>                      Remove results from poll
+  update-asset-document <id> <file>          Update an asset from a document file
   update-asset-image <id> <file>             Update an asset from an image file
   update-asset-json <id> <file>              Update an asset from a JSON file
   update-poll <ballot>                       Add a ballot to the poll

--- a/doc/keymaster-api.json
+++ b/doc/keymaster-api.json
@@ -5418,7 +5418,7 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "image": {
+                    "document": {
                       "type": "object",
                       "description": "The document data and metadata.",
                       "properties": {
@@ -5451,21 +5451,6 @@
                     "error": {
                       "type": "string",
                       "description": "Error message indicating the document was not found."
-                    }
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal server error.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "error": {
-                      "type": "string"
                     }
                   }
                 }

--- a/doc/keymaster-api.json
+++ b/doc/keymaster-api.json
@@ -5264,6 +5264,268 @@
         }
       }
     },
+    "/documents": {
+      "post": {
+        "summary": "Upload a binary document and create a DID for it.",
+        "description": "Accepts binary data as the request body and creates a DID for the uploaded document. Additional options can be passed via the `X-Options` header.\n",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "description": "The binary document data to store as a DID asset."
+        },
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Options",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "A JSON string containing additional options for the document creation process. Example: `{\"registry\":\"local\",\"validUntil\":\"2025-12-31T23:59:59Z\"}`\n"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The DID created for the uploaded document.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "did": {
+                      "type": "string",
+                      "description": "The DID representing the uploaded document."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/{id}": {
+      "put": {
+        "summary": "Update an existing binary document.",
+        "description": "Updates the binary data of an existing document identified by its DID. Additional options can be passed via the `X-Options` header.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The DID of the document to update."
+          },
+          {
+            "in": "header",
+            "name": "X-Options",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "A JSON string containing additional options for the document update process. Example: `{\"registry\":\"local\",\"validUntil\":\"2025-12-31T23:59:59Z\"}`\n"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          },
+          "description": "The new binary document data to replace the existing one."
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates whether the update was successful.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "description": "true if the update was successful, otherwise `false`."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "Retrieve a binary document by its DID.",
+        "description": "Fetches the binary document data and metadata associated with the specified DID.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The DID of the document to retrieve."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the document data and metadata.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "image": {
+                      "type": "object",
+                      "description": "The document data and metadata.",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "description": "The MIME type of the document (e.g., \"application/pdf\")."
+                        },
+                        "bytes": {
+                          "type": "integer",
+                          "description": "The size of the document in bytes."
+                        },
+                        "cid": {
+                          "type": "string",
+                          "description": "The Content Identifier (CID) of the document."
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Document not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "Error message indicating the document was not found."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/{id}/test": {
+      "post": {
+        "summary": "Test if the specified document is valid.",
+        "description": "Checks whether the document associated with the given DID is valid or meets specific criteria.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The DID of the document to test."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The result of the test.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "test": {
+                      "type": "boolean",
+                      "description": "true if the document is valid, otherwise `false`."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or test criteria not met.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "Error message indicating why the test failed."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/cas/data/{cid}": {
       "get": {
         "summary": "Retrieve data from the CAS (Content Addressable Storage)",

--- a/packages/keymaster/src/keymaster-client.ts
+++ b/packages/keymaster/src/keymaster-client.ts
@@ -1006,4 +1006,24 @@ export default class KeymasterClient implements KeymasterInterface {
             throwError(error);
         }
     }
+
+    async getDocument(id: string): Promise<string> {
+        try {
+            const response = await axios.get(`${this.API}/documents/${id}`);
+            return response.data.document;
+        }
+        catch (error) {
+            throwError(error);
+        }
+    }
+
+    async testDocument(id: string): Promise<boolean> {
+        try {
+            const response = await axios.post(`${this.API}/documents/${id}/test`);
+            return response.data.test;
+        }
+        catch (error) {
+            throwError(error);
+        }
+    }
 }

--- a/packages/keymaster/src/keymaster-client.ts
+++ b/packages/keymaster/src/keymaster-client.ts
@@ -7,6 +7,7 @@ import {
     ChallengeResponse,
     CheckWalletResult,
     CreateAssetOptions,
+    CreateFileAssetOptions,
     CreateResponseOptions,
     EncryptOptions,
     FixWalletResult,
@@ -962,6 +963,24 @@ export default class KeymasterClient implements KeymasterInterface {
         try {
             const response = await axios.post(`${this.API}/images/${id}/test`);
             return response.data.test;
+        }
+        catch (error) {
+            throwError(error);
+        }
+    }
+
+    async createDocument(
+        data: Buffer,
+        options: CreateFileAssetOptions = {}
+    ): Promise<string> {
+        try {
+            const response = await axios.post(`${this.API}/documents`, data, {
+                headers: {
+                    'Content-Type': 'application/octet-stream',
+                    'X-Options': JSON.stringify(options), // Pass options as a custom header
+                }
+            });
+            return response.data.did;
         }
         catch (error) {
             throwError(error);

--- a/packages/keymaster/src/keymaster-client.ts
+++ b/packages/keymaster/src/keymaster-client.ts
@@ -993,7 +993,7 @@ export default class KeymasterClient implements KeymasterInterface {
         id: string,
         data: Buffer,
         options: FileAssetOptions = {}
-    ): Promise<string> {
+    ): Promise<boolean> {
         try {
             const response = await axios.put(`${this.API}/documents/${id}`, data, {
                 headers: {

--- a/packages/keymaster/src/keymaster-client.ts
+++ b/packages/keymaster/src/keymaster-client.ts
@@ -7,7 +7,7 @@ import {
     ChallengeResponse,
     CheckWalletResult,
     CreateAssetOptions,
-    CreateFileAssetOptions,
+    FileAssetOptions,
     CreateResponseOptions,
     EncryptOptions,
     FixWalletResult,
@@ -921,6 +921,7 @@ export default class KeymasterClient implements KeymasterInterface {
         try {
             const response = await axios.post(`${this.API}/images`, data, {
                 headers: {
+                    // eslint-disable-next-line
                     'Content-Type': 'application/octet-stream',
                     'X-Options': JSON.stringify(options), // Pass options as a custom header
                 }
@@ -971,7 +972,7 @@ export default class KeymasterClient implements KeymasterInterface {
 
     async createDocument(
         data: Buffer,
-        options: CreateFileAssetOptions = {}
+        options: FileAssetOptions = {}
     ): Promise<string> {
         try {
             const response = await axios.post(`${this.API}/documents`, data, {
@@ -981,6 +982,25 @@ export default class KeymasterClient implements KeymasterInterface {
                 }
             });
             return response.data.did;
+        }
+        catch (error) {
+            throwError(error);
+        }
+    }
+
+    async updateDocument(
+        id: string,
+        data: Buffer,
+        options: FileAssetOptions = {}
+    ): Promise<string> {
+        try {
+            const response = await axios.put(`${this.API}/documents/${id}`, data, {
+                headers: {
+                    'Content-Type': 'application/octet-stream',
+                    'X-Options': JSON.stringify(options), // Pass options as a custom header
+                }
+            });
+            return response.data.ok;
         }
         catch (error) {
             throwError(error);

--- a/packages/keymaster/src/keymaster-client.ts
+++ b/packages/keymaster/src/keymaster-client.ts
@@ -10,8 +10,10 @@ import {
     FileAssetOptions,
     CreateResponseOptions,
     EncryptOptions,
+    FileAsset,
     FixWalletResult,
     Group,
+    ImageAsset,
     IssueCredentialsOptions,
     KeymasterInterface,
     Poll,
@@ -22,7 +24,6 @@ import {
 } from './types.js'
 
 import axios, { AxiosError } from 'axios';
-import { Image } from "./keymaster.js";
 
 const VERSION = '/api/v1';
 
@@ -950,7 +951,7 @@ export default class KeymasterClient implements KeymasterInterface {
         }
     }
 
-    async getImage(id: string): Promise<Image | null> {
+    async getImage(id: string): Promise<ImageAsset | null> {
         try {
             const response = await axios.get(`${this.API}/images/${id}`);
             return response.data.image;
@@ -1007,7 +1008,7 @@ export default class KeymasterClient implements KeymasterInterface {
         }
     }
 
-    async getDocument(id: string): Promise<string> {
+    async getDocument(id: string): Promise<FileAsset | null> {
         try {
             const response = await axios.get(`${this.API}/documents/${id}`);
             return response.data.document;

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -778,7 +778,7 @@ export default class Keymaster implements KeymasterInterface {
         options: FileAssetOptions = {}
     ): Promise<boolean> {
         const filename = options.filename || 'document';
-        const type = filename.split('.').pop() || 'unknown';
+        const type = filename.includes('.') ? filename.split('.').pop() || 'unknown' : 'unknown';
         const cid = await this.gatekeeper.addData(buffer);
         const document: FileAsset = {
             cid,

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -20,9 +20,11 @@ import {
     FileAssetOptions,
     CreateResponseOptions,
     EncryptOptions,
+    FileAsset,
     FixWalletResult,
     Group,
     IDInfo,
+    ImageAsset,
     IssueCredentialsOptions,
     KeymasterInterface,
     Poll,
@@ -70,21 +72,6 @@ export interface EncryptedMessage {
 
 interface PossiblySigned {
     signature?: Signature;
-}
-
-export interface Image {
-    cid: string;
-    type: string;
-    width: number;
-    height: number;
-    bytes: number;
-}
-
-export interface FileAsset {
-    cid: string;
-    type: string;
-    filename: string;
-    bytes: number;
 }
 
 export default class Keymaster implements KeymasterInterface {
@@ -738,9 +725,9 @@ export default class Keymaster implements KeymasterInterface {
         return this.updateAsset(id, data);
     }
 
-    async getImage(id: string): Promise<Image | null> {
+    async getImage(id: string): Promise<ImageAsset | null> {
         const asset = await this.resolveAsset(id);
-        const castAsset = asset as { image?: Image };
+        const castAsset = asset as { image?: ImageAsset };
 
         return castAsset.image ?? null;
     }

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -760,7 +760,7 @@ export default class Keymaster implements KeymasterInterface {
         options: FileAssetOptions = {}
     ): Promise<string> {
         const filename = options.filename || 'document';
-        const type = filename.split('.').pop() || 'unknown';
+        const type = filename.includes('.') ? filename.split('.').pop() || 'unknown' : 'unknown';
         const cid = await this.gatekeeper.addData(buffer);
         const document: FileAsset = {
             cid,

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -17,7 +17,7 @@ import {
     ChallengeResponse,
     CheckWalletResult,
     CreateAssetOptions,
-    CreateFileAssetOptions,
+    FileAssetOptions,
     CreateResponseOptions,
     EncryptOptions,
     FixWalletResult,
@@ -80,7 +80,7 @@ export interface Image {
     bytes: number;
 }
 
-export interface Document {
+export interface FileAsset {
     cid: string;
     type: string;
     filename: string;
@@ -757,12 +757,12 @@ export default class Keymaster implements KeymasterInterface {
 
     async createDocument(
         buffer: Buffer,
-        options: CreateFileAssetOptions = {}
+        options: FileAssetOptions = {}
     ): Promise<string> {
-        const filename = options.filename || 'unknown';
+        const filename = options.filename || 'document';
         const type = filename.split('.').pop() || 'unknown';
         const cid = await this.gatekeeper.addData(buffer);
-        const document: Document = {
+        const document: FileAsset = {
             cid,
             filename,
             type,
@@ -773,13 +773,14 @@ export default class Keymaster implements KeymasterInterface {
     }
 
     async updateDocument(
-        filename: string,
         id: string,
-        buffer: Buffer
+        buffer: Buffer,
+        options: FileAssetOptions = {}
     ): Promise<boolean> {
+        const filename = options.filename || 'document';
         const type = filename.split('.').pop() || 'unknown';
         const cid = await this.gatekeeper.addData(buffer);
-        const document: Document = {
+        const document: FileAsset = {
             cid,
             filename,
             type,
@@ -789,9 +790,9 @@ export default class Keymaster implements KeymasterInterface {
         return this.updateAsset(id, { document });
     }
 
-    async getDocument(id: string): Promise<Document | null> {
+    async getDocument(id: string): Promise<FileAsset | null> {
         const asset = await this.resolveAsset(id);
-        const castAsset = asset as { document?: Document };
+        const castAsset = asset as { document?: FileAsset };
 
         return castAsset.document ?? null;
     }

--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -56,6 +56,10 @@ export interface CreateAssetOptions {
     name?: string;
 }
 
+export interface CreateFileAssetOptions extends CreateAssetOptions {
+    filename?: string;
+}
+
 export interface EncryptOptions extends CreateAssetOptions {
     encryptForSender?: boolean;
     includeHash?: boolean;

--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -283,6 +283,13 @@ export interface KeymasterInterface {
 
     // Images
     createImage(data: Buffer, options?: CreateAssetOptions): Promise<string>;
+    updateImage(did: string, data: Buffer): Promise<boolean>;
     getImage(id: string): Promise<ImageAsset | null>;
     testImage(id: string): Promise<boolean>;
+
+    // Documents
+    createDocument(data: Buffer, options?: FileAssetOptions): Promise<string>;
+    updateDocument(did: string, data: Buffer, options?: FileAssetOptions): Promise<boolean>;
+    getDocument(id: string): Promise<FileAsset | null>;
+    testDocument(id: string): Promise<boolean>;
 }

--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -2,7 +2,6 @@ import {
     MdipDocument,
     ResolveDIDOptions,
 } from '@mdip/gatekeeper/types';
-import { Image } from "./keymaster.js";
 
 export interface EncryptedWallet {
     salt: string
@@ -167,6 +166,21 @@ export interface ViewPollResult {
     results?: PollResults;
 }
 
+export interface ImageAsset {
+    cid: string;
+    type: string;
+    width: number;
+    height: number;
+    bytes: number;
+}
+
+export interface FileAsset {
+    cid: string;
+    type: string;
+    filename: string;
+    bytes: number;
+}
+
 export type StoredWallet = EncryptedWallet | WalletFile | null;
 
 export interface WalletBase {
@@ -269,6 +283,6 @@ export interface KeymasterInterface {
 
     // Images
     createImage(data: Buffer, options?: CreateAssetOptions): Promise<string>;
-    getImage(id: string): Promise<Image | null>;
+    getImage(id: string): Promise<ImageAsset | null>;
     testImage(id: string): Promise<boolean>;
 }

--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -2,7 +2,7 @@ import {
     MdipDocument,
     ResolveDIDOptions,
 } from '@mdip/gatekeeper/types';
-import {Image} from "./keymaster.js";
+import { Image } from "./keymaster.js";
 
 export interface EncryptedWallet {
     salt: string
@@ -56,7 +56,7 @@ export interface CreateAssetOptions {
     name?: string;
 }
 
-export interface CreateFileAssetOptions extends CreateAssetOptions {
+export interface FileAssetOptions extends CreateAssetOptions {
     filename?: string;
 }
 

--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -166,19 +166,19 @@ export interface ViewPollResult {
     results?: PollResults;
 }
 
-export interface ImageAsset {
+export interface BinaryAsset {
     cid: string;
     type: string;
-    width: number;
-    height: number;
     bytes: number;
 }
 
-export interface FileAsset {
-    cid: string;
-    type: string;
+export interface ImageAsset extends BinaryAsset {
+    width: number;
+    height: number;
+}
+
+export interface FileAsset extends BinaryAsset {
     filename: string;
-    bytes: number;
 }
 
 export type StoredWallet = EncryptedWallet | WalletFile | null;

--- a/scripts/keychain-cli.js
+++ b/scripts/keychain-cli.js
@@ -840,6 +840,24 @@ program
     });
 
 program
+    .command('create-asset-document <file>')
+    .description('Create an asset from a document file')
+    .option('-n, --name <name>', 'DID name')
+    .option('-r, --registry <registry>', 'registry to use')
+    .action(async (file, options) => {
+        try {
+            const { name, registry } = options;
+            const data = fs.readFileSync(file);
+            const filename = file.split('/').pop();
+            const did = await keymaster.createDocument(data, { filename, name, registry });
+            console.log(did);
+        }
+        catch (error) {
+            console.error(error.error || error);
+        }
+    });
+
+program
     .command('get-asset <id>')
     .description('Get asset by name or DID')
     .action(async (id) => {

--- a/scripts/keychain-cli.js
+++ b/scripts/keychain-cli.js
@@ -899,6 +899,21 @@ program
     });
 
 program
+    .command('update-asset-document <id> <file>')
+    .description('Update an asset from a document file')
+    .action(async (id, file) => {
+        try {
+            const data = fs.readFileSync(file);
+            const filename = file.split('/').pop();
+            const ok = await keymaster.updateDocument(id, data, { filename });
+            console.log(ok ? UPDATE_OK : UPDATE_FAILED);
+        }
+        catch (error) {
+            console.error(error.error || error);
+        }
+    });
+
+program
     .command('transfer-asset <id> <controller>')
     .description('Transfer asset to a new controller')
     .action(async (id, controller) => {

--- a/services/keymaster/server/src/keymaster-api.ts
+++ b/services/keymaster/server/src/keymaster-api.ts
@@ -4534,7 +4534,7 @@ v1router.put('/documents/:id', express.raw({ type: 'application/octet-stream', l
  *             schema:
  *               type: object
  *               properties:
- *                 image:
+ *                 document:
  *                   type: object
  *                   description: The document data and metadata.
  *                   properties:
@@ -4557,15 +4557,6 @@ v1router.put('/documents/:id', express.raw({ type: 'application/octet-stream', l
  *                 error:
  *                   type: string
  *                   description: Error message indicating the document was not found.
- *       500:
- *         description: Internal server error.
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 error:
- *                   type: string
  */
 v1router.get('/documents/:id', async (req, res) => {
     try {

--- a/services/keymaster/server/src/keymaster-api.ts
+++ b/services/keymaster/server/src/keymaster-api.ts
@@ -4230,6 +4230,19 @@ v1router.post('/images', express.raw({ type: 'application/octet-stream', limit: 
     }
 });
 
+v1router.post('/documents', express.raw({ type: 'application/octet-stream', limit: '10mb' }), async (req, res) => {
+    try {
+        const data = req.body;
+        const headers = req.headers;
+        const options = typeof headers['x-options'] === 'string' ? JSON.parse(headers['x-options']) : {};
+        const did = await keymaster.createDocument(data, options);
+
+        res.json({ did });
+    } catch (error: any) {
+        res.status(500).send(error.toString());
+    }
+});
+
 /**
  * @swagger
  * /images/{id}:

--- a/services/keymaster/server/src/keymaster-api.ts
+++ b/services/keymaster/server/src/keymaster-api.ts
@@ -4243,6 +4243,19 @@ v1router.post('/documents', express.raw({ type: 'application/octet-stream', limi
     }
 });
 
+v1router.put('/documents/:id', express.raw({ type: 'application/octet-stream', limit: '10mb' }), async (req, res) => {
+    try {
+        const data = req.body;
+        const headers = req.headers;
+        const options = typeof headers['x-options'] === 'string' ? JSON.parse(headers['x-options']) : {};
+        const ok = await keymaster.updateDocument(req.params.id, data, options);
+
+        res.json({ ok });
+    } catch (error: any) {
+        res.status(500).send(error.toString());
+    }
+});
+
 /**
  * @swagger
  * /images/{id}:

--- a/services/keymaster/server/src/keymaster-api.ts
+++ b/services/keymaster/server/src/keymaster-api.ts
@@ -4569,8 +4569,8 @@ v1router.put('/documents/:id', express.raw({ type: 'application/octet-stream', l
  */
 v1router.get('/documents/:id', async (req, res) => {
     try {
-        const image = await keymaster.getDocument(req.params.id);
-        res.json({ image });
+        const document = await keymaster.getDocument(req.params.id);
+        res.json({ document });
     } catch (error: any) {
         res.status(404).send({ error: error.toString() });
     }

--- a/services/keymaster/server/src/keymaster-api.ts
+++ b/services/keymaster/server/src/keymaster-api.ts
@@ -4230,32 +4230,6 @@ v1router.post('/images', express.raw({ type: 'application/octet-stream', limit: 
     }
 });
 
-v1router.post('/documents', express.raw({ type: 'application/octet-stream', limit: '10mb' }), async (req, res) => {
-    try {
-        const data = req.body;
-        const headers = req.headers;
-        const options = typeof headers['x-options'] === 'string' ? JSON.parse(headers['x-options']) : {};
-        const did = await keymaster.createDocument(data, options);
-
-        res.json({ did });
-    } catch (error: any) {
-        res.status(500).send(error.toString());
-    }
-});
-
-v1router.put('/documents/:id', express.raw({ type: 'application/octet-stream', limit: '10mb' }), async (req, res) => {
-    try {
-        const data = req.body;
-        const headers = req.headers;
-        const options = typeof headers['x-options'] === 'string' ? JSON.parse(headers['x-options']) : {};
-        const ok = await keymaster.updateDocument(req.params.id, data, options);
-
-        res.json({ ok });
-    } catch (error: any) {
-        res.status(500).send(error.toString());
-    }
-});
-
 /**
  * @swagger
  * /images/{id}:
@@ -4410,6 +4384,237 @@ v1router.get('/images/:id', async (req, res) => {
 v1router.post('/images/:id/test', async (req, res) => {
     try {
         const test = await keymaster.testImage(req.params.id);
+        res.json({ test });
+    } catch (error: any) {
+        res.status(400).send({ error: error.toString() });
+    }
+});
+
+/**
+ * @swagger
+ * /documents:
+ *   post:
+ *     summary: Upload a binary document and create a DID for it.
+ *     description: >
+ *       Accepts binary data as the request body and creates a DID for the uploaded document. Additional options can be passed via the `X-Options` header.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/octet-stream:
+ *           schema:
+ *             type: string
+ *             format: binary
+ *       description: The binary document data to store as a DID asset.
+ *     parameters:
+ *       - in: header
+ *         name: X-Options
+ *         required: false
+ *         schema:
+ *           type: string
+ *         description: >
+ *           A JSON string containing additional options for the document creation process.
+ *           Example: `{"registry":"local","validUntil":"2025-12-31T23:59:59Z"}`
+ *     responses:
+ *       200:
+ *         description: The DID created for the uploaded document.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 did:
+ *                   type: string
+ *                   description: The DID representing the uploaded document.
+ *       500:
+ *         description: Internal server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ */
+v1router.post('/documents', express.raw({ type: 'application/octet-stream', limit: '10mb' }), async (req, res) => {
+    try {
+        const data = req.body;
+        const headers = req.headers;
+        const options = typeof headers['x-options'] === 'string' ? JSON.parse(headers['x-options']) : {};
+        const did = await keymaster.createDocument(data, options);
+
+        res.json({ did });
+    } catch (error: any) {
+        res.status(500).send(error.toString());
+    }
+});
+
+/**
+ * @swagger
+ * /documents/{id}:
+ *   put:
+ *     summary: Update an existing binary document.
+ *     description: >
+ *       Updates the binary data of an existing document identified by its DID. Additional options can be passed via the `X-Options` header.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The DID of the document to update.
+ *       - in: header
+ *         name: X-Options
+ *         required: false
+ *         schema:
+ *           type: string
+ *         description: >
+ *           A JSON string containing additional options for the document update process.
+ *           Example: `{"registry":"local","validUntil":"2025-12-31T23:59:59Z"}`
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/octet-stream:
+ *           schema:
+ *             type: string
+ *             format: binary
+ *       description: The new binary document data to replace the existing one.
+ *     responses:
+ *       200:
+ *         description: Indicates whether the update was successful.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                   description: true if the update was successful, otherwise `false`.
+ *       500:
+ *         description: Internal server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ */
+v1router.put('/documents/:id', express.raw({ type: 'application/octet-stream', limit: '10mb' }), async (req, res) => {
+    try {
+        const data = req.body;
+        const headers = req.headers;
+        const options = typeof headers['x-options'] === 'string' ? JSON.parse(headers['x-options']) : {};
+        const ok = await keymaster.updateDocument(req.params.id, data, options);
+
+        res.json({ ok });
+    } catch (error: any) {
+        res.status(500).send(error.toString());
+    }
+});
+
+/**
+ * @swagger
+ * /documents/{id}:
+ *   get:
+ *     summary: Retrieve a binary document by its DID.
+ *     description: >
+ *       Fetches the binary document data and metadata associated with the specified DID.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The DID of the document to retrieve.
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved the document data and metadata.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 image:
+ *                   type: object
+ *                   description: The document data and metadata.
+ *                   properties:
+ *                     type:
+ *                       type: string
+ *                       description: The MIME type of the document (e.g., "application/pdf").
+ *                     bytes:
+ *                       type: integer
+ *                       description: The size of the document in bytes.
+ *                     cid:
+ *                       type: string
+ *                       description: The Content Identifier (CID) of the document.
+ *       404:
+ *         description: Document not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   description: Error message indicating the document was not found.
+ *       500:
+ *         description: Internal server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ */
+v1router.get('/documents/:id', async (req, res) => {
+    try {
+        const image = await keymaster.getDocument(req.params.id);
+        res.json({ image });
+    } catch (error: any) {
+        res.status(404).send({ error: error.toString() });
+    }
+});
+
+/**
+ * @swagger
+ * /documents/{id}/test:
+ *   post:
+ *     summary: Test if the specified document is valid.
+ *     description: >
+ *       Checks whether the document associated with the given DID is valid or meets specific criteria.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The DID of the document to test.
+ *     responses:
+ *       200:
+ *         description: The result of the test.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 test:
+ *                   type: boolean
+ *                   description: true if the document is valid, otherwise `false`.
+ *       400:
+ *         description: Invalid request or test criteria not met.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ *                   description: Error message indicating why the test failed.
+ */
+v1router.post('/documents/:id/test', async (req, res) => {
+    try {
+        const test = await keymaster.testDocument(req.params.id);
         res.json({ test });
     } catch (error: any) {
         res.status(400).send({ error: error.toString() });

--- a/tests/cli-tests/test_cli_validate_help.expect
+++ b/tests/cli-tests/test_cli_validate_help.expect
@@ -45,6 +45,7 @@ Commands:
   check-wallet                               Validate DIDs in wallet
   clone-asset [options] <id>                 Clone an asset
   create-asset [options]                     Create an empty asset
+  create-asset-document [options] <file>     Create an asset from a document file
   create-asset-image [options] <file>        Create an asset from an image file
   create-asset-json [options] <file>         Create an asset from a JSON file
   create-challenge [options] [file]          Create a challenge (optionally from a file)
@@ -103,6 +104,7 @@ Commands:
   transfer-asset <id> <controller>           Transfer asset to a new controller
   unpublish-credential <did>                 Remove a credential from the current user manifest
   unpublish-poll <poll>                      Remove results from poll
+  update-asset-document <id> <file>          Update an asset from a document file
   update-asset-image <id> <file>             Update an asset from an image file
   update-asset-json <id> <file>              Update an asset from a JSON file
   update-poll <ballot>                       Add a ballot to the poll
@@ -138,17 +140,17 @@ if {$output == $reference} {
     exit 0
 } else {
     puts "FAILURE: Output does not match reference"
-    
+
     # Create comparison files
     set ref_file "kc_help_reference.txt"
     set fp [open $ref_file "w"]
     puts $fp $reference
     close $fp
-    
+
     puts "Saved reference to $ref_file"
     puts "Log file saved to $logfile"
     puts "You can compare with: diff -u $logfile $ref_file"
-    
+
     # Show the first difference
     set max_len [expr {min($output_length, $reference_length)}]
     for {set i 0} {$i < $max_len} {incr i} {
@@ -157,10 +159,10 @@ if {$output == $reference} {
         if {$o_char != $r_char} {
             set context_start [expr {max(0, $i-20)}]
             set context_end [expr {min($i+20, $max_len)}]
-            
+
             set o_context [string range $output $context_start $context_end]
             set r_context [string range $reference $context_start $context_end]
-            
+
             puts "\n❌\nFirst difference at position $i:"
             puts "\n❌ Output: '$o_char' (ASCII [scan $o_char %c])"
             puts "\n❌ Reference: '$r_char' (ASCII [scan $r_char %c])"
@@ -169,6 +171,6 @@ if {$output == $reference} {
             break
         }
     }
-    
+
     exit 1
 }

--- a/tests/keymaster-client.test.ts
+++ b/tests/keymaster-client.test.ts
@@ -1160,7 +1160,7 @@ describe('cloneAsset', () => {
 });
 
 describe('transferAsset', () => {
-    const mockDID = 'did:example:123456789abcd';
+    const mockDID = 'did:example:124356789abcd';
     const controller = 'did:example:controller';
 
     it('should transfer asset', async () => {
@@ -2458,7 +2458,7 @@ describe('testImage', () => {
         expect(result).toBe(true);
     });
 
-    it('should throw exception on testSchema server error', async () => {
+    it('should throw exception on testImage server error', async () => {
         nock(KeymasterURL)
             .post(`${Endpoints.images}/${mockImageId}/test`)
             .reply(500, ServerError);
@@ -2554,7 +2554,7 @@ describe('getDocument', () => {
         expect(schema).toStrictEqual(mockDocument);
     });
 
-    it('should throw exception on getImage server error', async () => {
+    it('should throw exception on getDocument server error', async () => {
         nock(KeymasterURL)
             .get(`${Endpoints.documents}/${mockDocumentId}`)
             .reply(500, ServerError);
@@ -2571,7 +2571,7 @@ describe('getDocument', () => {
     });
 });
 
-describe('testImage', () => {
+describe('testDocument', () => {
     const mockDocumentId = 'document1';
 
     it('should test document', async () => {
@@ -2585,7 +2585,7 @@ describe('testImage', () => {
         expect(result).toBe(true);
     });
 
-    it('should throw exception on testSchema server error', async () => {
+    it('should throw exception on testDocument server error', async () => {
         nock(KeymasterURL)
             .post(`${Endpoints.documents}/${mockDocumentId}/test`)
             .reply(500, ServerError);

--- a/tests/keymaster-client.test.ts
+++ b/tests/keymaster-client.test.ts
@@ -41,6 +41,7 @@ const Endpoints = {
     polls_vote: '/api/v1/polls/vote',
     polls_update: '/api/v1/polls/update',
     images: '/api/v1/images',
+    documents: '/api/v1/documents',
 };
 
 const mockConsole = {
@@ -2466,6 +2467,133 @@ describe('testImage', () => {
 
         try {
             await keymaster.testImage(mockImageId);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(ServerError.message);
+        }
+    });
+});
+
+describe('createDocument', () => {
+    const mockDocument = Buffer.from('document data');
+    const mockDID = 'did:example:123456789abcd';
+
+    it('should create an document asset', async () => {
+        nock(KeymasterURL)
+            .post(Endpoints.documents)
+            .reply(200, { did: mockDID });
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const did = await keymaster.createDocument(mockDocument);
+
+        expect(did).toBe(mockDID);
+    });
+
+    it('should throw exception on createDocument server error', async () => {
+        nock(KeymasterURL)
+            .post(Endpoints.documents)
+            .reply(500, ServerError);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+
+        try {
+            await keymaster.createDocument(mockDocument);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(ServerError.message);
+        }
+    });
+});
+
+describe('updateDocument', () => {
+    const mockDocument = Buffer.from('document data');
+    const mockDID = 'did:example:923456789abcd';
+
+    it('should update a document asset', async () => {
+        nock(KeymasterURL)
+            .put(`${Endpoints.documents}/${mockDID}`)
+            .reply(200, { ok: true });
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const ok = await keymaster.updateDocument(mockDID, mockDocument);
+
+        expect(ok).toBe(true);
+    });
+
+    it('should throw exception on updateDocument server error', async () => {
+        nock(KeymasterURL)
+            .put(`${Endpoints.documents}/${mockDID}`)
+            .reply(500, ServerError);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+
+        try {
+            await keymaster.updateDocument(mockDID, mockDocument);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(ServerError.message);
+        }
+    });
+});
+
+describe('getDocument', () => {
+    const mockDocumentId = 'document1';
+    const mockDocument = { cid: 'mockCID', bytes: 12345, type: 'pdf' };
+
+    it('should get document', async () => {
+        nock(KeymasterURL)
+            .get(`${Endpoints.documents}/${mockDocumentId}`)
+            .reply(200, { document: mockDocument });
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const schema = await keymaster.getDocument(mockDocumentId);
+
+        expect(schema).toStrictEqual(mockDocument);
+    });
+
+    it('should throw exception on getImage server error', async () => {
+        nock(KeymasterURL)
+            .get(`${Endpoints.documents}/${mockDocumentId}`)
+            .reply(500, ServerError);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+
+        try {
+            await keymaster.getDocument(mockDocumentId);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(ServerError.message);
+        }
+    });
+});
+
+describe('testImage', () => {
+    const mockDocumentId = 'document1';
+
+    it('should test document', async () => {
+        nock(KeymasterURL)
+            .post(`${Endpoints.documents}/${mockDocumentId}/test`)
+            .reply(200, { test: true });
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const result = await keymaster.testDocument(mockDocumentId);
+
+        expect(result).toBe(true);
+    });
+
+    it('should throw exception on testSchema server error', async () => {
+        nock(KeymasterURL)
+            .post(`${Endpoints.documents}/${mockDocumentId}/test`)
+            .reply(500, ServerError);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+
+        try {
+            await keymaster.testDocument(mockDocumentId);
             throw new ExpectedExceptionError();
         }
         catch (error: any) {

--- a/tests/keymaster.test.ts
+++ b/tests/keymaster.test.ts
@@ -5813,7 +5813,7 @@ describe('testImage', () => {
         mockFs.restore();
     });
 
-    it('should return true for agent DID', async () => {
+    it('should return true for image DID', async () => {
         mockFs({});
 
         // Create a small image buffer using sharp
@@ -5833,7 +5833,28 @@ describe('testImage', () => {
         expect(isImage).toBe(true);
     });
 
-    it('should return false for non-agent DID', async () => {
+    it('should return true for image name', async () => {
+        mockFs({});
+
+        // Create a small image buffer using sharp
+        const mockImage = await sharp({
+            create: {
+                width: 100,
+                height: 100,
+                channels: 3,
+                background: { r: 255, g: 0, b: 0 }
+            }
+        }).png().toBuffer();
+        const name = 'mockImage';
+
+        await keymaster.createId('Bob');
+        await keymaster.createImage(mockImage, { name });
+        const isImage = await keymaster.testImage(name);
+
+        expect(isImage).toBe(true);
+    });
+
+    it('should return false for non-image DID', async () => {
         mockFs({});
 
         await keymaster.createId('Bob');
@@ -5890,6 +5911,57 @@ describe('createDocument', () => {
 
         expect(doc.didDocumentData).toStrictEqual(expected);
     });
+
+    it('should handle case where no filename is provided', async () => {
+        mockFs({});
+
+        const mockDocument = Buffer.from('This is another mock binary document.', 'utf-8');
+        const cid = await generateCID(mockDocument);
+
+        const ownerDid = await keymaster.createId('Bob');
+        const dataDid = await keymaster.createDocument(mockDocument);
+        const doc = await keymaster.resolveDID(dataDid);
+
+        expect(doc.didDocument!.id).toBe(dataDid);
+        expect(doc.didDocument!.controller).toBe(ownerDid);
+
+        const expected = {
+            document: {
+                cid,
+                filename: 'document',
+                bytes: 37,
+                type: 'unknown',
+            }
+        };
+
+        expect(doc.didDocumentData).toStrictEqual(expected);
+    });
+
+    it('should handle case where filename has no extension', async () => {
+        mockFs({});
+
+        const mockDocument = Buffer.from('This is another mock document.', 'utf-8');
+        const cid = await generateCID(mockDocument);
+        const filename = 'mockDocument';
+
+        const ownerDid = await keymaster.createId('Bob');
+        const dataDid = await keymaster.createDocument(mockDocument, { filename });
+        const doc = await keymaster.resolveDID(dataDid);
+
+        expect(doc.didDocument!.id).toBe(dataDid);
+        expect(doc.didDocument!.controller).toBe(ownerDid);
+
+        const expected = {
+            document: {
+                cid,
+                filename,
+                bytes: 30,
+                type: 'unknown',
+            }
+        };
+
+        expect(doc.didDocumentData).toStrictEqual(expected);
+    });
 });
 
 describe('updateDocument', () => {
@@ -5924,5 +5996,89 @@ describe('updateDocument', () => {
         expect(ok).toBe(true);
         expect(doc.didDocumentData).toStrictEqual(expected);
         expect(doc.didDocumentMetadata!.version).toBe(2);
+    });
+});
+
+describe('getDocument', () => {
+
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should return the document asset', async () => {
+        mockFs({});
+
+        const mockDocument = Buffer.from('This is a mock binary document.', 'utf-8');
+        const cid = await generateCID(mockDocument);
+        const filename = 'mockDocument.txt';
+
+        await keymaster.createId('Bob');
+        const did = await keymaster.createDocument(mockDocument, { filename });
+        const asset = await keymaster.getDocument(did);
+
+        const document = {
+            cid,
+            filename,
+            bytes: 31,
+            type: 'txt',
+        };
+
+        expect(asset).toStrictEqual(document);
+    });
+});
+
+describe('testDocument', () => {
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should return true for document DID', async () => {
+        mockFs({});
+
+        const mockDocument = Buffer.from('This is a test document.', 'utf-8');
+
+        await keymaster.createId('Bob');
+        const did = await keymaster.createDocument(mockDocument);
+        const isDocument = await keymaster.testDocument(did);
+
+        expect(isDocument).toBe(true);
+    });
+
+    it('should return true for document name', async () => {
+        mockFs({});
+
+        const mockDocument = Buffer.from('This is another test document.', 'utf-8');
+
+        await keymaster.createId('Bob');
+        const name = 'mockDocument';
+        await keymaster.createDocument(mockDocument, { name });
+        const isDocument = await keymaster.testDocument(name);
+
+        expect(isDocument).toBe(true);
+    });
+
+    it('should return false for non-document DID', async () => {
+        mockFs({});
+
+        await keymaster.createId('Bob');
+        const did = await keymaster.createAsset({ name: 'mockAnchor' });
+        const isDocument = await keymaster.testDocument(did);
+
+        expect(isDocument).toBe(false);
+    });
+
+    it('should return false if no DID specified', async () => {
+        mockFs({});
+
+        // @ts-expect-error Testing invalid usage, missing arg
+        const isDocument = await keymaster.testDocument();
+        expect(isDocument).toBe(false);
+    });
+
+    it('should return false if invalid DID specified', async () => {
+        mockFs({});
+
+        const isDocument = await keymaster.testDocument('mock');
+        expect(isDocument).toBe(false);
     });
 });

--- a/tests/keymaster.test.ts
+++ b/tests/keymaster.test.ts
@@ -5997,6 +5997,61 @@ describe('updateDocument', () => {
         expect(doc.didDocumentData).toStrictEqual(expected);
         expect(doc.didDocumentMetadata!.version).toBe(2);
     });
+
+    it('should handle case where no filename is provided', async () => {
+        mockFs({});
+
+        const mockdoc_v1 = Buffer.from('This is another first version.', 'utf-8');
+        const mockdoc_v2 = Buffer.from('This is another second version.', 'utf-8');
+        const cid = await generateCID(mockdoc_v2);
+        const name = 'mockdoc';
+
+        await keymaster.createId('Bob');
+        await keymaster.createDocument(mockdoc_v1, { name });
+        const ok = await keymaster.updateDocument(name, mockdoc_v2);
+        const doc = await keymaster.resolveDID(name);
+
+        const expected = {
+            document: {
+                cid,
+                filename: 'document',
+                bytes: 31,
+                type: 'unknown',
+            }
+        };
+
+        expect(ok).toBe(true);
+        expect(doc.didDocumentData).toStrictEqual(expected);
+        expect(doc.didDocumentMetadata!.version).toBe(2);
+    });
+
+    it('should handle case where filename has no extension', async () => {
+        mockFs({});
+
+        const mockdoc_v1 = Buffer.from('This is yet another first version.', 'utf-8');
+        const mockdoc_v2 = Buffer.from('This is yet another second version.', 'utf-8');
+        const cid = await generateCID(mockdoc_v2);
+        const name = 'mockdoc';
+        const filename = 'mockdoc';
+
+        await keymaster.createId('Bob');
+        await keymaster.createDocument(mockdoc_v1, { name, filename });
+        const ok = await keymaster.updateDocument(name, mockdoc_v2, { filename });
+        const doc = await keymaster.resolveDID(name);
+
+        const expected = {
+            document: {
+                cid,
+                filename,
+                bytes: 35,
+                type: 'unknown',
+            }
+        };
+
+        expect(ok).toBe(true);
+        expect(doc.didDocumentData).toStrictEqual(expected);
+        expect(doc.didDocumentMetadata!.version).toBe(2);
+    });
 });
 
 describe('getDocument', () => {


### PR DESCRIPTION
This PR adds support for document assets in keymaster by implementing new endpoints, client methods, and tests while updating related types and CLI commands.

-    Added tests for document creation, update, retrieval, and validation.
-    Implemented new document asset endpoints in the server API with Swagger documentation.
-    Updated client, CLI scripts, and types to support document asset operations.
