### PR TITLE
fix: Updated issue-credential command options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,84 +77,84 @@ Options:
   -h, --help                                 display help for command
 
 Commands:
-  accept-credential [options] <did>          Save verifiable credential for current ID
-  add-group-member <group> <member>          Add a member to a group
-  add-name <name> <did>                      Add a name for a DID
-  backup-id                                  Backup the current ID to its registry
-  backup-wallet-did                          Backup wallet to encrypted DID and seed bank
-  backup-wallet-file <file>                  Backup wallet to file
-  bind-credential <schema> <subject>         Create bound credential for a user
-  check-wallet                               Validate DIDs in wallet
-  clone-asset [options] <id>                 Clone an asset
-  create-asset [options]                     Create an empty asset
-  create-asset-document [options] <file>     Create an asset from a document file
-  create-asset-image [options] <file>        Create an asset from an image file
-  create-asset-json [options] <file>         Create an asset from a JSON file
-  create-challenge [options] [file]          Create a challenge (optionally from a file)
-  create-challenge-cc [options] <did>        Create a challenge from a credential DID
-  create-group [options] <name>              Create a new group
-  create-id <name> [registry]                Create a new decentralized ID
-  create-poll [options] <file>               Create a poll
-  create-poll-template                       Create a poll template
-  create-response <challenge>                Create a response to a challenge
-  create-schema [options] <file>             Create a schema from a file
-  create-schema-template <schema>            Create a template from a schema
-  create-wallet                              Create a new wallet (or show existing wallet)
-  decrypt-did <did>                          Decrypt an encrypted message DID
-  decrypt-json <did>                         Decrypt an encrypted JSON DID
-  encrypt-file <file> <did>                  Encrypt a file for a DID
-  encrypt-message <message> <did>            Encrypt a message for a DID
-  encrypt-wallet                             Encrypt wallet
-  fix-wallet                                 Remove invalid DIDs from the wallet
-  get-asset <id>                             Get asset by name or DID
-  get-credential <did>                       Get credential by DID
-  get-group <did>                            Get group by DID
-  get-name <name>                            Get DID assigned to name
-  get-schema <did>                           Get schema by DID
-  help [command]                             display help for command
-  import-wallet <recovery-phrase>            Create new wallet from a recovery phrase
-  issue-credential <file> [registry] [name]  Sign and encrypt a bound credential file
-  list-assets                                List assets owned by current ID
-  list-credentials                           List credentials by current ID
-  list-groups                                List groups owned by current ID
-  list-ids                                   List IDs and show current ID
-  list-issued                                List issued credentials
-  list-names                                 List DID names (aliases)
-  list-schemas                               List schemas owned by current ID
-  perf-test [N]                              Performance test to create N credentials
-  publish-credential <did>                   Publish the existence of a credential to the current user manifest
-  publish-poll <poll>                        Publish results to poll, hiding ballots
-  recover-id <did>                           Recovers the ID from the DID
-  recover-wallet-did [did]                   Recover wallet from seed bank or encrypted DID
-  remove-group-member <group> <member>       Remove a member from a group
-  remove-id <name>                           Deletes named ID
-  remove-name <name>                         Removes a name for a DID
-  rename-id <oldName> <newName>              Renames the ID
-  resolve-did <did> [confirm]                Return document associated with DID
-  resolve-did-version <did> <version>        Return specified version of document associated with DID
-  resolve-id                                 Resolves the current ID
-  restore-wallet-file <file>                 Restore wallet from backup file
-  reveal-credential <did>                    Reveal a credential to the current user manifest
-  reveal-poll <poll>                         Publish results to poll, revealing ballots
-  revoke-credential <did>                    Revokes a verifiable credential
-  rotate-keys                                Generates new set of keys for current ID
-  set-property <id> <key> [value]            Assign a key-value pair to an asset
-  show-mnemonic                              Show recovery phrase for wallet
-  show-wallet                                Show wallet
-  sign-file <file>                           Sign a JSON file
-  test-group <group> [member]                Determine if a member is in a group
-  transfer-asset <id> <controller>           Transfer asset to a new controller
-  unpublish-credential <did>                 Remove a credential from the current user manifest
-  unpublish-poll <poll>                      Remove results from poll
-  update-asset-document <id> <file>          Update an asset from a document file
-  update-asset-image <id> <file>             Update an asset from an image file
-  update-asset-json <id> <file>              Update an asset from a JSON file
-  update-poll <ballot>                       Add a ballot to the poll
-  use-id <name>                              Set the current ID
-  verify-file <file>                         Verify the signature in a JSON file
-  verify-response <response>                 Decrypt and validate a response to a challenge
-  view-poll <poll>                           View poll details
-  vote-poll <poll> <vote> [spoil]            Vote in a poll
+  accept-credential [options] <did>       Save verifiable credential for current ID
+  add-group-member <group> <member>       Add a member to a group
+  add-name <name> <did>                   Add a name for a DID
+  backup-id                               Backup the current ID to its registry
+  backup-wallet-did                       Backup wallet to encrypted DID and seed bank
+  backup-wallet-file <file>               Backup wallet to file
+  bind-credential <schema> <subject>      Create bound credential for a user
+  check-wallet                            Validate DIDs in wallet
+  clone-asset [options] <id>              Clone an asset
+  create-asset [options]                  Create an empty asset
+  create-asset-document [options] <file>  Create an asset from a document file
+  create-asset-image [options] <file>     Create an asset from an image file
+  create-asset-json [options] <file>      Create an asset from a JSON file
+  create-challenge [options] [file]       Create a challenge (optionally from a file)
+  create-challenge-cc [options] <did>     Create a challenge from a credential DID
+  create-group [options] <name>           Create a new group
+  create-id [options] <name>              Create a new decentralized ID
+  create-poll [options] <file>            Create a poll
+  create-poll-template                    Create a poll template
+  create-response <challenge>             Create a response to a challenge
+  create-schema [options] <file>          Create a schema from a file
+  create-schema-template <schema>         Create a template from a schema
+  create-wallet                           Create a new wallet (or show existing wallet)
+  decrypt-did <did>                       Decrypt an encrypted message DID
+  decrypt-json <did>                      Decrypt an encrypted JSON DID
+  encrypt-file <file> <did>               Encrypt a file for a DID
+  encrypt-message <message> <did>         Encrypt a message for a DID
+  encrypt-wallet                          Encrypt wallet
+  fix-wallet                              Remove invalid DIDs from the wallet
+  get-asset <id>                          Get asset by name or DID
+  get-credential <did>                    Get credential by DID
+  get-group <did>                         Get group by DID
+  get-name <name>                         Get DID assigned to name
+  get-schema <did>                        Get schema by DID
+  help [command]                          display help for command
+  import-wallet <recovery-phrase>         Create new wallet from a recovery phrase
+  issue-credential [options] <file>       Sign and encrypt a bound credential file
+  list-assets                             List assets owned by current ID
+  list-credentials                        List credentials by current ID
+  list-groups                             List groups owned by current ID
+  list-ids                                List IDs and show current ID
+  list-issued                             List issued credentials
+  list-names                              List DID names (aliases)
+  list-schemas                            List schemas owned by current ID
+  perf-test [N]                           Performance test to create N credentials
+  publish-credential <did>                Publish the existence of a credential to the current user manifest
+  publish-poll <poll>                     Publish results to poll, hiding ballots
+  recover-id <did>                        Recovers the ID from the DID
+  recover-wallet-did [did]                Recover wallet from seed bank or encrypted DID
+  remove-group-member <group> <member>    Remove a member from a group
+  remove-id <name>                        Deletes named ID
+  remove-name <name>                      Removes a name for a DID
+  rename-id <oldName> <newName>           Renames the ID
+  resolve-did <did> [confirm]             Return document associated with DID
+  resolve-did-version <did> <version>     Return specified version of document associated with DID
+  resolve-id                              Resolves the current ID
+  restore-wallet-file <file>              Restore wallet from backup file
+  reveal-credential <did>                 Reveal a credential to the current user manifest
+  reveal-poll <poll>                      Publish results to poll, revealing ballots
+  revoke-credential <did>                 Revokes a verifiable credential
+  rotate-keys                             Generates new set of keys for current ID
+  set-property <id> <key> [value]         Assign a key-value pair to an asset
+  show-mnemonic                           Show recovery phrase for wallet
+  show-wallet                             Show wallet
+  sign-file <file>                        Sign a JSON file
+  test-group <group> [member]             Determine if a member is in a group
+  transfer-asset <id> <controller>        Transfer asset to a new controller
+  unpublish-credential <did>              Remove a credential from the current user manifest
+  unpublish-poll <poll>                   Remove results from poll
+  update-asset-document <id> <file>       Update an asset from a document file
+  update-asset-image <id> <file>          Update an asset from an image file
+  update-asset-json <id> <file>           Update an asset from a JSON file
+  update-poll <ballot>                    Add a ballot to the poll
+  use-id <name>                           Set the current ID
+  verify-file <file>                      Verify the signature in a JSON file
+  verify-response <response>              Decrypt and validate a response to a challenge
+  view-poll <poll>                        View poll details
+  vote-poll <poll> <vote> [spoil]         Vote in a poll
 ```
 
 ## admin-cli

--- a/doc/keychain/clients/cli/README.md
+++ b/doc/keychain/clients/cli/README.md
@@ -84,84 +84,84 @@ Options:
   -h, --help                                 display help for command
 
 Commands:
-  accept-credential [options] <did>          Save verifiable credential for current ID
-  add-group-member <group> <member>          Add a member to a group
-  add-name <name> <did>                      Add a name for a DID
-  backup-id                                  Backup the current ID to its registry
-  backup-wallet-did                          Backup wallet to encrypted DID and seed bank
-  backup-wallet-file <file>                  Backup wallet to file
-  bind-credential <schema> <subject>         Create bound credential for a user
-  check-wallet                               Validate DIDs in wallet
-  clone-asset [options] <id>                 Clone an asset
-  create-asset [options]                     Create an empty asset
-  create-asset-document [options] <file>     Create an asset from a document file
-  create-asset-image [options] <file>        Create an asset from an image file
-  create-asset-json [options] <file>         Create an asset from a JSON file
-  create-challenge [options] [file]          Create a challenge (optionally from a file)
-  create-challenge-cc [options] <did>        Create a challenge from a credential DID
-  create-group [options] <name>              Create a new group
-  create-id <name> [registry]                Create a new decentralized ID
-  create-poll [options] <file>               Create a poll
-  create-poll-template                       Create a poll template
-  create-response <challenge>                Create a response to a challenge
-  create-schema [options] <file>             Create a schema from a file
-  create-schema-template <schema>            Create a template from a schema
-  create-wallet                              Create a new wallet (or show existing wallet)
-  decrypt-did <did>                          Decrypt an encrypted message DID
-  decrypt-json <did>                         Decrypt an encrypted JSON DID
-  encrypt-file <file> <did>                  Encrypt a file for a DID
-  encrypt-message <message> <did>            Encrypt a message for a DID
-  encrypt-wallet                             Encrypt wallet
-  fix-wallet                                 Remove invalid DIDs from the wallet
-  get-asset <id>                             Get asset by name or DID
-  get-credential <did>                       Get credential by DID
-  get-group <did>                            Get group by DID
-  get-name <name>                            Get DID assigned to name
-  get-schema <did>                           Get schema by DID
-  help [command]                             display help for command
-  import-wallet <recovery-phrase>            Create new wallet from a recovery phrase
-  issue-credential <file> [registry] [name]  Sign and encrypt a bound credential file
-  list-assets                                List assets owned by current ID
-  list-credentials                           List credentials by current ID
-  list-groups                                List groups owned by current ID
-  list-ids                                   List IDs and show current ID
-  list-issued                                List issued credentials
-  list-names                                 List DID names (aliases)
-  list-schemas                               List schemas owned by current ID
-  perf-test [N]                              Performance test to create N credentials
-  publish-credential <did>                   Publish the existence of a credential to the current user manifest
-  publish-poll <poll>                        Publish results to poll, hiding ballots
-  recover-id <did>                           Recovers the ID from the DID
-  recover-wallet-did [did]                   Recover wallet from seed bank or encrypted DID
-  remove-group-member <group> <member>       Remove a member from a group
-  remove-id <name>                           Deletes named ID
-  remove-name <name>                         Removes a name for a DID
-  rename-id <oldName> <newName>              Renames the ID
-  resolve-did <did> [confirm]                Return document associated with DID
-  resolve-did-version <did> <version>        Return specified version of document associated with DID
-  resolve-id                                 Resolves the current ID
-  restore-wallet-file <file>                 Restore wallet from backup file
-  reveal-credential <did>                    Reveal a credential to the current user manifest
-  reveal-poll <poll>                         Publish results to poll, revealing ballots
-  revoke-credential <did>                    Revokes a verifiable credential
-  rotate-keys                                Generates new set of keys for current ID
-  set-property <id> <key> [value]            Assign a key-value pair to an asset
-  show-mnemonic                              Show recovery phrase for wallet
-  show-wallet                                Show wallet
-  sign-file <file>                           Sign a JSON file
-  test-group <group> [member]                Determine if a member is in a group
-  transfer-asset <id> <controller>           Transfer asset to a new controller
-  unpublish-credential <did>                 Remove a credential from the current user manifest
-  unpublish-poll <poll>                      Remove results from poll
-  update-asset-document <id> <file>          Update an asset from a document file
-  update-asset-image <id> <file>             Update an asset from an image file
-  update-asset-json <id> <file>              Update an asset from a JSON file
-  update-poll <ballot>                       Add a ballot to the poll
-  use-id <name>                              Set the current ID
-  verify-file <file>                         Verify the signature in a JSON file
-  verify-response <response>                 Decrypt and validate a response to a challenge
-  view-poll <poll>                           View poll details
-  vote-poll <poll> <vote> [spoil]            Vote in a poll
+  accept-credential [options] <did>       Save verifiable credential for current ID
+  add-group-member <group> <member>       Add a member to a group
+  add-name <name> <did>                   Add a name for a DID
+  backup-id                               Backup the current ID to its registry
+  backup-wallet-did                       Backup wallet to encrypted DID and seed bank
+  backup-wallet-file <file>               Backup wallet to file
+  bind-credential <schema> <subject>      Create bound credential for a user
+  check-wallet                            Validate DIDs in wallet
+  clone-asset [options] <id>              Clone an asset
+  create-asset [options]                  Create an empty asset
+  create-asset-document [options] <file>  Create an asset from a document file
+  create-asset-image [options] <file>     Create an asset from an image file
+  create-asset-json [options] <file>      Create an asset from a JSON file
+  create-challenge [options] [file]       Create a challenge (optionally from a file)
+  create-challenge-cc [options] <did>     Create a challenge from a credential DID
+  create-group [options] <name>           Create a new group
+  create-id [options] <name>              Create a new decentralized ID
+  create-poll [options] <file>            Create a poll
+  create-poll-template                    Create a poll template
+  create-response <challenge>             Create a response to a challenge
+  create-schema [options] <file>          Create a schema from a file
+  create-schema-template <schema>         Create a template from a schema
+  create-wallet                           Create a new wallet (or show existing wallet)
+  decrypt-did <did>                       Decrypt an encrypted message DID
+  decrypt-json <did>                      Decrypt an encrypted JSON DID
+  encrypt-file <file> <did>               Encrypt a file for a DID
+  encrypt-message <message> <did>         Encrypt a message for a DID
+  encrypt-wallet                          Encrypt wallet
+  fix-wallet                              Remove invalid DIDs from the wallet
+  get-asset <id>                          Get asset by name or DID
+  get-credential <did>                    Get credential by DID
+  get-group <did>                         Get group by DID
+  get-name <name>                         Get DID assigned to name
+  get-schema <did>                        Get schema by DID
+  help [command]                          display help for command
+  import-wallet <recovery-phrase>         Create new wallet from a recovery phrase
+  issue-credential [options] <file>       Sign and encrypt a bound credential file
+  list-assets                             List assets owned by current ID
+  list-credentials                        List credentials by current ID
+  list-groups                             List groups owned by current ID
+  list-ids                                List IDs and show current ID
+  list-issued                             List issued credentials
+  list-names                              List DID names (aliases)
+  list-schemas                            List schemas owned by current ID
+  perf-test [N]                           Performance test to create N credentials
+  publish-credential <did>                Publish the existence of a credential to the current user manifest
+  publish-poll <poll>                     Publish results to poll, hiding ballots
+  recover-id <did>                        Recovers the ID from the DID
+  recover-wallet-did [did]                Recover wallet from seed bank or encrypted DID
+  remove-group-member <group> <member>    Remove a member from a group
+  remove-id <name>                        Deletes named ID
+  remove-name <name>                      Removes a name for a DID
+  rename-id <oldName> <newName>           Renames the ID
+  resolve-did <did> [confirm]             Return document associated with DID
+  resolve-did-version <did> <version>     Return specified version of document associated with DID
+  resolve-id                              Resolves the current ID
+  restore-wallet-file <file>              Restore wallet from backup file
+  reveal-credential <did>                 Reveal a credential to the current user manifest
+  reveal-poll <poll>                      Publish results to poll, revealing ballots
+  revoke-credential <did>                 Revokes a verifiable credential
+  rotate-keys                             Generates new set of keys for current ID
+  set-property <id> <key> [value]         Assign a key-value pair to an asset
+  show-mnemonic                           Show recovery phrase for wallet
+  show-wallet                             Show wallet
+  sign-file <file>                        Sign a JSON file
+  test-group <group> [member]             Determine if a member is in a group
+  transfer-asset <id> <controller>        Transfer asset to a new controller
+  unpublish-credential <did>              Remove a credential from the current user manifest
+  unpublish-poll <poll>                   Remove results from poll
+  update-asset-document <id> <file>       Update an asset from a document file
+  update-asset-image <id> <file>          Update an asset from an image file
+  update-asset-json <id> <file>           Update an asset from a JSON file
+  update-poll <ballot>                    Add a ballot to the poll
+  use-id <name>                           Set the current ID
+  verify-file <file>                      Verify the signature in a JSON file
+  verify-response <response>              Decrypt and validate a response to a challenge
+  view-poll <poll>                        View poll details
+  vote-poll <poll> <vote> [spoil]         Vote in a poll
 ```
 
 </details>

