### PR TITLE
fix: Distinguish group name and DID name in createGroup

### DIFF
--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -1976,14 +1976,14 @@ export default class Keymaster implements KeymasterInterface {
 
     async createGroup(
         name: string,
-        options: { registry?: string; members?: string[] } = {}
+        options = {}
     ): Promise<string> {
         const group = {
             name: name,
-            members: options.members || []
+            members: []
         };
 
-        return this.createAsset({ group }, { ...options, name });
+        return this.createAsset({ group }, options);
     }
 
     async getGroup(id: string): Promise<Group | null> {

--- a/scripts/keychain-cli.js
+++ b/scripts/keychain-cli.js
@@ -657,14 +657,14 @@ program
     });
 
 program
-    .command('create-group <name>')
+    .command('create-group <groupName>')
     .description('Create a new group')
-    .requiredOption('-n, --name <name>', 'group name')
+    .option('-n, --name <name>', 'DID name')
     .option('-r, --registry <registry>', 'registry to use')
-    .action(async (options) => {
+    .action(async (groupName, options) => {
         try {
             const { name, registry } = options;
-            const did = await keymaster.createGroup(name, { registry });
+            const did = await keymaster.createGroup(groupName, { name, registry });
             console.log(did);
         }
         catch (error) {

--- a/tests/keymaster.test.ts
+++ b/tests/keymaster.test.ts
@@ -3465,21 +3465,18 @@ describe('createGroup', () => {
         expect(doc.didDocumentData).toStrictEqual(expectedGroup);
     });
 
-    it('should create a new group with members', async () => {
+    it('should create a new named group with with the same DID name', async () => {
         mockFs({});
 
-        const ownerDid = await keymaster.createId('Bob');
+        await keymaster.createId('Bob');
         const groupName = 'mockGroup';
-        const groupDid = await keymaster.createGroup(groupName, { members: [ownerDid] });
-        const doc = await keymaster.resolveDID(groupDid);
-
-        expect(doc.didDocument!.id).toBe(groupDid);
-        expect(doc.didDocument!.controller).toBe(ownerDid);
+        await keymaster.createGroup(groupName, { name: groupName });
+        const doc = await keymaster.resolveDID(groupName);
 
         const expectedGroup = {
             group: {
                 name: groupName,
-                members: [ownerDid],
+                members: [],
             }
         };
 

--- a/tests/keymaster.test.ts
+++ b/tests/keymaster.test.ts
@@ -3465,13 +3465,14 @@ describe('createGroup', () => {
         expect(doc.didDocumentData).toStrictEqual(expectedGroup);
     });
 
-    it('should create a new named group with with the same DID name', async () => {
+    it('should create a new named group with a different DID name', async () => {
         mockFs({});
 
         await keymaster.createId('Bob');
         const groupName = 'mockGroup';
-        await keymaster.createGroup(groupName, { name: groupName });
-        const doc = await keymaster.resolveDID(groupName);
+        const didName = 'mockName';
+        await keymaster.createGroup(groupName, { name: didName });
+        const doc = await keymaster.resolveDID(didName);
 
         const expectedGroup = {
             group: {


### PR DESCRIPTION
This PR fixes the behavior of createGroup so that the group name and the DID name are clearly distinguished across tests, CLI, and the keymaster module.

-    Updated test cases to reflect the new behavior, avoiding member assignment and resolving by group name
-    Modified CLI command and keymaster.ts createGroup to align with the new naming distinction
