### PR TITLE
test: setup pipeline for cli tests

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -1,0 +1,56 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Build & Test Docker images
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build_test_images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      
+      - name: Setup env for Testing
+        working-directory: ./tests/cli-tests
+        run: |
+          sudo apt update
+          sudo apt-get install -y expect
+          ./generate_test_env.sh
+          ln -s "$GITHUB_WORKSPACE/kc" /usr/local/bin/kc
+          ln -s "$GITHUB_WORKSPACE/admin" /usr/local/bin/admin
+          echo "/usr/local/bin" >> $GITHUB_PATH
+          sleep 30
+      
+
+      - name: Install Docker Compose
+        run: |
+            sudo curl -L "https://github.com/docker/compose/releases/download/v2.3.3/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+            sudo chmod +x /usr/local/bin/docker-compose
+            docker-compose --version
+        continue-on-error: false
+
+      - name: Run Docker-compose
+        run: |
+          docker compose build cli keymaster gatekeeper
+          docker compose up cli keymaster gatekeeper -d --no-build
+          docker ps
+          sleep 30
+      
+      - name: Run cli-tests
+        working-directory: ./tests
+        run: |
+          ./run_cli_tests.sh --ci
+      
+      - name: Teardown Docker
+        run: |
+          docker-compose down
+

--- a/tests/cli-tests/README.md
+++ b/tests/cli-tests/README.md
@@ -10,7 +10,7 @@ Dependencies:
 - Framework can be installed for MacOSx using Homebrew: https://formulae.brew.sh/formula/expect
 - When starting nodes, use the following command: "./start-node cli"
 - Before running tests, the tests expect the cli commands are accessible by running the "kc" or "admin" command globally.This can be done by adding them to your PATH.
-- Then from /tests, run "./run_cli_tests.sh"
+- Then from /tests, run "./run_cli_tests.sh --local"
 
 * When running without hyperswarm you should set KC_DEFAULT_REGISTRY=local in the .env, otherwise create operations will fail.
 * Tests at this time run only for "local" registry, but will be updated later for others.

--- a/tests/cli-tests/generate_test_env.sh
+++ b/tests/cli-tests/generate_test_env.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -e
+
+# Change to the project root, assuming the script is in ./scripts/
+cd "$(git rev-parse --show-toplevel)"
+
+ENV_FILE=".env"
+
+echo "Generating .env file at project root..."
+
+cat > "$ENV_FILE" <<EOL
+# Auto-generated .env file
+
+# General
+KC_UID=1000
+KC_GID=1000
+KC_NODE_NAME=mdip-quality
+KC_NODE_ID=mdip-quality
+KC_MDIP_PROTOCOL=/MDIP/test
+
+
+# Gatekeeper
+KC_GATEKEEPER_PORT=4224
+KC_GATEKEEPER_DID_PREFIX=did:test
+KC_GATEKEEPER_DB=redis
+KC_GATEKEEPER_REGISTRIES=local
+KC_GATEKEEPER_GC_INTERVAL=60
+KC_GATEKEEPER_STATUS_INTERVAL=1
+
+# Keymaster
+KC_KEYMASTER_PORT=4226
+KC_KEYMASTER_DB=json
+KC_ENCRYPTED_PASSPHRASE=
+KC_WALLET_CACHE=false
+KC_DEFAULT_REGISTRY=local
+
+# CLI
+KC_GATEKEEPER_URL=http://localhost:4224
+KC_KEYMASTER_URL=http://localhost:4226
+
+# Hyperswarm
+KC_HYPR_EXPORT_INTERVAL=2
+KC_MDIP_PROTOCOL=/MDIP/testing
+
+# Bitcoin testnet4 mediator
+KC_TBTC_HOST=localhost
+KC_TBTC_CHAIN=TBTC
+KC_TBTC_NETWORK=testnet
+KC_TBTC_START_BLOCK=38000
+KC_TBTC_PORT=48332
+KC_TBTC_USER=testnet4
+KC_TBTC_PASS=testnet4
+KC_TBTC_WALLET=mdip
+KC_TBTC_IMPORT_INTERVAL=1
+KC_TBTC_EXPORT_INTERVAL=1
+KC_TBTC_FEE_MIN=0.00000200
+KC_TBTC_FEE_MAX=0.00000600
+KC_TBTC_FEE_INC=0
+KC_TBTC_REIMPORT=true
+KC_TBTC_DB=json
+
+# Feathercoin testnet mediator
+KC_TFTC_HOST=localhost
+KC_TFTC_START_BLOCK=0
+KC_TFTC_PORT=19337
+KC_TFTC_USER=feathercoin
+KC_TFTC_PASS=feathercoin
+KC_TFTC_WALLET=mdip
+KC_TFTC_IMPORT_INTERVAL=1
+KC_TFTC_EXPORT_INTERVAL=1
+KC_TFTC_FEE_MIN=0.00000300
+KC_TFTC_FEE_MAX=0.00003000
+KC_TFTC_FEE_INC=0
+KC_TFTC_REIMPORT=true
+KC_TFTC_DB=json
+
+# IPFS mediator
+KC_IPFS_INTERVAL=60
+KC_IPFS_BATCH_SIZE=100
+KC_IPFS_CONCURRENCY=10
+EOL
+
+echo ".env file created with the following content:"
+cat "$ENV_FILE"

--- a/tests/cli-tests/test_cli_add_name.expect
+++ b/tests/cli-tests/test_cli_add_name.expect
@@ -104,24 +104,35 @@ expect {
     }
 }
 
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Delete Wallet
-set script_dir [file dirname [file normalize [info script]]]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+    } elseif {$key == "--no-ci} {
+        # Delete Wallet
+        set script_dir [file dirname [file normalize [info script]]]
 
-# Navigate one level up from script directory, then into kc/data/wallet.json
-set filepath [file join $script_dir ../../data/wallet.json]
+        # Navigate one level up from script directory, then into kc/data/wallet.json
+        set filepath [file join $script_dir ../../data/wallet.json]
 
-# Normalize the path to get an absolute reference
-set abs_filepath [file normalize $filepath]
+        # Normalize the path to get an absolute reference
+        set abs_filepath [file normalize $filepath]
 
-# Check if the file exists
-if {[file exists $abs_filepath]} {
-    puts "File exists: $abs_filepath"
-    # Delete the file
-    file delete -force $abs_filepath
-    puts "File deleted: $abs_filepath"
-} else {
-    puts "File not found: $abs_filepath"
+        # Check if the file exists
+        if {[file exists $abs_filepath]} {
+            puts "File exists: $abs_filepath"
+            # Delete the file
+            file delete -force $abs_filepath
+            puts "File deleted: $abs_filepath"
+        } else {
+            puts "File not found: $abs_filepath"
+        }
+        
+    }
 }
 
 spawn bash kc create-wallet