--- a/scripts/keychain-cli.js
+++ b/scripts/keychain-cli.js
@@ -159,6 +159,7 @@ program
 program
     .command('create-id <name>')
     .description('Create a new decentralized ID')
+    // eslint-disable-next-line
     .option('-r, --registry <registry>', 'registry to use')
     .action(async (name, options) => {
         try {
@@ -659,7 +660,6 @@ program
     .command('create-group <name>')
     .description('Create a new group')
     .requiredOption('-n, --name <name>', 'group name')
-    // eslint-disable-next-line
     .option('-r, --registry <registry>', 'registry to use')
     .action(async (options) => {
         try {

--- a/scripts/keychain-cli.js
+++ b/scripts/keychain-cli.js
@@ -157,10 +157,12 @@ program
     });
 
 program
-    .command('create-id <name> [registry]')
+    .command('create-id <name>')
     .description('Create a new decentralized ID')
-    .action(async (name, registry) => {
+    .option('-r, --registry <registry>', 'registry to use')
+    .action(async (name, options) => {
         try {
+            const { registry } = options;
             const did = await keymaster.createId(name, { registry });
             console.log(did);
         }
@@ -437,10 +439,13 @@ program
     });
 
 program
-    .command('issue-credential <file> [registry] [name]')
+    .command('issue-credential <file>')
     .description('Sign and encrypt a bound credential file')
-    .action(async (file, registry, name) => {
+    .option('-n, --name <name>', 'DID name')
+    .option('-r, --registry <registry>', 'registry to use')
+    .action(async (file, options) => {
         try {
+            const { name, registry } = options;
             const vc = JSON.parse(fs.readFileSync(file).toString());
             const did = await keymaster.issueCredential(vc, { registry, name });
             console.log(did);


### PR DESCRIPTION
This PR updates the CLI commands to replace optional positional parameters with explicit options for registry and DID name handling.

-    Modified the "create-id" command to remove the positional [registry] parameter and add the "--registry" option.
-    Revised the "issue-credential" command to remove the positional [registry] and [name] parameters and instead add "--registry" and "--name" options.
