### PR TITLE
ci: fix pipeline for cli-tests

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -28,29 +28,41 @@ jobs:
           ln -s "$GITHUB_WORKSPACE/kc" /usr/local/bin/kc
           ln -s "$GITHUB_WORKSPACE/admin" /usr/local/bin/admin
           echo "/usr/local/bin" >> $GITHUB_PATH
-          sleep 30
       
 
-      - name: Install Docker Compose
+      - name: Run Node
         run: |
-            sudo curl -L "https://github.com/docker/compose/releases/download/v2.3.3/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-            sudo chmod +x /usr/local/bin/docker-compose
-            docker-compose --version
-        continue-on-error: false
-
-      - name: Run Docker-compose
-        run: |
-          docker compose build cli keymaster gatekeeper
-          docker compose up cli keymaster gatekeeper -d --no-build
-          docker ps
+          ./start-node-ci cli
+          docker compose ps
           sleep 30
-      
+
+
       - name: Run cli-tests
         working-directory: ./tests
+        env:
+          KC_GATEKEEPER_URL: http://localhost:4224
+          KC_KEYMASTER_URL: http://localhost:4226
         run: |
-          ./run_cli_tests.sh --ci
+          ./run_cli_tests.sh --ci-redis
+        
+
+      - name: Grab logs
+        if: always()
+        run: |
+          docker compose logs --no-color keymaster cli gatekeeper redis > docker-compose-logs.txt
+          cat docker-compose-logs.txt
       
+
       - name: Teardown Docker
         run: |
-          docker-compose down
+          ./stop-node
+      
+          
+      - name: Upload docker logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-compose-logs
+          path: docker-compose-logs.txt
+
 

--- a/start-node-ci
+++ b/start-node-ci
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -e
+source .env
+
+echo $KC_GATEKEEPER_URL
+
+docker compose down
+docker compose build "$@"
+docker compose up -d "$@"
+
+echo "Waiting for all services to be 'Up'..."
+
+MAX_RETRIES=30
+RETRY_INTERVAL=5
+RETRY_COUNT=0
+
+while true; do
+  # Count total services defined
+  TOTAL_SERVICES="6"
+  
+  # Count lines with 'Up' in status
+  UP_COUNT=$(docker compose ps | grep 'Up' | wc -l)
+
+  if [[ "$UP_COUNT" -eq "$TOTAL_SERVICES" ]]; then
+    echo "✅ All containers are 'Up'"
+    break
+  fi
+
+  if [[ "$RETRY_COUNT" -ge "$MAX_RETRIES" ]]; then
+    echo "❌ Timed out waiting for containers to be 'Up'"
+    docker compose ps
+    exit 1
+  fi
+
+  echo "⏳ Waiting... ($RETRY_COUNT/$MAX_RETRIES)"
+  sleep "$RETRY_INTERVAL"
+  ((RETRY_COUNT++))
+done

--- a/tests/cli-tests/generate_test_env.sh
+++ b/tests/cli-tests/generate_test_env.sh
@@ -5,6 +5,8 @@ set -e
 # Change to the project root, assuming the script is in ./scripts/
 cd "$(git rev-parse --show-toplevel)"
 
+touch .env
+
 ENV_FILE=".env"
 
 echo "Generating .env file at project root..."
@@ -30,7 +32,7 @@ KC_GATEKEEPER_STATUS_INTERVAL=1
 
 # Keymaster
 KC_KEYMASTER_PORT=4226
-KC_KEYMASTER_DB=json
+KC_KEYMASTER_DB=redis
 KC_ENCRYPTED_PASSPHRASE=
 KC_WALLET_CACHE=false
 KC_DEFAULT_REGISTRY=local

--- a/tests/cli-tests/hyperswarm/test_cli_import_wallet.expect
+++ b/tests/cli-tests/hyperswarm/test_cli_import_wallet.expect
@@ -17,6 +17,13 @@ expect {
     }
 }
 
+# Wait for the process to finish and check exit code
+expect eof
+if {[lindex [wait] 3] != 0} {
+    puts "❌ Command failed with non-zero exit code."
+    exit 1
+}
+
 # Validation procedure
 proc validate_wallet_output {output} {
     # Initialize validation tracking
@@ -76,6 +83,11 @@ set validated_keys {}
     }
 }
 
+    if {[validate_wallet_output $output] == 0} {
+        puts "❌ Wallet validation failed. Exiting..."
+        exit 1
+    }
+
 # Clean up
 spawn bash admin reset-db
 expect {
@@ -89,7 +101,7 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
+    if {$key == "--ci-json"} {
         # Run docker exec to delete the file
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
@@ -116,6 +128,12 @@ foreach {key val} $argv {
             puts "File not found: $abs_filepath"
         }
         
+    } elseif {$key == "--ci-redis"} {
+        # Run docker exec to delete the file
+        set result [exec docker compose exec redis redis-cli flushall]
+
+        # Print result
+        puts "Resetted Redis!"
     }
 }
 

--- a/tests/cli-tests/test_cli_add_name.expect
+++ b/tests/cli-tests/test_cli_add_name.expect
@@ -105,14 +105,14 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
+    if {$key == "--ci-json"} {
         # Run docker exec to delete the file
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
         # Print result
         puts "Deleted wallet.json!"
         
-    } elseif {$key == "--no-ci} {
+    } elseif {$key == "--local"} {
         # Delete Wallet
         set script_dir [file dirname [file normalize [info script]]]
 
@@ -132,6 +132,12 @@ foreach {key val} $argv {
             puts "File not found: $abs_filepath"
         }
         
+    } elseif {$key == "--ci-redis"} {
+        # Run docker exec to delete the file
+        set result [exec docker compose exec redis redis-cli flushall]
+
+        # Print result
+        puts "Resetted Redis!"
     }
 }
 