--- a/tests/cli-tests/test_cli_backup_id.expect
+++ b/tests/cli-tests/test_cli_backup_id.expect
@@ -58,23 +58,35 @@ expect {
 }
 
 
-# Delete Wallet
-set script_dir [file dirname [file normalize [info script]]]
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Navigate one level up from script directory, then into kc/data/wallet.json
-set filepath [file join $script_dir ../../data/wallet.json]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+    } elseif {$key == "--local"} {
+        # Delete Wallet
+        set script_dir [file dirname [file normalize [info script]]]
 
-# Normalize the path to get an absolute reference
-set abs_filepath [file normalize $filepath]
+        # Navigate one level up from script directory, then into kc/data/wallet.json
+        set filepath [file join $script_dir ../../data/wallet.json]
 
-# Check if the file exists
-if {[file exists $abs_filepath]} {
-    puts "File exists: $abs_filepath"
-    # Delete the file
-    file delete -force $abs_filepath
-    puts "File deleted: $abs_filepath"
-} else {
-    puts "File not found: $abs_filepath"
+        # Normalize the path to get an absolute reference
+        set abs_filepath [file normalize $filepath]
+
+        # Check if the file exists
+        if {[file exists $abs_filepath]} {
+            puts "File exists: $abs_filepath"
+            # Delete the file
+            file delete -force $abs_filepath
+            puts "File deleted: $abs_filepath"
+        } else {
+            puts "File not found: $abs_filepath"
+        }
+        
+    }
 }
 
 spawn bash kc create-wallet

--- a/tests/cli-tests/test_cli_check_list_ids.expect
+++ b/tests/cli-tests/test_cli_check_list_ids.expect
@@ -65,23 +65,35 @@ expect {
 }
 
 
-# Delete Wallet
-set script_dir [file dirname [file normalize [info script]]]
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Navigate one level up from script directory, then into kc/data/wallet.json
-set filepath [file join $script_dir ../../data/wallet.json]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+    } elseif {$key == "--local"} {
+        # Delete Wallet
+        set script_dir [file dirname [file normalize [info script]]]
 
-# Normalize the path to get an absolute reference
-set abs_filepath [file normalize $filepath]
+        # Navigate one level up from script directory, then into kc/data/wallet.json
+        set filepath [file join $script_dir ../../data/wallet.json]
 
-# Check if the file exists
-if {[file exists $abs_filepath]} {
-    puts "File exists: $abs_filepath"
-    # Delete the file
-    file delete -force $abs_filepath
-    puts "File deleted: $abs_filepath"
-} else {
-    puts "File not found: $abs_filepath"
+        # Normalize the path to get an absolute reference
+        set abs_filepath [file normalize $filepath]
+
+        # Check if the file exists
+        if {[file exists $abs_filepath]} {
+            puts "File exists: $abs_filepath"
+            # Delete the file
+            file delete -force $abs_filepath
+            puts "File deleted: $abs_filepath"
+        } else {
+            puts "File not found: $abs_filepath"
+        }
+        
+    }
 }
 
 spawn bash kc create-wallet

--- a/tests/cli-tests/test_cli_check_wallet.expect
+++ b/tests/cli-tests/test_cli_check_wallet.expect
@@ -64,23 +64,35 @@ expect {
     }
 }
 
-# Delete Wallet
-set script_dir [file dirname [file normalize [info script]]]
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Navigate one level up from script directory, then into kc/data/wallet.json
-set filepath [file join $script_dir ../../data/wallet.json]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+    } elseif {$key == "--local"} {
+        # Delete Wallet
+        set script_dir [file dirname [file normalize [info script]]]
 
-# Normalize the path to get an absolute reference
-set abs_filepath [file normalize $filepath]
+        # Navigate one level up from script directory, then into kc/data/wallet.json
+        set filepath [file join $script_dir ../../data/wallet.json]
 
-# Check if the file exists
-if {[file exists $abs_filepath]} {
-    puts "File exists: $abs_filepath"
-    # Delete the file
-    file delete -force $abs_filepath
-    puts "File deleted: $abs_filepath"
-} else {
-    puts "File not found: $abs_filepath"
+        # Normalize the path to get an absolute reference
+        set abs_filepath [file normalize $filepath]
+
+        # Check if the file exists
+        if {[file exists $abs_filepath]} {
+            puts "File exists: $abs_filepath"
+            # Delete the file
+            file delete -force $abs_filepath
+            puts "File deleted: $abs_filepath"
+        } else {
+            puts "File not found: $abs_filepath"
+        }
+        
+    }
 }
 
 spawn bash kc create-wallet

--- a/tests/cli-tests/test_cli_create_id.expect
+++ b/tests/cli-tests/test_cli_create_id.expect
@@ -32,23 +32,35 @@ expect {
     }
 }
 
-# Delete Wallet
-set script_dir [file dirname [file normalize [info script]]]
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Navigate one level up from script directory, then into kc/data/wallet.json
-set filepath [file join $script_dir ../../data/wallet.json]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+    } elseif {$key == "--local"} {
+        # Delete Wallet
+        set script_dir [file dirname [file normalize [info script]]]
 
-# Normalize the path to get an absolute reference
-set abs_filepath [file normalize $filepath]
+        # Navigate one level up from script directory, then into kc/data/wallet.json
+        set filepath [file join $script_dir ../../data/wallet.json]
 
-# Check if the file exists
-if {[file exists $abs_filepath]} {
-    puts "File exists: $abs_filepath"
-    # Delete the file
-    file delete -force $abs_filepath
-    puts "File deleted: $abs_filepath"
-} else {
-    puts "File not found: $abs_filepath"
+        # Normalize the path to get an absolute reference
+        set abs_filepath [file normalize $filepath]
+
+        # Check if the file exists
+        if {[file exists $abs_filepath]} {
+            puts "File exists: $abs_filepath"
+            # Delete the file
+            file delete -force $abs_filepath
+            puts "File deleted: $abs_filepath"
+        } else {
+            puts "File not found: $abs_filepath"
+        }
+        
+    }
 }
 
 spawn bash kc create-wallet

--- a/tests/cli-tests/test_cli_create_schema.expect
+++ b/tests/cli-tests/test_cli_create_schema.expect
@@ -68,23 +68,35 @@ expect {
     }
 }
 
-# Delete Wallet
-set script_dir [file dirname [file normalize [info script]]]
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Navigate one level up from script directory, then into kc/data/wallet.json
-set filepath [file join $script_dir ../../data/wallet.json]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+    } elseif {$key == "--local"} {
+        # Delete Wallet
+        set script_dir [file dirname [file normalize [info script]]]
 
-# Normalize the path to get an absolute reference
-set abs_filepath [file normalize $filepath]
+        # Navigate one level up from script directory, then into kc/data/wallet.json
+        set filepath [file join $script_dir ../../data/wallet.json]
 
-# Check if the file exists
-if {[file exists $abs_filepath]} {
-    puts "File exists: $abs_filepath"
-    # Delete the file
-    file delete -force $abs_filepath
-    puts "File deleted: $abs_filepath"
-} else {
-    puts "File not found: $abs_filepath"
+        # Normalize the path to get an absolute reference
+        set abs_filepath [file normalize $filepath]
+
+        # Check if the file exists
+        if {[file exists $abs_filepath]} {
+            puts "File exists: $abs_filepath"
+            # Delete the file
+            file delete -force $abs_filepath
+            puts "File deleted: $abs_filepath"
+        } else {
+            puts "File not found: $abs_filepath"
+        }
+        
+    }
 }
 
 spawn bash kc create-wallet

--- a/tests/cli-tests/test_cli_create_schema_template.expect
+++ b/tests/cli-tests/test_cli_create_schema_template.expect
@@ -136,23 +136,35 @@ expect {
     }
 }
 
-# Delete Wallet
-set script_dir [file dirname [file normalize [info script]]]
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Navigate one level up from script directory, then into kc/data/wallet.json
-set filepath [file join $script_dir ../../data/wallet.json]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+    } elseif {$key == "--local"} {
+        # Delete Wallet
+        set script_dir [file dirname [file normalize [info script]]]
 
-# Normalize the path to get an absolute reference
-set abs_filepath [file normalize $filepath]
+        # Navigate one level up from script directory, then into kc/data/wallet.json
+        set filepath [file join $script_dir ../../data/wallet.json]
 
-# Check if the file exists
-if {[file exists $abs_filepath]} {
-    puts "File exists: $abs_filepath"
-    # Delete the file
-    file delete -force $abs_filepath
-    puts "File deleted: $abs_filepath"
-} else {
-    puts "File not found: $abs_filepath"
+        # Normalize the path to get an absolute reference
+        set abs_filepath [file normalize $filepath]
+
+        # Check if the file exists
+        if {[file exists $abs_filepath]} {
+            puts "File exists: $abs_filepath"
+            # Delete the file
+            file delete -force $abs_filepath
+            puts "File deleted: $abs_filepath"
+        } else {
+            puts "File not found: $abs_filepath"
+        }
+        
+    }
 }
 
 spawn bash kc create-wallet

--- a/tests/cli-tests/test_cli_create_wallet.expect
+++ b/tests/cli-tests/test_cli_create_wallet.expect
@@ -93,23 +93,35 @@ expect {
     }
 }
 
-# Delete Wallet
-set script_dir [file dirname [file normalize [info script]]]
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Navigate one level up from script directory, then into kc/data/wallet.json
-set filepath [file join $script_dir ../../data/wallet.json]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+    } elseif {$key == "--local"} {
+        # Delete Wallet
+        set script_dir [file dirname [file normalize [info script]]]
 
-# Normalize the path to get an absolute reference
-set abs_filepath [file normalize $filepath]
+        # Navigate one level up from script directory, then into kc/data/wallet.json
+        set filepath [file join $script_dir ../../data/wallet.json]
 
-# Check if the file exists
-if {[file exists $abs_filepath]} {
-    puts "File exists: $abs_filepath"
-    # Delete the file
-    file delete -force $abs_filepath
-    puts "File deleted: $abs_filepath"
-} else {
-    puts "File not found: $abs_filepath"
+        # Normalize the path to get an absolute reference
+        set abs_filepath [file normalize $filepath]
+
+        # Check if the file exists
+        if {[file exists $abs_filepath]} {
+            puts "File exists: $abs_filepath"
+            # Delete the file
+            file delete -force $abs_filepath
+            puts "File deleted: $abs_filepath"
+        } else {
+            puts "File not found: $abs_filepath"
+        }
+        
+    }
 }
 
 spawn bash kc create-wallet

--- a/tests/cli-tests/test_cli_encrypt_file.expect
+++ b/tests/cli-tests/test_cli_encrypt_file.expect
@@ -69,23 +69,35 @@ expect {
     }
 }
 
-# Delete Wallet
-set script_dir [file dirname [file normalize [info script]]]
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Navigate one level up from script directory, then into kc/data/wallet.json
-set filepath [file join $script_dir ../../data/wallet.json]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+    } elseif {$key == "--local"} {
+        # Delete Wallet
+        set script_dir [file dirname [file normalize [info script]]]
 
-# Normalize the path to get an absolute reference
-set abs_filepath [file normalize $filepath]
+        # Navigate one level up from script directory, then into kc/data/wallet.json
+        set filepath [file join $script_dir ../../data/wallet.json]
 
-# Check if the file exists
-if {[file exists $abs_filepath]} {
-    puts "File exists: $abs_filepath"
-    # Delete the file
-    file delete -force $abs_filepath
-    puts "File deleted: $abs_filepath"
-} else {
-    puts "File not found: $abs_filepath"
+        # Normalize the path to get an absolute reference
+        set abs_filepath [file normalize $filepath]
+
+        # Check if the file exists
+        if {[file exists $abs_filepath]} {
+            puts "File exists: $abs_filepath"
+            # Delete the file
+            file delete -force $abs_filepath
+            puts "File deleted: $abs_filepath"
+        } else {
+            puts "File not found: $abs_filepath"
+        }
+        
+    }
 }
 
 spawn bash kc create-wallet

--- a/tests/cli-tests/test_cli_get_credential_by_id.expect
+++ b/tests/cli-tests/test_cli_get_credential_by_id.expect
@@ -175,23 +175,35 @@ expect {
     }
 }
 
-# Delete Wallet
-set script_dir [file dirname [file normalize [info script]]]
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Navigate one level up from script directory, then into kc/data/wallet.json
-set filepath [file join $script_dir ../../data/wallet.json]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+    } elseif {$key == "--local"} {
+        # Delete Wallet
+        set script_dir [file dirname [file normalize [info script]]]
 
-# Normalize the path to get an absolute reference
-set abs_filepath [file normalize $filepath]
+        # Navigate one level up from script directory, then into kc/data/wallet.json
+        set filepath [file join $script_dir ../../data/wallet.json]
 
-# Check if the file exists
-if {[file exists $abs_filepath]} {
-    puts "File exists: $abs_filepath"
-    # Delete the file
-    file delete -force $abs_filepath
-    puts "File deleted: $abs_filepath"
-} else {
-    puts "File not found: $abs_filepath"
+        # Normalize the path to get an absolute reference
+        set abs_filepath [file normalize $filepath]
+
+        # Check if the file exists
+        if {[file exists $abs_filepath]} {
+            puts "File exists: $abs_filepath"
+            # Delete the file
+            file delete -force $abs_filepath
+            puts "File deleted: $abs_filepath"
+        } else {
+            puts "File not found: $abs_filepath"
+        }
+        
+    }
 }
 
 spawn bash kc create-wallet