--- a/tests/cli-tests/test_cli_backup_id.expect
+++ b/tests/cli-tests/test_cli_backup_id.expect
@@ -59,7 +59,7 @@ expect {
 
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
+    if {$key == "--ci-json"} {
         # Run docker exec to delete the file
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
@@ -86,6 +86,12 @@ foreach {key val} $argv {
             puts "File not found: $abs_filepath"
         }
         
+    } elseif {$key == "--ci-redis"} {
+        # Run docker exec to delete the file
+        set result [exec docker compose exec redis redis-cli flushall]
+
+        # Print result
+        puts "Resetted Redis!"
     }
 }
 

--- a/tests/cli-tests/test_cli_check_list_ids.expect
+++ b/tests/cli-tests/test_cli_check_list_ids.expect
@@ -66,7 +66,7 @@ expect {
 
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
+    if {$key == "--ci-json"} {
         # Run docker exec to delete the file
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
@@ -93,6 +93,12 @@ foreach {key val} $argv {
             puts "File not found: $abs_filepath"
         }
         
+    } elseif {$key == "--ci-redis"} {
+        # Run docker exec to delete the file
+        set result [exec docker compose exec redis redis-cli flushall]
+
+        # Print result
+        puts "Resetted Redis!"
     }
 }
 

--- a/tests/cli-tests/test_cli_check_wallet.expect
+++ b/tests/cli-tests/test_cli_check_wallet.expect
@@ -65,7 +65,7 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
+    if {$key == "--ci-json"} {
         # Run docker exec to delete the file
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
@@ -92,6 +92,12 @@ foreach {key val} $argv {
             puts "File not found: $abs_filepath"
         }
         
+    } elseif {$key == "--ci-redis"} {
+        # Run docker exec to delete the file
+        set result [exec docker compose exec redis redis-cli flushall]
+
+        # Print result
+        puts "Resetted Redis!"
     }
 }
 

--- a/tests/cli-tests/test_cli_create_id.expect
+++ b/tests/cli-tests/test_cli_create_id.expect
@@ -33,7 +33,7 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
+    if {$key == "--ci-json"} {
         # Run docker exec to delete the file
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
@@ -60,6 +60,12 @@ foreach {key val} $argv {
             puts "File not found: $abs_filepath"
         }
         
+    } elseif {$key == "--ci-redis"} {
+        # Run docker exec to delete the file
+        set result [exec docker compose exec redis redis-cli flushall]
+
+        # Print result
+        puts "Resetted Redis!"
     }
 }
 

--- a/tests/cli-tests/test_cli_create_schema.expect
+++ b/tests/cli-tests/test_cli_create_schema.expect
@@ -69,7 +69,7 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
+    if {$key == "--ci-json"} {
         # Run docker exec to delete the file
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
@@ -96,6 +96,12 @@ foreach {key val} $argv {
             puts "File not found: $abs_filepath"
         }
         
+    } elseif {$key == "--ci-redis"} {
+        # Run docker exec to delete the file
+        set result [exec docker compose exec redis redis-cli flushall]
+
+        # Print result
+        puts "Resetted Redis!"
     }
 }
 

--- a/tests/cli-tests/test_cli_create_schema_template.expect
+++ b/tests/cli-tests/test_cli_create_schema_template.expect
@@ -137,7 +137,7 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
+    if {$key == "--ci-json"} {
         # Run docker exec to delete the file
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
@@ -164,6 +164,12 @@ foreach {key val} $argv {
             puts "File not found: $abs_filepath"
         }
         
+    } elseif {$key == "--ci-redis"} {
+        # Run docker exec to delete the file
+        set result [exec docker compose exec redis redis-cli flushall]
+
+        # Print result
+        puts "Resetted Redis!"
     }
 }
 

--- a/tests/cli-tests/test_cli_create_wallet.expect
+++ b/tests/cli-tests/test_cli_create_wallet.expect
@@ -94,7 +94,7 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
+    if {$key == "--ci-json"} {
         # Run docker exec to delete the file
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
@@ -121,6 +121,12 @@ foreach {key val} $argv {
             puts "File not found: $abs_filepath"
         }
         
+    } elseif {$key == "--ci-redis"} {
+        # Run docker exec to delete the file
+        set result [exec docker compose exec redis redis-cli flushall]
+
+        # Print result
+        puts "Resetted Redis!"
     }
 }
 

--- a/tests/cli-tests/test_cli_encrypt_file.expect
+++ b/tests/cli-tests/test_cli_encrypt_file.expect
@@ -70,7 +70,7 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
+    if {$key == "--ci-json"} {
         # Run docker exec to delete the file
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
@@ -97,6 +97,12 @@ foreach {key val} $argv {
             puts "File not found: $abs_filepath"
         }
         
+    } elseif {$key == "--ci-redis"} {
+        # Run docker exec to delete the file
+        set result [exec docker compose exec redis redis-cli flushall]
+
+        # Print result
+        puts "Resetted Redis!"
     }
 }
 

--- a/tests/cli-tests/test_cli_get_credential_by_id.expect
+++ b/tests/cli-tests/test_cli_get_credential_by_id.expect
@@ -176,7 +176,7 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
+    if {$key == "--ci-json"} {
         # Run docker exec to delete the file
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
@@ -203,6 +203,12 @@ foreach {key val} $argv {
             puts "File not found: $abs_filepath"
         }
         
+    } elseif {$key == "--ci-redis"} {
+        # Run docker exec to delete the file
+        set result [exec docker compose exec redis redis-cli flushall]
+
+        # Print result
+        puts "Resetted Redis!"
     }
 }
 

--- a/tests/cli-tests/test_cli_get_schema.expect
+++ b/tests/cli-tests/test_cli_get_schema.expect
@@ -130,7 +130,7 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
+    if {$key == "--ci-json"} {
         # Run docker exec to delete the file
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
@@ -157,6 +157,12 @@ foreach {key val} $argv {
             puts "File not found: $abs_filepath"
         }
         
+    } elseif {$key == "--ci-redis"} {
+        # Run docker exec to delete the file
+        set result [exec docker compose exec redis redis-cli flushall]
+
+        # Print result
+        puts "Resetted Redis!"
     }
 }
 