--- a/tests/cli-tests/test_cli_get_schema.expect
+++ b/tests/cli-tests/test_cli_get_schema.expect
@@ -129,23 +129,35 @@ expect {
     }
 }
 
-# Delete Wallet
-set script_dir [file dirname [file normalize [info script]]]
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Navigate one level up from script directory, then into kc/data/wallet.json
-set filepath [file join $script_dir ../../data/wallet.json]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+    } elseif {$key == "--local"} {
+        # Delete Wallet
+        set script_dir [file dirname [file normalize [info script]]]
 
-# Normalize the path to get an absolute reference
-set abs_filepath [file normalize $filepath]
+        # Navigate one level up from script directory, then into kc/data/wallet.json
+        set filepath [file join $script_dir ../../data/wallet.json]
 
-# Check if the file exists
-if {[file exists $abs_filepath]} {
-    puts "File exists: $abs_filepath"
-    # Delete the file
-    file delete -force $abs_filepath
-    puts "File deleted: $abs_filepath"
-} else {
-    puts "File not found: $abs_filepath"
+        # Normalize the path to get an absolute reference
+        set abs_filepath [file normalize $filepath]
+
+        # Check if the file exists
+        if {[file exists $abs_filepath]} {
+            puts "File exists: $abs_filepath"
+            # Delete the file
+            file delete -force $abs_filepath
+            puts "File deleted: $abs_filepath"
+        } else {
+            puts "File not found: $abs_filepath"
+        }
+        
+    }
 }
 
 spawn bash kc create-wallet

--- a/tests/cli-tests/test_cli_import_wallet.expect
+++ b/tests/cli-tests/test_cli_import_wallet.expect
@@ -88,23 +88,35 @@ expect {
     }
 }
 
-# Delete Wallet
-set script_dir [file dirname [file normalize [info script]]]
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Navigate one level up from script directory, then into kc/data/wallet.json
-set filepath [file join $script_dir ../../data/wallet.json]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+    } elseif {$key == "--local"} {
+        # Delete Wallet
+        set script_dir [file dirname [file normalize [info script]]]
 
-# Normalize the path to get an absolute reference
-set abs_filepath [file normalize $filepath]
+        # Navigate one level up from script directory, then into kc/data/wallet.json
+        set filepath [file join $script_dir ../../data/wallet.json]
 
-# Check if the file exists
-if {[file exists $abs_filepath]} {
-    puts "File exists: $abs_filepath"
-    # Delete the file
-    file delete -force $abs_filepath
-    puts "File deleted: $abs_filepath"
-} else {
-    puts "File not found: $abs_filepath"
+        # Normalize the path to get an absolute reference
+        set abs_filepath [file normalize $filepath]
+
+        # Check if the file exists
+        if {[file exists $abs_filepath]} {
+            puts "File exists: $abs_filepath"
+            # Delete the file
+            file delete -force $abs_filepath
+            puts "File deleted: $abs_filepath"
+        } else {
+            puts "File not found: $abs_filepath"
+        }
+        
+    }
 }
 
 spawn bash kc create-wallet

--- a/tests/cli-tests/test_cli_issue_credential.expect
+++ b/tests/cli-tests/test_cli_issue_credential.expect
@@ -105,34 +105,75 @@ expect {
         exit 1
     }
 }
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Delete Schema on docker
-spawn bash -c "docker compose exec cli rm -rf /app/share/qa-credential-final.json"
+        # Print result
+        puts "Deleted wallet.json!"
+        
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-cli-1 rm -rf /app/share/qa-credential-final.json]
 
-# Delete Wallet and Credential Files
-set script_dir [file dirname [file normalize [info script]]]
+        # Print result
+        puts "Deleted qa-credential-final.json!"
+        
+        # Delete credential file
+        set script_dir [file dirname [file normalize [info script]]]
 
-# File paths to delete
-set wallet_path [file join $script_dir ../../data/wallet.json]
-set qa_cred_path [file join $script_dir ../qa-credential.json]
-set qa_cred_final_path [file join $script_dir ../qa-credential-final.json]
+        # File paths to delete
+        set qa_cred_path [file join $script_dir qa-credential.json]
 
-# List of files to process
-set files_to_delete [list $wallet_path $qa_cred_path $qa_cred_final_path]
+        # List of files to process
+        set files_to_delete [list $qa_cred_path]
+        
+        # Process each file
+        foreach filepath $files_to_delete {
+            # Normalize the path to get an absolute reference
+            set abs_filepath [file normalize $filepath]
 
-# Process each file
-foreach filepath $files_to_delete {
-    # Normalize the path to get an absolute reference
-    set abs_filepath [file normalize $filepath]
+            # Check if the file exists
+            if {[file exists $abs_filepath]} {
+                puts "File exists: $abs_filepath"
+                # Delete the file
+                file delete -force $abs_filepath
+                puts "File deleted: $abs_filepath"
+            } else {
+                puts "File not found: $abs_filepath"
+            }
+        }
+        
+    } elseif {$key == "--local"} {
+        # Delete Schema on docker
+        spawn bash -c "docker compose exec cli rm -rf /app/share/qa-credential-final.json"
 
-    # Check if the file exists
-    if {[file exists $abs_filepath]} {
-        puts "File exists: $abs_filepath"
-        # Delete the file
-        file delete -force $abs_filepath
-        puts "File deleted: $abs_filepath"
-    } else {
-        puts "File not found: $abs_filepath"
+        # Delete Wallet and Credential Files
+        set script_dir [file dirname [file normalize [info script]]]
+
+        # File paths to delete
+        set wallet_path [file join $script_dir ../../data/wallet.json]
+        set qa_cred_path [file join $script_dir ../qa-credential.json]
+        set qa_cred_final_path [file join $script_dir ../qa-credential-final.json]
+
+        # List of files to process
+        set files_to_delete [list $wallet_path $qa_cred_path $qa_cred_final_path]
+
+        # Process each file
+        foreach filepath $files_to_delete {
+            # Normalize the path to get an absolute reference
+            set abs_filepath [file normalize $filepath]
+
+            # Check if the file exists
+            if {[file exists $abs_filepath]} {
+                puts "File exists: $abs_filepath"
+                # Delete the file
+                file delete -force $abs_filepath
+                puts "File deleted: $abs_filepath"
+            } else {
+                puts "File not found: $abs_filepath"
+            }
+        }
     }
 }
 

--- a/tests/cli-tests/test_cli_list_credentials.expect
+++ b/tests/cli-tests/test_cli_list_credentials.expect
@@ -119,33 +119,75 @@ expect {
     }
 }
 
-# Delete Schema on docker
-spawn bash -c "docker compose exec cli rm -rf /app/share/qa-credential-final.json"
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Delete Wallet and Credential Files
-set script_dir [file dirname [file normalize [info script]]]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-cli-1 rm -rf /app/share/qa-credential-final.json]
 
-# File paths to delete
-set wallet_path [file join $script_dir ../../data/wallet.json]
-set qa_cred_path [file join $script_dir ../qa-credential.json]
-set qa_cred_final_path [file join $script_dir ../qa-credential-final.json]
+        # Print result
+        puts "Deleted qa-credential-final.json!"
+        
+        # Delete credential file
+        set script_dir [file dirname [file normalize [info script]]]
 
-# List of files to process
-set files_to_delete [list $wallet_path $qa_cred_path $qa_cred_final_path]
+        # File paths to delete
+        set qa_cred_path [file join $script_dir qa-credential.json]
 
-# Process each file
-foreach filepath $files_to_delete {
-    # Normalize the path to get an absolute reference
-    set abs_filepath [file normalize $filepath]
+        # List of files to process
+        set files_to_delete [list $qa_cred_path]
+        
+        # Process each file
+        foreach filepath $files_to_delete {
+            # Normalize the path to get an absolute reference
+            set abs_filepath [file normalize $filepath]
 
-    # Check if the file exists
-    if {[file exists $abs_filepath]} {
-        puts "File exists: $abs_filepath"
-        # Delete the file
-        file delete -force $abs_filepath
-        puts "File deleted: $abs_filepath"
-    } else {
-        puts "File not found: $abs_filepath"
+            # Check if the file exists
+            if {[file exists $abs_filepath]} {
+                puts "File exists: $abs_filepath"
+                # Delete the file
+                file delete -force $abs_filepath
+                puts "File deleted: $abs_filepath"
+            } else {
+                puts "File not found: $abs_filepath"
+            }
+        }
+        
+    } elseif {$key == "--local"} {
+        # Delete Schema on docker
+        spawn bash -c "docker compose exec cli rm -rf /app/share/qa-credential-final.json"
+
+        # Delete Wallet and Credential Files
+        set script_dir [file dirname [file normalize [info script]]]
+
+        # File paths to delete
+        set wallet_path [file join $script_dir ../../data/wallet.json]
+        set qa_cred_path [file join $script_dir ../qa-credential.json]
+        set qa_cred_final_path [file join $script_dir ../qa-credential-final.json]
+
+        # List of files to process
+        set files_to_delete [list $wallet_path $qa_cred_path $qa_cred_final_path]
+
+        # Process each file
+        foreach filepath $files_to_delete {
+            # Normalize the path to get an absolute reference
+            set abs_filepath [file normalize $filepath]
+
+            # Check if the file exists
+            if {[file exists $abs_filepath]} {
+                puts "File exists: $abs_filepath"
+                # Delete the file
+                file delete -force $abs_filepath
+                puts "File deleted: $abs_filepath"
+            } else {
+                puts "File not found: $abs_filepath"
+            }
+        }
     }
 }
 

--- a/tests/cli-tests/test_cli_list_dids.expect
+++ b/tests/cli-tests/test_cli_list_dids.expect
@@ -51,23 +51,35 @@ expect {
     }
 }
 
-# Delete Wallet
-set script_dir [file dirname [file normalize [info script]]]
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Navigate one level up from script directory, then into kc/data/wallet.json
-set filepath [file join $script_dir ../../data/wallet.json]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+    } elseif {$key == "--local"} {
+        # Delete Wallet
+        set script_dir [file dirname [file normalize [info script]]]
 
-# Normalize the path to get an absolute reference
-set abs_filepath [file normalize $filepath]
+        # Navigate one level up from script directory, then into kc/data/wallet.json
+        set filepath [file join $script_dir ../../data/wallet.json]
 
-# Check if the file exists
-if {[file exists $abs_filepath]} {
-    puts "File exists: $abs_filepath"
-    # Delete the file
-    file delete -force $abs_filepath
-    puts "File deleted: $abs_filepath"
-} else {
-    puts "File not found: $abs_filepath"
+        # Normalize the path to get an absolute reference
+        set abs_filepath [file normalize $filepath]
+
+        # Check if the file exists
+        if {[file exists $abs_filepath]} {
+            puts "File exists: $abs_filepath"
+            # Delete the file
+            file delete -force $abs_filepath
+            puts "File deleted: $abs_filepath"
+        } else {
+            puts "File not found: $abs_filepath"
+        }
+        
+    }
 }
 
 spawn bash kc create-wallet

--- a/tests/cli-tests/test_cli_list_issue_credentials.expect
+++ b/tests/cli-tests/test_cli_list_issue_credentials.expect
@@ -121,33 +121,75 @@ expect {
     }
 }
 
-# Delete Schema on docker
-spawn bash -c "docker compose exec cli rm -rf /app/share/qa-credential-final.json"
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Delete Wallet and Credential Files
-set script_dir [file dirname [file normalize [info script]]]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-cli-1 rm -rf /app/share/qa-credential-final.json]
 
-# File paths to delete
-set wallet_path [file join $script_dir ../../data/wallet.json]
-set qa_cred_path [file join $script_dir ../qa-credential.json]
-set qa_cred_final_path [file join $script_dir ../qa-credential-final.json]
+        # Print result
+        puts "Deleted qa-credential-final.json!"
+        
+        # Delete credential file
+        set script_dir [file dirname [file normalize [info script]]]
 
-# List of files to process
-set files_to_delete [list $wallet_path $qa_cred_path $qa_cred_final_path]
+        # File paths to delete
+        set qa_cred_path [file join $script_dir qa-credential.json]
 
-# Process each file
-foreach filepath $files_to_delete {
-    # Normalize the path to get an absolute reference
-    set abs_filepath [file normalize $filepath]
+        # List of files to process
+        set files_to_delete [list $qa_cred_path]
+        
+        # Process each file
+        foreach filepath $files_to_delete {
+            # Normalize the path to get an absolute reference
+            set abs_filepath [file normalize $filepath]
 
-    # Check if the file exists
-    if {[file exists $abs_filepath]} {
-        puts "File exists: $abs_filepath"
-        # Delete the file
-        file delete -force $abs_filepath
-        puts "File deleted: $abs_filepath"
-    } else {
-        puts "File not found: $abs_filepath"
+            # Check if the file exists
+            if {[file exists $abs_filepath]} {
+                puts "File exists: $abs_filepath"
+                # Delete the file
+                file delete -force $abs_filepath
+                puts "File deleted: $abs_filepath"
+            } else {
+                puts "File not found: $abs_filepath"
+            }
+        }
+        
+    } elseif {$key == "--local"} {
+        # Delete Schema on docker
+        spawn bash -c "docker compose exec cli rm -rf /app/share/qa-credential-final.json"
+
+        # Delete Wallet and Credential Files
+        set script_dir [file dirname [file normalize [info script]]]
+
+        # File paths to delete
+        set wallet_path [file join $script_dir ../../data/wallet.json]
+        set qa_cred_path [file join $script_dir ../qa-credential.json]
+        set qa_cred_final_path [file join $script_dir ../qa-credential-final.json]
+
+        # List of files to process
+        set files_to_delete [list $wallet_path $qa_cred_path $qa_cred_final_path]
+
+        # Process each file
+        foreach filepath $files_to_delete {
+            # Normalize the path to get an absolute reference
+            set abs_filepath [file normalize $filepath]
+
+            # Check if the file exists
+            if {[file exists $abs_filepath]} {
+                puts "File exists: $abs_filepath"
+                # Delete the file
+                file delete -force $abs_filepath
+                puts "File deleted: $abs_filepath"
+            } else {
+                puts "File not found: $abs_filepath"
+            }
+        }
     }
 }
 