--- a/tests/cli-tests/test_cli_issue_credential.expect
+++ b/tests/cli-tests/test_cli_issue_credential.expect
@@ -106,68 +106,63 @@ expect {
     }
 }
 foreach {key val} $argv {
-    if {$key == "--ci"} {
-        # Run docker exec to delete the file
+    if {$key == "--ci-json"} {
+        # Delete docker files
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
-
-        # Print result
         puts "Deleted wallet.json!"
-        
-        # Run docker exec to delete the file
-        set result [exec docker exec kc-cli-1 rm -rf /app/share/qa-credential-final.json]
 
-        # Print result
-        puts "Deleted qa-credential-final.json!"
-        
-        # Delete credential file
+        # Delete credential file from local script path
         set script_dir [file dirname [file normalize [info script]]]
-
-        # File paths to delete
         set qa_cred_path [file join $script_dir qa-credential.json]
-
-        # List of files to process
         set files_to_delete [list $qa_cred_path]
-        
-        # Process each file
-        foreach filepath $files_to_delete {
-            # Normalize the path to get an absolute reference
-            set abs_filepath [file normalize $filepath]
 
-            # Check if the file exists
+        foreach filepath $files_to_delete {
+            set abs_filepath [file normalize $filepath]
             if {[file exists $abs_filepath]} {
                 puts "File exists: $abs_filepath"
-                # Delete the file
                 file delete -force $abs_filepath
                 puts "File deleted: $abs_filepath"
             } else {
                 puts "File not found: $abs_filepath"
             }
         }
-        
+
     } elseif {$key == "--local"} {
         # Delete Schema on docker
         spawn bash -c "docker compose exec cli rm -rf /app/share/qa-credential-final.json"
 
         # Delete Wallet and Credential Files
         set script_dir [file dirname [file normalize [info script]]]
-
-        # File paths to delete
         set wallet_path [file join $script_dir ../../data/wallet.json]
         set qa_cred_path [file join $script_dir ../qa-credential.json]
         set qa_cred_final_path [file join $script_dir ../qa-credential-final.json]
-
-        # List of files to process
         set files_to_delete [list $wallet_path $qa_cred_path $qa_cred_final_path]
 
-        # Process each file
         foreach filepath $files_to_delete {
-            # Normalize the path to get an absolute reference
             set abs_filepath [file normalize $filepath]
-
-            # Check if the file exists
             if {[file exists $abs_filepath]} {
                 puts "File exists: $abs_filepath"
-                # Delete the file
+                file delete -force $abs_filepath
+                puts "File deleted: $abs_filepath"
+            } else {
+                puts "File not found: $abs_filepath"
+            }
+        }
+
+    } elseif {$key == "--ci-redis"} {
+        # Flush Redis data
+        set result [exec docker compose exec redis redis-cli flushall]
+        puts "Resetted Redis!"
+
+        # Delete credential file
+        set script_dir [file dirname [file normalize [info script]]]
+        set qa_cred_path [file join $script_dir qa-credential.json]
+        set files_to_delete [list $qa_cred_path]
+
+        foreach filepath $files_to_delete {
+            set abs_filepath [file normalize $filepath]
+            if {[file exists $abs_filepath]} {
+                puts "File exists: $abs_filepath"
                 file delete -force $abs_filepath
                 puts "File deleted: $abs_filepath"
             } else {

--- a/tests/cli-tests/test_cli_list_credentials.expect
+++ b/tests/cli-tests/test_cli_list_credentials.expect
@@ -120,68 +120,63 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
-        # Run docker exec to delete the file
+if {$key == "--ci-json"} {
+        # Delete docker files
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
-
-        # Print result
         puts "Deleted wallet.json!"
-        
-        # Run docker exec to delete the file
-        set result [exec docker exec kc-cli-1 rm -rf /app/share/qa-credential-final.json]
 
-        # Print result
-        puts "Deleted qa-credential-final.json!"
-        
-        # Delete credential file
+        # Delete credential file from local script path
         set script_dir [file dirname [file normalize [info script]]]
-
-        # File paths to delete
         set qa_cred_path [file join $script_dir qa-credential.json]
-
-        # List of files to process
         set files_to_delete [list $qa_cred_path]
-        
-        # Process each file
-        foreach filepath $files_to_delete {
-            # Normalize the path to get an absolute reference
-            set abs_filepath [file normalize $filepath]
 
-            # Check if the file exists
+        foreach filepath $files_to_delete {
+            set abs_filepath [file normalize $filepath]
             if {[file exists $abs_filepath]} {
                 puts "File exists: $abs_filepath"
-                # Delete the file
                 file delete -force $abs_filepath
                 puts "File deleted: $abs_filepath"
             } else {
                 puts "File not found: $abs_filepath"
             }
         }
-        
+
     } elseif {$key == "--local"} {
         # Delete Schema on docker
         spawn bash -c "docker compose exec cli rm -rf /app/share/qa-credential-final.json"
 
         # Delete Wallet and Credential Files
         set script_dir [file dirname [file normalize [info script]]]
-
-        # File paths to delete
         set wallet_path [file join $script_dir ../../data/wallet.json]
         set qa_cred_path [file join $script_dir ../qa-credential.json]
         set qa_cred_final_path [file join $script_dir ../qa-credential-final.json]
-
-        # List of files to process
         set files_to_delete [list $wallet_path $qa_cred_path $qa_cred_final_path]
 
-        # Process each file
         foreach filepath $files_to_delete {
-            # Normalize the path to get an absolute reference
             set abs_filepath [file normalize $filepath]
-
-            # Check if the file exists
             if {[file exists $abs_filepath]} {
                 puts "File exists: $abs_filepath"
-                # Delete the file
+                file delete -force $abs_filepath
+                puts "File deleted: $abs_filepath"
+            } else {
+                puts "File not found: $abs_filepath"
+            }
+        }
+
+    } elseif {$key == "--ci-redis"} {
+        # Flush Redis data
+        set result [exec docker compose exec redis redis-cli flushall]
+        puts "Resetted Redis!"
+
+        # Delete credential file
+        set script_dir [file dirname [file normalize [info script]]]
+        set qa_cred_path [file join $script_dir qa-credential.json]
+        set files_to_delete [list $qa_cred_path]
+
+        foreach filepath $files_to_delete {
+            set abs_filepath [file normalize $filepath]
+            if {[file exists $abs_filepath]} {
+                puts "File exists: $abs_filepath"
                 file delete -force $abs_filepath
                 puts "File deleted: $abs_filepath"
             } else {
@@ -190,6 +185,7 @@ foreach {key val} $argv {
         }
     }
 }
+
 
 spawn bash kc create-wallet
 expect {

--- a/tests/cli-tests/test_cli_list_dids.expect
+++ b/tests/cli-tests/test_cli_list_dids.expect
@@ -52,7 +52,7 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
+    if {$key == "--ci-json"} {
         # Run docker exec to delete the file
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
@@ -79,6 +79,12 @@ foreach {key val} $argv {
             puts "File not found: $abs_filepath"
         }
         
+    } elseif {$key == "--ci-redis"} {
+        # Run docker exec to delete the file
+        set result [exec docker compose exec redis redis-cli flushall]
+
+        # Print result
+        puts "Resetted Redis!"
     }
 }
 

--- a/tests/cli-tests/test_cli_list_issue_credentials.expect
+++ b/tests/cli-tests/test_cli_list_issue_credentials.expect
@@ -122,68 +122,63 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
-        # Run docker exec to delete the file
+if {$key == "--ci-json"} {
+        # Delete docker files
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
-
-        # Print result
         puts "Deleted wallet.json!"
-        
-        # Run docker exec to delete the file
-        set result [exec docker exec kc-cli-1 rm -rf /app/share/qa-credential-final.json]
 
-        # Print result
-        puts "Deleted qa-credential-final.json!"
-        
-        # Delete credential file
+        # Delete credential file from local script path
         set script_dir [file dirname [file normalize [info script]]]
-
-        # File paths to delete
         set qa_cred_path [file join $script_dir qa-credential.json]
-
-        # List of files to process
         set files_to_delete [list $qa_cred_path]
-        
-        # Process each file
-        foreach filepath $files_to_delete {
-            # Normalize the path to get an absolute reference
-            set abs_filepath [file normalize $filepath]
 
-            # Check if the file exists
+        foreach filepath $files_to_delete {
+            set abs_filepath [file normalize $filepath]
             if {[file exists $abs_filepath]} {
                 puts "File exists: $abs_filepath"
-                # Delete the file
                 file delete -force $abs_filepath
                 puts "File deleted: $abs_filepath"
             } else {
                 puts "File not found: $abs_filepath"
             }
         }
-        
+
     } elseif {$key == "--local"} {
         # Delete Schema on docker
         spawn bash -c "docker compose exec cli rm -rf /app/share/qa-credential-final.json"
 
         # Delete Wallet and Credential Files
         set script_dir [file dirname [file normalize [info script]]]
-
-        # File paths to delete
         set wallet_path [file join $script_dir ../../data/wallet.json]
         set qa_cred_path [file join $script_dir ../qa-credential.json]
         set qa_cred_final_path [file join $script_dir ../qa-credential-final.json]
-
-        # List of files to process
         set files_to_delete [list $wallet_path $qa_cred_path $qa_cred_final_path]
 
-        # Process each file
         foreach filepath $files_to_delete {
-            # Normalize the path to get an absolute reference
             set abs_filepath [file normalize $filepath]
-
-            # Check if the file exists
             if {[file exists $abs_filepath]} {
                 puts "File exists: $abs_filepath"
-                # Delete the file
+                file delete -force $abs_filepath
+                puts "File deleted: $abs_filepath"
+            } else {
+                puts "File not found: $abs_filepath"
+            }
+        }
+
+    } elseif {$key == "--ci-redis"} {
+        # Flush Redis data
+        set result [exec docker compose exec redis redis-cli flushall]
+        puts "Resetted Redis!"
+
+        # Delete credential file
+        set script_dir [file dirname [file normalize [info script]]]
+        set qa_cred_path [file join $script_dir qa-credential.json]
+        set files_to_delete [list $qa_cred_path]
+
+        foreach filepath $files_to_delete {
+            set abs_filepath [file normalize $filepath]
+            if {[file exists $abs_filepath]} {
+                puts "File exists: $abs_filepath"
                 file delete -force $abs_filepath
                 puts "File deleted: $abs_filepath"
             } else {

--- a/tests/cli-tests/test_cli_list_names.expect
+++ b/tests/cli-tests/test_cli_list_names.expect
@@ -64,7 +64,7 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
+    if {$key == "--ci-json"} {
         # Run docker exec to delete the file
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
@@ -91,6 +91,12 @@ foreach {key val} $argv {
             puts "File not found: $abs_filepath"
         }
         
+    } elseif {$key == "--ci-redis"} {
+        # Run docker exec to delete the file
+        set result [exec docker compose exec redis redis-cli flushall]
+
+        # Print result
+        puts "Resetted Redis!"
     }
 }
 

--- a/tests/cli-tests/test_cli_list_schema.expect
+++ b/tests/cli-tests/test_cli_list_schema.expect
@@ -77,7 +77,7 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
+    if {$key == "--ci-json"} {
         # Run docker exec to delete the file
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
@@ -104,6 +104,12 @@ foreach {key val} $argv {
             puts "File not found: $abs_filepath"
         }
         
+    } elseif {$key == "--ci-redis"} {
+        # Run docker exec to delete the file
+        set result [exec docker compose exec redis redis-cli flushall]
+
+        # Print result
+        puts "Resetted Redis!"
     }
 }
 

--- a/tests/cli-tests/test_cli_remove_id.expect
+++ b/tests/cli-tests/test_cli_remove_id.expect
@@ -43,7 +43,7 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
+    if {$key == "--ci-json"} {
         # Run docker exec to delete the file
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
@@ -70,6 +70,12 @@ foreach {key val} $argv {
             puts "File not found: $abs_filepath"
         }
         
+    } elseif {$key == "--ci-redis"} {
+        # Run docker exec to delete the file
+        set result [exec docker compose exec redis redis-cli flushall]
+
+        # Print result
+        puts "Resetted Redis!"
     }
 }
 

--- a/tests/cli-tests/test_cli_remove_name.expect
+++ b/tests/cli-tests/test_cli_remove_name.expect
@@ -80,7 +80,7 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
+    if {$key == "--ci-json"} {
         # Run docker exec to delete the file
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
@@ -107,6 +107,12 @@ foreach {key val} $argv {
             puts "File not found: $abs_filepath"
         }
         
+    } elseif {$key == "--ci-redis"} {
+        # Run docker exec to delete the file
+        set result [exec docker compose exec redis redis-cli flushall]
+
+        # Print result
+        puts "Resetted Redis!"
     }
 }
 

--- a/tests/cli-tests/test_cli_resolve_id.expect
+++ b/tests/cli-tests/test_cli_resolve_id.expect
@@ -116,7 +116,7 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
+    if {$key == "--ci-json"} {
         # Run docker exec to delete the file
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
@@ -143,6 +143,12 @@ foreach {key val} $argv {
             puts "File not found: $abs_filepath"
         }
         
+    } elseif {$key == "--ci-redis"} {
+        # Run docker exec to delete the file
+        set result [exec docker compose exec redis redis-cli flushall]
+
+        # Print result
+        puts "Resetted Redis!"
     }
 }
 

--- a/tests/cli-tests/test_cli_reveal_credentials.expect
+++ b/tests/cli-tests/test_cli_reveal_credentials.expect
@@ -161,68 +161,63 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
-        # Run docker exec to delete the file
+if {$key == "--ci-json"} {
+        # Delete docker files
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
-
-        # Print result
         puts "Deleted wallet.json!"
-        
-        # Run docker exec to delete the file
-        set result [exec docker exec kc-cli-1 rm -rf /app/share/qa-credential-final.json]
 
-        # Print result
-        puts "Deleted qa-credential-final.json!"
-        
-        # Delete credential file
+        # Delete credential file from local script path
         set script_dir [file dirname [file normalize [info script]]]
-
-        # File paths to delete
         set qa_cred_path [file join $script_dir qa-credential.json]
-
-        # List of files to process
         set files_to_delete [list $qa_cred_path]
-        
-        # Process each file
-        foreach filepath $files_to_delete {
-            # Normalize the path to get an absolute reference
-            set abs_filepath [file normalize $filepath]
 
-            # Check if the file exists
+        foreach filepath $files_to_delete {
+            set abs_filepath [file normalize $filepath]
             if {[file exists $abs_filepath]} {
                 puts "File exists: $abs_filepath"
-                # Delete the file
                 file delete -force $abs_filepath
                 puts "File deleted: $abs_filepath"
             } else {
                 puts "File not found: $abs_filepath"
             }
         }
-        
+
     } elseif {$key == "--local"} {
         # Delete Schema on docker
         spawn bash -c "docker compose exec cli rm -rf /app/share/qa-credential-final.json"
 
         # Delete Wallet and Credential Files
         set script_dir [file dirname [file normalize [info script]]]
-
-        # File paths to delete
         set wallet_path [file join $script_dir ../../data/wallet.json]
         set qa_cred_path [file join $script_dir ../qa-credential.json]
         set qa_cred_final_path [file join $script_dir ../qa-credential-final.json]
-
-        # List of files to process
         set files_to_delete [list $wallet_path $qa_cred_path $qa_cred_final_path]
 
-        # Process each file
         foreach filepath $files_to_delete {
-            # Normalize the path to get an absolute reference
             set abs_filepath [file normalize $filepath]
-
-            # Check if the file exists
             if {[file exists $abs_filepath]} {
                 puts "File exists: $abs_filepath"
-                # Delete the file
+                file delete -force $abs_filepath
+                puts "File deleted: $abs_filepath"
+            } else {
+                puts "File not found: $abs_filepath"
+            }
+        }
+
+    } elseif {$key == "--ci-redis"} {
+        # Flush Redis data
+        set result [exec docker compose exec redis redis-cli flushall]
+        puts "Resetted Redis!"
+
+        # Delete credential file
+        set script_dir [file dirname [file normalize [info script]]]
+        set qa_cred_path [file join $script_dir qa-credential.json]
+        set files_to_delete [list $qa_cred_path]
+
+        foreach filepath $files_to_delete {
+            set abs_filepath [file normalize $filepath]
+            if {[file exists $abs_filepath]} {
+                puts "File exists: $abs_filepath"
                 file delete -force $abs_filepath
                 puts "File deleted: $abs_filepath"
             } else {

--- a/tests/cli-tests/test_cli_revoke_credentials.expect
+++ b/tests/cli-tests/test_cli_revoke_credentials.expect
@@ -122,68 +122,63 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
-        # Run docker exec to delete the file
+if {$key == "--ci-json"} {
+        # Delete docker files
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
-
-        # Print result
         puts "Deleted wallet.json!"
-        
-        # Run docker exec to delete the file
-        set result [exec docker exec kc-cli-1 rm -rf /app/share/qa-credential-final.json]
 
-        # Print result
-        puts "Deleted qa-credential-final.json!"
-        
-        # Delete credential file
+        # Delete credential file from local script path
         set script_dir [file dirname [file normalize [info script]]]
-
-        # File paths to delete
         set qa_cred_path [file join $script_dir qa-credential.json]
-
-        # List of files to process
         set files_to_delete [list $qa_cred_path]
-        
-        # Process each file
-        foreach filepath $files_to_delete {
-            # Normalize the path to get an absolute reference
-            set abs_filepath [file normalize $filepath]
 
-            # Check if the file exists
+        foreach filepath $files_to_delete {
+            set abs_filepath [file normalize $filepath]
             if {[file exists $abs_filepath]} {
                 puts "File exists: $abs_filepath"
-                # Delete the file
                 file delete -force $abs_filepath
                 puts "File deleted: $abs_filepath"
             } else {
                 puts "File not found: $abs_filepath"
             }
         }
-        
+
     } elseif {$key == "--local"} {
         # Delete Schema on docker
         spawn bash -c "docker compose exec cli rm -rf /app/share/qa-credential-final.json"
 
         # Delete Wallet and Credential Files
         set script_dir [file dirname [file normalize [info script]]]
-
-        # File paths to delete
         set wallet_path [file join $script_dir ../../data/wallet.json]
         set qa_cred_path [file join $script_dir ../qa-credential.json]
         set qa_cred_final_path [file join $script_dir ../qa-credential-final.json]
-
-        # List of files to process
         set files_to_delete [list $wallet_path $qa_cred_path $qa_cred_final_path]
 
-        # Process each file
         foreach filepath $files_to_delete {
-            # Normalize the path to get an absolute reference
             set abs_filepath [file normalize $filepath]
-
-            # Check if the file exists
             if {[file exists $abs_filepath]} {
                 puts "File exists: $abs_filepath"
-                # Delete the file
+                file delete -force $abs_filepath
+                puts "File deleted: $abs_filepath"
+            } else {
+                puts "File not found: $abs_filepath"
+            }
+        }
+
+    } elseif {$key == "--ci-redis"} {
+        # Flush Redis data
+        set result [exec docker compose exec redis redis-cli flushall]
+        puts "Resetted Redis!"
+
+        # Delete credential file
+        set script_dir [file dirname [file normalize [info script]]]
+        set qa_cred_path [file join $script_dir qa-credential.json]
+        set files_to_delete [list $qa_cred_path]
+
+        foreach filepath $files_to_delete {
+            set abs_filepath [file normalize $filepath]
+            if {[file exists $abs_filepath]} {
+                puts "File exists: $abs_filepath"
                 file delete -force $abs_filepath
                 puts "File deleted: $abs_filepath"
             } else {

--- a/tests/cli-tests/test_cli_rotate_keys.expect
+++ b/tests/cli-tests/test_cli_rotate_keys.expect
@@ -148,7 +148,7 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
+    if {$key == "--ci-json"} {
         # Run docker exec to delete the file
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
@@ -175,6 +175,12 @@ foreach {key val} $argv {
             puts "File not found: $abs_filepath"
         }
         
+    } elseif {$key == "--ci-redis"} {
+        # Run docker exec to delete the file
+        set result [exec docker compose exec redis redis-cli flushall]
+
+        # Print result
+        puts "Resetted Redis!"
     }
 }
 

--- a/tests/cli-tests/test_cli_show_mnemonic.expect
+++ b/tests/cli-tests/test_cli_show_mnemonic.expect
@@ -46,7 +46,7 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
+    if {$key == "--ci-json"} {
         # Run docker exec to delete the file
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
@@ -73,6 +73,12 @@ foreach {key val} $argv {
             puts "File not found: $abs_filepath"
         }
         
+    } elseif {$key == "--ci-redis"} {
+        # Run docker exec to delete the file
+        set result [exec docker compose exec redis redis-cli flushall]
+
+        # Print result
+        puts "Resetted Redis!"
     }
 }
 

--- a/tests/cli-tests/test_cli_show_wallet.expect
+++ b/tests/cli-tests/test_cli_show_wallet.expect
@@ -102,7 +102,7 @@ expect {
 }
 
 foreach {key val} $argv {
-    if {$key == "--ci"} {
+    if {$key == "--ci-json"} {
         # Run docker exec to delete the file
         set result [exec docker exec kc-gatekeeper-1 rm -rf /app/gatekeeper/data/wallet.json]
 
@@ -129,6 +129,12 @@ foreach {key val} $argv {
             puts "File not found: $abs_filepath"
         }
         
+    } elseif {$key == "--ci-redis"} {
+        # Run docker exec to delete the file
+        set result [exec docker compose exec redis redis-cli flushall]
+
+        # Print result
+        puts "Resetted Redis!"
     }
 }
 

--- a/tests/cli-tests/test_cli_validate_help.expect
+++ b/tests/cli-tests/test_cli_validate_help.expect
@@ -31,88 +31,88 @@ set reference {Usage: keychain-cli [options] [command]
 Keychain CLI tool
 
 Options:
-  -V, --version                              output the version number
-  -h, --help                                 display help for command
+  -V, --version                           output the version number
+  -h, --help                              display help for command
 
 Commands:
-  accept-credential [options] <did>          Save verifiable credential for current ID
-  add-group-member <group> <member>          Add a member to a group
-  add-name <name> <did>                      Add a name for a DID
-  backup-id                                  Backup the current ID to its registry
-  backup-wallet-did                          Backup wallet to encrypted DID and seed bank
-  backup-wallet-file <file>                  Backup wallet to file
-  bind-credential <schema> <subject>         Create bound credential for a user
-  check-wallet                               Validate DIDs in wallet
-  clone-asset [options] <id>                 Clone an asset
-  create-asset [options]                     Create an empty asset
-  create-asset-document [options] <file>     Create an asset from a document file
-  create-asset-image [options] <file>        Create an asset from an image file
-  create-asset-json [options] <file>         Create an asset from a JSON file
-  create-challenge [options] [file]          Create a challenge (optionally from a file)
-  create-challenge-cc [options] <did>        Create a challenge from a credential DID
-  create-group [options] <name>              Create a new group
-  create-id <name> [registry]                Create a new decentralized ID
-  create-poll [options] <file>               Create a poll
-  create-poll-template                       Create a poll template
-  create-response <challenge>                Create a response to a challenge
-  create-schema [options] <file>             Create a schema from a file
-  create-schema-template <schema>            Create a template from a schema
-  create-wallet                              Create a new wallet (or show existing wallet)
-  decrypt-did <did>                          Decrypt an encrypted message DID
-  decrypt-json <did>                         Decrypt an encrypted JSON DID
-  encrypt-file <file> <did>                  Encrypt a file for a DID
-  encrypt-message <message> <did>            Encrypt a message for a DID
-  encrypt-wallet                             Encrypt wallet
-  fix-wallet                                 Remove invalid DIDs from the wallet
-  get-asset <id>                             Get asset by name or DID
-  get-credential <did>                       Get credential by DID
-  get-group <did>                            Get group by DID
-  get-name <name>                            Get DID assigned to name
-  get-schema <did>                           Get schema by DID
-  help [command]                             display help for command
-  import-wallet <recovery-phrase>            Create new wallet from a recovery phrase
-  issue-credential <file> [registry] [name]  Sign and encrypt a bound credential file
-  list-assets                                List assets owned by current ID
-  list-credentials                           List credentials by current ID
-  list-groups                                List groups owned by current ID
-  list-ids                                   List IDs and show current ID
-  list-issued                                List issued credentials
-  list-names                                 List DID names (aliases)
-  list-schemas                               List schemas owned by current ID
-  perf-test [N]                              Performance test to create N credentials
-  publish-credential <did>                   Publish the existence of a credential to the current user manifest
-  publish-poll <poll>                        Publish results to poll, hiding ballots
-  recover-id <did>                           Recovers the ID from the DID
-  recover-wallet-did [did]                   Recover wallet from seed bank or encrypted DID
-  remove-group-member <group> <member>       Remove a member from a group
-  remove-id <name>                           Deletes named ID
-  remove-name <name>                         Removes a name for a DID
-  rename-id <oldName> <newName>              Renames the ID
-  resolve-did <did> [confirm]                Return document associated with DID
-  resolve-did-version <did> <version>        Return specified version of document associated with DID
-  resolve-id                                 Resolves the current ID
-  restore-wallet-file <file>                 Restore wallet from backup file
-  reveal-credential <did>                    Reveal a credential to the current user manifest
-  reveal-poll <poll>                         Publish results to poll, revealing ballots
-  revoke-credential <did>                    Revokes a verifiable credential
-  rotate-keys                                Generates new set of keys for current ID
-  set-property <id> <key> [value]            Assign a key-value pair to an asset
-  show-mnemonic                              Show recovery phrase for wallet
-  show-wallet                                Show wallet
-  sign-file <file>                           Sign a JSON file
-  test-group <group> [member]                Determine if a member is in a group
-  transfer-asset <id> <controller>           Transfer asset to a new controller
-  unpublish-credential <did>                 Remove a credential from the current user manifest
-  unpublish-poll <poll>                      Remove results from poll
-  update-asset-document <id> <file>          Update an asset from a document file
-  update-asset-image <id> <file>             Update an asset from an image file
-  update-asset-json <id> <file>              Update an asset from a JSON file
-  update-poll <ballot>                       Add a ballot to the poll
-  use-id <name>                              Set the current ID
-  verify-file <file>                         Verify the signature in a JSON file
-  verify-response <response>                 Decrypt and validate a response to a challenge
-  view-poll <poll>                           View poll details
-  vote-poll <poll> <vote> [spoil]            Vote in a poll}
+  accept-credential [options] <did>       Save verifiable credential for current ID
+  add-group-member <group> <member>       Add a member to a group
+  add-name <name> <did>                   Add a name for a DID
+  backup-id                               Backup the current ID to its registry
+  backup-wallet-did                       Backup wallet to encrypted DID and seed bank
+  backup-wallet-file <file>               Backup wallet to file
+  bind-credential <schema> <subject>      Create bound credential for a user
+  check-wallet                            Validate DIDs in wallet
+  clone-asset [options] <id>              Clone an asset
+  create-asset [options]                  Create an empty asset
+  create-asset-document [options] <file>  Create an asset from a document file
+  create-asset-image [options] <file>     Create an asset from an image file
+  create-asset-json [options] <file>      Create an asset from a JSON file
+  create-challenge [options] [file]       Create a challenge (optionally from a file)
+  create-challenge-cc [options] <did>     Create a challenge from a credential DID
+  create-group [options] <groupName>      Create a new group
+  create-id [options] <name>              Create a new decentralized ID
+  create-poll [options] <file>            Create a poll
+  create-poll-template                    Create a poll template
+  create-response <challenge>             Create a response to a challenge
+  create-schema [options] <file>          Create a schema from a file
+  create-schema-template <schema>         Create a template from a schema
+  create-wallet                           Create a new wallet (or show existing wallet)
+  decrypt-did <did>                       Decrypt an encrypted message DID
+  decrypt-json <did>                      Decrypt an encrypted JSON DID
+  encrypt-file <file> <did>               Encrypt a file for a DID
+  encrypt-message <message> <did>         Encrypt a message for a DID
+  encrypt-wallet                          Encrypt wallet
+  fix-wallet                              Remove invalid DIDs from the wallet
+  get-asset <id>                          Get asset by name or DID
+  get-credential <did>                    Get credential by DID
+  get-group <did>                         Get group by DID
+  get-name <name>                         Get DID assigned to name
+  get-schema <did>                        Get schema by DID
+  help [command]                          display help for command
+  import-wallet <recovery-phrase>         Create new wallet from a recovery phrase
+  issue-credential [options] <file>       Sign and encrypt a bound credential file
+  list-assets                             List assets owned by current ID
+  list-credentials                        List credentials by current ID
+  list-groups                             List groups owned by current ID
+  list-ids                                List IDs and show current ID
+  list-issued                             List issued credentials
+  list-names                              List DID names (aliases)
+  list-schemas                            List schemas owned by current ID
+  perf-test [N]                           Performance test to create N credentials
+  publish-credential <did>                Publish the existence of a credential to the current user manifest
+  publish-poll <poll>                     Publish results to poll, hiding ballots
+  recover-id <did>                        Recovers the ID from the DID
+  recover-wallet-did [did]                Recover wallet from seed bank or encrypted DID
+  remove-group-member <group> <member>    Remove a member from a group
+  remove-id <name>                        Deletes named ID
+  remove-name <name>                      Removes a name for a DID
+  rename-id <oldName> <newName>           Renames the ID
+  resolve-did <did> [confirm]             Return document associated with DID
+  resolve-did-version <did> <version>     Return specified version of document associated with DID
+  resolve-id                              Resolves the current ID
+  restore-wallet-file <file>              Restore wallet from backup file
+  reveal-credential <did>                 Reveal a credential to the current user manifest
+  reveal-poll <poll>                      Publish results to poll, revealing ballots
+  revoke-credential <did>                 Revokes a verifiable credential
+  rotate-keys                             Generates new set of keys for current ID
+  set-property <id> <key> [value]         Assign a key-value pair to an asset
+  show-mnemonic                           Show recovery phrase for wallet
+  show-wallet                             Show wallet
+  sign-file <file>                        Sign a JSON file
+  test-group <group> [member]             Determine if a member is in a group
+  transfer-asset <id> <controller>        Transfer asset to a new controller
+  unpublish-credential <did>              Remove a credential from the current user manifest
+  unpublish-poll <poll>                   Remove results from poll
+  update-asset-document <id> <file>       Update an asset from a document file
+  update-asset-image <id> <file>          Update an asset from an image file
+  update-asset-json <id> <file>           Update an asset from a JSON file
+  update-poll <ballot>                    Add a ballot to the poll
+  use-id <name>                           Set the current ID
+  verify-file <file>                      Verify the signature in a JSON file
+  verify-response <response>              Decrypt and validate a response to a challenge
+  view-poll <poll>                        View poll details
+  vote-poll <poll> <vote> [spoil]         Vote in a poll}
 
 # Clean up the output (remove spawn line, ANSI codes, and normalize whitespace)
 # First remove the spawn line

--- a/tests/run_cli_tests.sh
+++ b/tests/run_cli_tests.sh
@@ -1,47 +1,45 @@
-#!/bin/bash
-# Capture the first argument (e.g., --ci or --no-ci)
+#!/usr/bin/env bash
+set -e
+
+# Capture the first argument (e.g., --ci-json or --local)
 CI_MODE="$1"
 PASS=()
 FAIL=()
-# Use regular arrays instead of associative arrays
 FAIL_SCRIPTS=()
 FAIL_OUTPUTS=()
-# Add arrays for timing
 TEST_NAMES=()
 TEST_TIMES=()
+
 SCRIPT_DIR="./cli-tests"
 shopt -s nullglob
 scripts=("$SCRIPT_DIR"/*.expect)
+
 if [ ${#scripts[@]} -eq 0 ]; then
   echo "No .expect scripts found in $SCRIPT_DIR"
   exit 1
 fi
+
 echo "Running expect scripts from $SCRIPT_DIR..."
 echo
 
 for f in "${scripts[@]}"; do
   echo "----------------------------------------"
   echo "Running $f..."
-  
-  # Start timer
+
   START_TIME=$(date +%s)
-  
-  # Run the expect script directly with -f flag and show output in real-time
+
   /usr/bin/expect -f "$f" -- "$CI_MODE" 2>&1 | tee /tmp/expect_output.$$
   EXIT_CODE=${PIPESTATUS[0]}
-  
-  # End timer and calculate duration
+
   END_TIME=$(date +%s)
   DURATION=$((END_TIME - START_TIME))
-  
-  # Store test name and time
+
   TEST_NAMES+=("$f")
   TEST_TIMES+=("$DURATION")
-  
-  # Store output in a temporary file
+
   OUTPUT=$(cat /tmp/expect_output.$$)
   rm -f /tmp/expect_output.$$
-  
+
   if [ "$EXIT_CODE" -eq 0 ]; then
     echo "[PASS] $f (${DURATION}s)"
     PASS+=("$f")
@@ -57,7 +55,6 @@ echo
 echo "==================== Summary ===================="
 echo "✅ Passed: ${#PASS[@]}"
 for f in "${PASS[@]}"; do
-  # Find the index of this test in the TEST_NAMES array
   for i in "${!TEST_NAMES[@]}"; do
     if [ "${TEST_NAMES[$i]}" = "$f" ]; then
       echo "  ✔️  $f (${TEST_TIMES[$i]}s)"
@@ -69,7 +66,6 @@ done
 echo
 echo "❌ Failed: ${#FAIL[@]}"
 for f in "${FAIL[@]}"; do
-  # Find the index of this test in the TEST_NAMES array
   for i in "${!TEST_NAMES[@]}"; do
     if [ "${TEST_NAMES[$i]}" = "$f" ]; then
       echo "  ❌ $f (${TEST_TIMES[$i]}s)"
@@ -82,7 +78,6 @@ if [ "${#FAIL[@]}" -gt 0 ]; then
   echo
   echo "============== Failed Script Output ============="
   for i in "${!FAIL_SCRIPTS[@]}"; do
-    # Find the index of this test in the TEST_NAMES array
     for j in "${!TEST_NAMES[@]}"; do
       if [ "${TEST_NAMES[$j]}" = "${FAIL_SCRIPTS[$i]}" ]; then
         echo
@@ -96,17 +91,14 @@ if [ "${#FAIL[@]}" -gt 0 ]; then
   done
 fi
 
-# Add time statistics
 echo
 echo "============== Timing Statistics =============="
-# Sort tests by execution time (if sort is available)
 if command -v sort &> /dev/null; then
   echo "Tests sorted by execution time (slowest first):"
   for i in "${!TEST_NAMES[@]}"; do
     echo "${TEST_TIMES[$i]}s ${TEST_NAMES[$i]}"
   done | sort -nr
-  
-  # Calculate total time
+
   TOTAL_TIME=0
   for t in "${TEST_TIMES[@]}"; do
     TOTAL_TIME=$((TOTAL_TIME + t))
@@ -115,3 +107,10 @@ if command -v sort &> /dev/null; then
   echo "Total execution time: ${TOTAL_TIME}s"
 fi
 echo "================================================="
+
+# Final exit based on failures
+if [ "${#FAIL[@]}" -gt 0 ]; then
+  exit 1
+else
+  exit 0
+fi


### PR DESCRIPTION
Patches the cli-tests to run with Redis and execute in the pipeline. Right now this runs separately, but will create a proposal with @macterra and @Flaxscrip to have it be kicked off as part of PRs and the Release for Testing. 

Average time it takes to execute is about 1 min at the moment. This will increase as more are added but we can look at sharding at that point.