--- a/tests/cli-tests/test_cli_list_names.expect
+++ b/tests/cli-tests/test_cli_list_names.expect
@@ -63,23 +63,35 @@ expect {
     }
 }
 
-# Delete Wallet
-set script_dir [file dirname [file normalize [info script]]]
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Navigate one level up from script directory, then into kc/data/wallet.json
-set filepath [file join $script_dir ../../data/wallet.json]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+    } elseif {$key == "--local"} {
+        # Delete Wallet
+        set script_dir [file dirname [file normalize [info script]]]
 
-# Normalize the path to get an absolute reference
-set abs_filepath [file normalize $filepath]
+        # Navigate one level up from script directory, then into kc/data/wallet.json
+        set filepath [file join $script_dir ../../data/wallet.json]
 
-# Check if the file exists
-if {[file exists $abs_filepath]} {
-    puts "File exists: $abs_filepath"
-    # Delete the file
-    file delete -force $abs_filepath
-    puts "File deleted: $abs_filepath"
-} else {
-    puts "File not found: $abs_filepath"
+        # Normalize the path to get an absolute reference
+        set abs_filepath [file normalize $filepath]
+
+        # Check if the file exists
+        if {[file exists $abs_filepath]} {
+            puts "File exists: $abs_filepath"
+            # Delete the file
+            file delete -force $abs_filepath
+            puts "File deleted: $abs_filepath"
+        } else {
+            puts "File not found: $abs_filepath"
+        }
+        
+    }
 }
 
 spawn bash kc create-wallet

--- a/tests/cli-tests/test_cli_list_schema.expect
+++ b/tests/cli-tests/test_cli_list_schema.expect
@@ -76,23 +76,35 @@ expect {
     }
 }
 
-# Delete Wallet
-set script_dir [file dirname [file normalize [info script]]]
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Navigate one level up from script directory, then into kc/data/wallet.json
-set filepath [file join $script_dir ../../data/wallet.json]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+    } elseif {$key == "--local"} {
+        # Delete Wallet
+        set script_dir [file dirname [file normalize [info script]]]
 
-# Normalize the path to get an absolute reference
-set abs_filepath [file normalize $filepath]
+        # Navigate one level up from script directory, then into kc/data/wallet.json
+        set filepath [file join $script_dir ../../data/wallet.json]
 
-# Check if the file exists
-if {[file exists $abs_filepath]} {
-    puts "File exists: $abs_filepath"
-    # Delete the file
-    file delete -force $abs_filepath
-    puts "File deleted: $abs_filepath"
-} else {
-    puts "File not found: $abs_filepath"
+        # Normalize the path to get an absolute reference
+        set abs_filepath [file normalize $filepath]
+
+        # Check if the file exists
+        if {[file exists $abs_filepath]} {
+            puts "File exists: $abs_filepath"
+            # Delete the file
+            file delete -force $abs_filepath
+            puts "File deleted: $abs_filepath"
+        } else {
+            puts "File not found: $abs_filepath"
+        }
+        
+    }
 }
 
 spawn bash kc create-wallet

--- a/tests/cli-tests/test_cli_remove_id.expect
+++ b/tests/cli-tests/test_cli_remove_id.expect
@@ -42,23 +42,35 @@ expect {
     }
 }
 
-# Delete Wallet
-set script_dir [file dirname [file normalize [info script]]]
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Navigate one level up from script directory, then into kc/data/wallet.json
-set filepath [file join $script_dir ../../data/wallet.json]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+    } elseif {$key == "--local"} {
+        # Delete Wallet
+        set script_dir [file dirname [file normalize [info script]]]
 
-# Normalize the path to get an absolute reference
-set abs_filepath [file normalize $filepath]
+        # Navigate one level up from script directory, then into kc/data/wallet.json
+        set filepath [file join $script_dir ../../data/wallet.json]
 
-# Check if the file exists
-if {[file exists $abs_filepath]} {
-    puts "File exists: $abs_filepath"
-    # Delete the file
-    file delete -force $abs_filepath
-    puts "File deleted: $abs_filepath"
-} else {
-    puts "File not found: $abs_filepath"
+        # Normalize the path to get an absolute reference
+        set abs_filepath [file normalize $filepath]
+
+        # Check if the file exists
+        if {[file exists $abs_filepath]} {
+            puts "File exists: $abs_filepath"
+            # Delete the file
+            file delete -force $abs_filepath
+            puts "File deleted: $abs_filepath"
+        } else {
+            puts "File not found: $abs_filepath"
+        }
+        
+    }
 }
 
 spawn bash kc create-wallet

--- a/tests/cli-tests/test_cli_remove_name.expect
+++ b/tests/cli-tests/test_cli_remove_name.expect
@@ -79,23 +79,35 @@ expect {
     }
 }
 
-# Delete Wallet
-set script_dir [file dirname [file normalize [info script]]]
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Navigate one level up from script directory, then into kc/data/wallet.json
-set filepath [file join $script_dir ../../data/wallet.json]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+    } elseif {$key == "--local"} {
+        # Delete Wallet
+        set script_dir [file dirname [file normalize [info script]]]
 
-# Normalize the path to get an absolute reference
-set abs_filepath [file normalize $filepath]
+        # Navigate one level up from script directory, then into kc/data/wallet.json
+        set filepath [file join $script_dir ../../data/wallet.json]
 
-# Check if the file exists
-if {[file exists $abs_filepath]} {
-    puts "File exists: $abs_filepath"
-    # Delete the file
-    file delete -force $abs_filepath
-    puts "File deleted: $abs_filepath"
-} else {
-    puts "File not found: $abs_filepath"
+        # Normalize the path to get an absolute reference
+        set abs_filepath [file normalize $filepath]
+
+        # Check if the file exists
+        if {[file exists $abs_filepath]} {
+            puts "File exists: $abs_filepath"
+            # Delete the file
+            file delete -force $abs_filepath
+            puts "File deleted: $abs_filepath"
+        } else {
+            puts "File not found: $abs_filepath"
+        }
+        
+    }
 }
 
 spawn bash kc create-wallet

--- a/tests/cli-tests/test_cli_resolve_id.expect
+++ b/tests/cli-tests/test_cli_resolve_id.expect
@@ -115,23 +115,35 @@ expect {
     }
 }
 
-# Delete Wallet
-set script_dir [file dirname [file normalize [info script]]]
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Navigate one level up from script directory, then into kc/data/wallet.json
-set filepath [file join $script_dir ../../data/wallet.json]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+    } elseif {$key == "--local"} {
+        # Delete Wallet
+        set script_dir [file dirname [file normalize [info script]]]
 
-# Normalize the path to get an absolute reference
-set abs_filepath [file normalize $filepath]
+        # Navigate one level up from script directory, then into kc/data/wallet.json
+        set filepath [file join $script_dir ../../data/wallet.json]
 
-# Check if the file exists
-if {[file exists $abs_filepath]} {
-    puts "File exists: $abs_filepath"
-    # Delete the file
-    file delete -force $abs_filepath
-    puts "File deleted: $abs_filepath"
-} else {
-    puts "File not found: $abs_filepath"
+        # Normalize the path to get an absolute reference
+        set abs_filepath [file normalize $filepath]
+
+        # Check if the file exists
+        if {[file exists $abs_filepath]} {
+            puts "File exists: $abs_filepath"
+            # Delete the file
+            file delete -force $abs_filepath
+            puts "File deleted: $abs_filepath"
+        } else {
+            puts "File not found: $abs_filepath"
+        }
+        
+    }
 }
 
 spawn bash kc create-wallet

--- a/tests/cli-tests/test_cli_reveal_credentials.expect
+++ b/tests/cli-tests/test_cli_reveal_credentials.expect
@@ -160,25 +160,75 @@ expect {
     }
 }
 
-# Delete schema file in Docker container
-spawn bash -c "docker compose exec cli rm -rf /app/share/qa-credential-final.json"
-expect eof
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Delete local wallet and credential files
-set script_dir [file dirname [file normalize [info script]]]
-set wallet_path [file join $script_dir ../../data/wallet.json]
-set qa_cred_path [file join $script_dir ../qa-credential.json]
-set qa_cred_final_path [file join $script_dir ../qa-credential-final.json]
-set files_to_delete [list $wallet_path $qa_cred_path $qa_cred_final_path]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-cli-1 rm -rf /app/share/qa-credential-final.json]
 
-foreach filepath $files_to_delete {
-    set abs_filepath [file normalize $filepath]
-    if {[file exists $abs_filepath]} {
-        puts "File exists: $abs_filepath"
-        file delete -force $abs_filepath
-        puts "File deleted: $abs_filepath"
-    } else {
-        puts "File not found: $abs_filepath"
+        # Print result
+        puts "Deleted qa-credential-final.json!"
+        
+        # Delete credential file
+        set script_dir [file dirname [file normalize [info script]]]
+
+        # File paths to delete
+        set qa_cred_path [file join $script_dir qa-credential.json]
+
+        # List of files to process
+        set files_to_delete [list $qa_cred_path]
+        
+        # Process each file
+        foreach filepath $files_to_delete {
+            # Normalize the path to get an absolute reference
+            set abs_filepath [file normalize $filepath]
+
+            # Check if the file exists
+            if {[file exists $abs_filepath]} {
+                puts "File exists: $abs_filepath"
+                # Delete the file
+                file delete -force $abs_filepath
+                puts "File deleted: $abs_filepath"
+            } else {
+                puts "File not found: $abs_filepath"
+            }
+        }
+        
+    } elseif {$key == "--local"} {
+        # Delete Schema on docker
+        spawn bash -c "docker compose exec cli rm -rf /app/share/qa-credential-final.json"
+
+        # Delete Wallet and Credential Files
+        set script_dir [file dirname [file normalize [info script]]]
+
+        # File paths to delete
+        set wallet_path [file join $script_dir ../../data/wallet.json]
+        set qa_cred_path [file join $script_dir ../qa-credential.json]
+        set qa_cred_final_path [file join $script_dir ../qa-credential-final.json]
+
+        # List of files to process
+        set files_to_delete [list $wallet_path $qa_cred_path $qa_cred_final_path]
+
+        # Process each file
+        foreach filepath $files_to_delete {
+            # Normalize the path to get an absolute reference
+            set abs_filepath [file normalize $filepath]
+
+            # Check if the file exists
+            if {[file exists $abs_filepath]} {
+                puts "File exists: $abs_filepath"
+                # Delete the file
+                file delete -force $abs_filepath
+                puts "File deleted: $abs_filepath"
+            } else {
+                puts "File not found: $abs_filepath"
+            }
+        }
     }
 }
 

--- a/tests/cli-tests/test_cli_revoke_credentials.expect
+++ b/tests/cli-tests/test_cli_revoke_credentials.expect
@@ -121,33 +121,75 @@ expect {
     }
 }
 
-# Delete Schema on docker
-spawn bash -c "docker compose exec cli rm -rf /app/share/qa-credential-final.json"
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Delete Wallet and Credential Files
-set script_dir [file dirname [file normalize [info script]]]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-cli-1 rm -rf /app/share/qa-credential-final.json]
 
-# File paths to delete
-set wallet_path [file join $script_dir ../../data/wallet.json]
-set qa_cred_path [file join $script_dir ../qa-credential.json]
-set qa_cred_final_path [file join $script_dir ../qa-credential-final.json]
+        # Print result
+        puts "Deleted qa-credential-final.json!"
+        
+        # Delete credential file
+        set script_dir [file dirname [file normalize [info script]]]
 
-# List of files to process
-set files_to_delete [list $wallet_path $qa_cred_path $qa_cred_final_path]
+        # File paths to delete
+        set qa_cred_path [file join $script_dir qa-credential.json]
 
-# Process each file
-foreach filepath $files_to_delete {
-    # Normalize the path to get an absolute reference
-    set abs_filepath [file normalize $filepath]
+        # List of files to process
+        set files_to_delete [list $qa_cred_path]
+        
+        # Process each file
+        foreach filepath $files_to_delete {
+            # Normalize the path to get an absolute reference
+            set abs_filepath [file normalize $filepath]
 
-    # Check if the file exists
-    if {[file exists $abs_filepath]} {
-        puts "File exists: $abs_filepath"
-        # Delete the file
-        file delete -force $abs_filepath
-        puts "File deleted: $abs_filepath"
-    } else {
-        puts "File not found: $abs_filepath"
+            # Check if the file exists
+            if {[file exists $abs_filepath]} {
+                puts "File exists: $abs_filepath"
+                # Delete the file
+                file delete -force $abs_filepath
+                puts "File deleted: $abs_filepath"
+            } else {
+                puts "File not found: $abs_filepath"
+            }
+        }
+        
+    } elseif {$key == "--local"} {
+        # Delete Schema on docker
+        spawn bash -c "docker compose exec cli rm -rf /app/share/qa-credential-final.json"
+
+        # Delete Wallet and Credential Files
+        set script_dir [file dirname [file normalize [info script]]]
+
+        # File paths to delete
+        set wallet_path [file join $script_dir ../../data/wallet.json]
+        set qa_cred_path [file join $script_dir ../qa-credential.json]
+        set qa_cred_final_path [file join $script_dir ../qa-credential-final.json]
+
+        # List of files to process
+        set files_to_delete [list $wallet_path $qa_cred_path $qa_cred_final_path]
+
+        # Process each file
+        foreach filepath $files_to_delete {
+            # Normalize the path to get an absolute reference
+            set abs_filepath [file normalize $filepath]
+
+            # Check if the file exists
+            if {[file exists $abs_filepath]} {
+                puts "File exists: $abs_filepath"
+                # Delete the file
+                file delete -force $abs_filepath
+                puts "File deleted: $abs_filepath"
+            } else {
+                puts "File not found: $abs_filepath"
+            }
+        }
     }
 }
 

--- a/tests/cli-tests/test_cli_rotate_keys.expect
+++ b/tests/cli-tests/test_cli_rotate_keys.expect
@@ -147,23 +147,35 @@ expect {
     }
 }
 
-# Delete Wallet
-set script_dir [file dirname [file normalize [info script]]]
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Navigate one level up from script directory, then into kc/data/wallet.json
-set filepath [file join $script_dir ../../data/wallet.json]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+    } elseif {$key == "--local"} {
+        # Delete Wallet
+        set script_dir [file dirname [file normalize [info script]]]
 
-# Normalize the path to get an absolute reference
-set abs_filepath [file normalize $filepath]
+        # Navigate one level up from script directory, then into kc/data/wallet.json
+        set filepath [file join $script_dir ../../data/wallet.json]
 
-# Check if the file exists
-if {[file exists $abs_filepath]} {
-    puts "File exists: $abs_filepath"
-    # Delete the file
-    file delete -force $abs_filepath
-    puts "File deleted: $abs_filepath"
-} else {
-    puts "File not found: $abs_filepath"
+        # Normalize the path to get an absolute reference
+        set abs_filepath [file normalize $filepath]
+
+        # Check if the file exists
+        if {[file exists $abs_filepath]} {
+            puts "File exists: $abs_filepath"
+            # Delete the file
+            file delete -force $abs_filepath
+            puts "File deleted: $abs_filepath"
+        } else {
+            puts "File not found: $abs_filepath"
+        }
+        
+    }
 }
 
 spawn bash kc create-wallet

--- a/tests/cli-tests/test_cli_show_mnemonic.expect
+++ b/tests/cli-tests/test_cli_show_mnemonic.expect
@@ -45,23 +45,35 @@ expect {
     }
 }
 
-# Delete Wallet
-set script_dir [file dirname [file normalize [info script]]]
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Navigate one level up from script directory, then into kc/data/wallet.json
-set filepath [file join $script_dir ../../data/wallet.json]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+    } elseif {$key == "--local"} {
+        # Delete Wallet
+        set script_dir [file dirname [file normalize [info script]]]
 
-# Normalize the path to get an absolute reference
-set abs_filepath [file normalize $filepath]
+        # Navigate one level up from script directory, then into kc/data/wallet.json
+        set filepath [file join $script_dir ../../data/wallet.json]
 
-# Check if the file exists
-if {[file exists $abs_filepath]} {
-    puts "File exists: $abs_filepath"
-    # Delete the file
-    file delete -force $abs_filepath
-    puts "File deleted: $abs_filepath"
-} else {
-    puts "File not found: $abs_filepath"
+        # Normalize the path to get an absolute reference
+        set abs_filepath [file normalize $filepath]
+
+        # Check if the file exists
+        if {[file exists $abs_filepath]} {
+            puts "File exists: $abs_filepath"
+            # Delete the file
+            file delete -force $abs_filepath
+            puts "File deleted: $abs_filepath"
+        } else {
+            puts "File not found: $abs_filepath"
+        }
+        
+    }
 }
 
 spawn bash kc create-wallet

--- a/tests/cli-tests/test_cli_show_wallet.expect
+++ b/tests/cli-tests/test_cli_show_wallet.expect
@@ -101,23 +101,35 @@ expect {
     }
 }
 
-# Delete Wallet
-set script_dir [file dirname [file normalize [info script]]]
+foreach {key val} $argv {
+    if {$key == "--ci"} {
+        # Run docker exec to delete the file
+        set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
-# Navigate one level up from script directory, then into kc/data/wallet.json
-set filepath [file join $script_dir ../../data/wallet.json]
+        # Print result
+        puts "Deleted wallet.json!"
+        
+    } elseif {$key == "--local"} {
+        # Delete Wallet
+        set script_dir [file dirname [file normalize [info script]]]
 
-# Normalize the path to get an absolute reference
-set abs_filepath [file normalize $filepath]
+        # Navigate one level up from script directory, then into kc/data/wallet.json
+        set filepath [file join $script_dir ../../data/wallet.json]
 
-# Check if the file exists
-if {[file exists $abs_filepath]} {
-    puts "File exists: $abs_filepath"
-    # Delete the file
-    file delete -force $abs_filepath
-    puts "File deleted: $abs_filepath"
-} else {
-    puts "File not found: $abs_filepath"
+        # Normalize the path to get an absolute reference
+        set abs_filepath [file normalize $filepath]
+
+        # Check if the file exists
+        if {[file exists $abs_filepath]} {
+            puts "File exists: $abs_filepath"
+            # Delete the file
+            file delete -force $abs_filepath
+            puts "File deleted: $abs_filepath"
+        } else {
+            puts "File not found: $abs_filepath"
+        }
+        
+    }
 }
 
 spawn bash kc create-wallet

--- a/tests/run_cli_tests.sh
+++ b/tests/run_cli_tests.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Capture the first argument (e.g., --ci or --no-ci)
+CI_MODE="$1"
 PASS=()
 FAIL=()
 # Use regular arrays instead of associative arrays
@@ -25,7 +27,7 @@ for f in "${scripts[@]}"; do
   START_TIME=$(date +%s)
   
   # Run the expect script directly with -f flag and show output in real-time
-  /usr/bin/expect -f "$f" 2>&1 | tee /tmp/expect_output.$$
+  /usr/bin/expect -f "$f" -- "$CI_MODE" 2>&1 | tee /tmp/expect_output.$$
   EXIT_CODE=${PIPESTATUS[0]}
   
   # End timer and calculate duration


### PR DESCRIPTION
This activates a new pipeline for running the CLI tests. I have ran these tests locally passing the new flag. I updated the README. There might still need to be changes for this to work. But I was able to confirm using a local service that replicates "GitHub runners" and was able to see it pass. 

This doesnt impact existing workflows for now. When we know it is working we can consolidate and or replace existing ones. 