### PR TITLE
feat: Adds timestamps to DID metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Commands:
   export-batch                                                 Export all events in a batch
   export-did <did>                                             Export DID to file
   export-dids                                                  Export all DIDs
+  get-block <registry> [blockHeightOrHash]                     Get block info for registry
   get-dids [updatedAfter] [updatedBefore] [confirm] [resolve]  Fetch all DIDs
   get-status                                                   Report gatekeeper status
   hash-dids <file>                                             Compute hash of batch

--- a/doc/gatekeeper-api.json
+++ b/doc/gatekeeper-api.json
@@ -1945,6 +1945,201 @@
           }
         }
       }
+    },
+    "/block/{registry}/latest": {
+      "get": {
+        "summary": "Retrieve the latest block for a specific registry",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "registry",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The name of the registry to retrieve the latest block from."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the latest block.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "hash": {
+                      "type": "string",
+                      "description": "The hash of the latest block."
+                    },
+                    "height": {
+                      "type": "integer",
+                      "description": "The height of the latest block."
+                    },
+                    "time": {
+                      "type": "integer",
+                      "description": "The timestamp of the latest block in seconds since the Unix epoch."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/block/{registry}/{blockId}": {
+      "get": {
+        "summary": "Retrieve a specific block for a given registry",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "registry",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The name of the registry to retrieve the block from."
+          },
+          {
+            "in": "path",
+            "name": "blockId",
+            "required": true,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "description": "The hash of the block."
+                },
+                {
+                  "type": "integer",
+                  "description": "The height of the block."
+                }
+              ]
+            },
+            "description": "The identifier of the block to retrieve. Can be either a block hash (string) or a block height (integer).\n"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved the block.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "hash": {
+                      "type": "string",
+                      "description": "The hash of the block."
+                    },
+                    "height": {
+                      "type": "integer",
+                      "description": "The height of the block."
+                    },
+                    "time": {
+                      "type": "integer",
+                      "description": "The timestamp of the block in seconds since the Unix epoch."
+                    },
+                    "timeISO": {
+                      "type": "string",
+                      "format": "date-time",
+                      "description": "The timestamp of the block in ISO 8601 format."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/block/{registry}": {
+      "post": {
+        "summary": "Add a new block to a specific registry",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "registry",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The name of the registry to which the block will be added."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "hash",
+                  "height",
+                  "time"
+                ],
+                "properties": {
+                  "hash": {
+                    "type": "string",
+                    "description": "The hash of the block."
+                  },
+                  "height": {
+                    "type": "integer",
+                    "description": "The height of the block."
+                  },
+                  "time": {
+                    "type": "integer",
+                    "description": "The timestamp of the block in seconds since the Unix epoch."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successfully added the block.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean",
+                  "example": true
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {},

--- a/doc/mdip/scheme.md
+++ b/doc/mdip/scheme.md
@@ -54,6 +54,7 @@ To create an agent DID, the MDIP client must sign and submit a "create" operatio
         1. `registry`  (from a list of valid registries, e.g. "BTC", "hyperswarm", etc.)
     1. `publicJwk` is the public key in JWK format
     1. `created` time in ISO format
+    1. `blockid` [optional] current block ID on registry (if registry is a blockchain)
 1. Sign the JSON with the private key corresponding the the public key (this enables the MDIP node to verify that the operation is coming from the owner of the public key)
 1. Submit the operation to the MDIP node. For example, with a REST API, post the operation to the MDIP node's endpoint to create new DIDs (e.g. `/api/v1/did/`)
 
@@ -101,6 +102,7 @@ To create an asset DID, the MDIP client must sign and submit a `create` operatio
     1. `controller` specifies the DID of the owner/controller of the new DID
     1. `data` can contain any data in JSON format, as long as it is not empty
     1. `created` time in ISO format
+    1. `blockid` [optional] current block ID on registry (if registry is a blockchain)
 1. Sign the JSON with the private key of the controller
 1. Submit the operation to the MDIP node. For example, with a REST API, post the operation to the MDIP node's endpoint to create new DIDs (e.g. `/api/v1/did/`)
 
@@ -147,6 +149,7 @@ A DID Update is a change to any of the documents associated with the DID. To ini
         1. `didDocumentData` the document's data
         1. `mdip` the MDIP protocol spec
     1. `previd` the CID of the previous operation
+    1. `blockid` [optional] current block ID on registry (if registry is a blockchain)
 1. Sign the JSON with the private key of the controller of the DID
 1. Submit the operation to the MDIP node. For example, with a REST API, post the operation to the MDIP node's endpoint to update DIDs (e.g. `/api/v1/did/`)
 
@@ -218,6 +221,7 @@ To revoke a DID, the MDIP client must sign and submit a `delete` operation to th
     1. `type`  must be "delete"
     1. `did` specifies the DID to be deleted
     1. `previd` the CID of the previous operation
+    1. `blockid` [optional] current block ID on registry (if registry is a blockchain)
 1. Sign the JSON with the private key of the controller of the DID
 1. Submit the operation to the MDIP node. For example, with a REST API, post the operation using the `DELETE` method to the MDIP node's endpoint to update DIDs (e.g. `/api/v1/did/`)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     image: mongo:latest
     volumes:
       - ./data/mongodb:/data/db
+    ports:
+      - 127.0.0.1:27017:27017
 
   redis:
     image: redis:latest
@@ -18,7 +20,7 @@ services:
     ports:
       - 4001:4001
       - 4001:4001/udp
-      - 5001:5001
+      - 127.0.0.1:5001:5001
     volumes:
       - ./data/ipfs:/data/ipfs
       - ./share:/export/share

--- a/packages/gatekeeper/src/db/sqlite.ts
+++ b/packages/gatekeeper/src/db/sqlite.ts
@@ -202,7 +202,7 @@ export default class DbSqlite implements GatekeeperDb {
         try {
             // Insert or replace the block information
             await this.db.run(
-                `INSERT OR REPLACE INTO blocks (registry, hash, height, time) VALUES (?, ?, ?, ?, ?)`,
+                `INSERT OR REPLACE INTO blocks (registry, hash, height, time) VALUES (?, ?, ?, ?)`,
                 registry,
                 blockInfo.hash,
                 blockInfo.height,

--- a/packages/gatekeeper/src/gatekeeper-client.ts
+++ b/packages/gatekeeper/src/gatekeeper-client.ts
@@ -1,5 +1,7 @@
 import axios, { AxiosError } from 'axios';
 import {
+    BlockId,
+    BlockInfo,
     GatekeeperInterface,
     GatekeeperEvent,
     Operation,
@@ -375,6 +377,28 @@ export default class GatekeeperClient implements GatekeeperInterface {
                 axiosError.response.data = JSON.parse(errorMessage);
             }
             throwError(axiosError);
+        }
+    }
+
+    async getBlock(registry: string, block?: BlockId): Promise<BlockInfo | null> {
+        try {
+            const url = block
+                ? `${this.API}/block/${registry}/${block}`
+                : `${this.API}/block/${registry}/latest`;
+            const response = await axios.get(url);
+            return response.data;
+        } catch (error) {
+            throwError(error);
+        }
+    }
+
+    async addBlock(registry: string, block: BlockInfo): Promise<boolean> {
+        try {
+            const response = await axios.post(`${this.API}/block/${registry}`, block);
+            return response.data;
+        }
+        catch (error) {
+            throwError(error);
         }
     }
 }

--- a/packages/gatekeeper/src/gatekeeper.ts
+++ b/packages/gatekeeper/src/gatekeeper.ts
@@ -683,7 +683,6 @@ export default class Gatekeeper implements GatekeeperInterface {
                             txid: blockchain.txid,
                             txidx: blockchain.index,
                             batchid: blockchain.batch,
-                            opid: versionId,
                             opidx: blockchain.opidx,
                         };
                     }
@@ -691,6 +690,8 @@ export default class Gatekeeper implements GatekeeperInterface {
 
                 if (lowerBound || upperBound) {
                     timestamp = {
+                        chain: doc.mdip.registry,
+                        opid: versionId,
                         lowerBound,
                         upperBound,
                     };
@@ -710,9 +711,6 @@ export default class Gatekeeper implements GatekeeperInterface {
                     confirmed,
                     timestamp,
                 }
-                if (doc.mdip) {
-                    doc.mdip.registration = blockchain || undefined;
-                }
                 continue;
             }
 
@@ -731,15 +729,13 @@ export default class Gatekeeper implements GatekeeperInterface {
                     confirmed,
                     timestamp,
                 }
-                if (doc.mdip) {
-                    doc.mdip.registration = blockchain || undefined;
-                }
             }
         }
 
         if (doc.mdip) {
             // Remove deprecated fields
             delete doc.mdip.opid // Replaced by didDocumentMetadata.versionId
+            delete doc.mdip.registration // Replaced by didDocumentMetadata.timestamp
         }
 
         return copyJSON(doc);

--- a/packages/gatekeeper/src/gatekeeper.ts
+++ b/packages/gatekeeper/src/gatekeeper.ts
@@ -654,10 +654,24 @@ export default class Gatekeeper implements GatekeeperInterface {
 
             let timestamp;
 
-            if (blockchain) {
-                timestamp = {
-                    blockchain,
-                };
+            if (blockchain && doc.mdip?.registry) {
+                const block = await this.db.getBlock(doc.mdip.registry, blockchain.height);
+
+                if (block) {
+                    timestamp = {
+                        lowerBound: {},
+                        upperBound: {
+                            time: block.time,
+                            blockid: block.hash,
+                            height: block.height,
+                            txid: blockchain.txid,
+                            txidx: blockchain.index,
+                            batchid: blockchain.batch,
+                            opidx: blockchain.opidx,
+                            opid: versionId,
+                        },
+                    };
+                }
             }
 
             if (operation.type === 'update') {

--- a/packages/gatekeeper/src/gatekeeper.ts
+++ b/packages/gatekeeper/src/gatekeeper.ts
@@ -605,53 +605,6 @@ export default class Gatekeeper implements GatekeeperInterface {
         for (const { time, operation, registry, blockchain } of events) {
             const versionId = await this.generateCID(operation);
             const updated = time;
-
-            if (operation.type === 'create') {
-                if (verify) {
-                    const valid = await this.verifyCreateOperation(operation);
-
-                    if (!valid) {
-                        throw new InvalidOperationError('signature');
-                    }
-                }
-
-                doc.didDocumentMetadata = {
-                    created,
-                    canonicalId,
-                    versionId,
-                    version,
-                    confirmed
-                }
-                continue;
-            }
-
-            if (atTime && new Date(time) > new Date(atTime)) {
-                break;
-            }
-
-            if (atVersion && version === atVersion) {
-                break;
-            }
-
-            confirmed = confirmed && doc.mdip?.registry === registry;
-
-            if (confirm && !confirmed) {
-                break;
-            }
-
-            if (verify) {
-                const valid = await this.verifyUpdateOperation(operation, doc);
-
-                if (!valid) {
-                    throw new InvalidOperationError('signature');
-                }
-
-                // TEMP during did:test, operation.previd is optional
-                if (operation.previd && operation.previd !== doc.didDocumentMetadata?.versionId) {
-                    throw new InvalidOperationError('previd');
-                }
-            }
-
             let timestamp;
 
             if (doc.mdip?.registry) {
@@ -695,6 +648,53 @@ export default class Gatekeeper implements GatekeeperInterface {
                         lowerBound,
                         upperBound,
                     };
+                }
+            }
+
+            if (operation.type === 'create') {
+                if (verify) {
+                    const valid = await this.verifyCreateOperation(operation);
+
+                    if (!valid) {
+                        throw new InvalidOperationError('signature');
+                    }
+                }
+
+                doc.didDocumentMetadata = {
+                    created,
+                    canonicalId,
+                    versionId,
+                    version,
+                    confirmed,
+                    timestamp,
+                }
+                continue;
+            }
+
+            if (atTime && new Date(time) > new Date(atTime)) {
+                break;
+            }
+
+            if (atVersion && version === atVersion) {
+                break;
+            }
+
+            confirmed = confirmed && doc.mdip?.registry === registry;
+
+            if (confirm && !confirmed) {
+                break;
+            }
+
+            if (verify) {
+                const valid = await this.verifyUpdateOperation(operation, doc);
+
+                if (!valid) {
+                    throw new InvalidOperationError('signature');
+                }
+
+                // TEMP during did:test, operation.previd is optional
+                if (operation.previd && operation.previd !== doc.didDocumentMetadata?.versionId) {
+                    throw new InvalidOperationError('previd');
                 }
             }
 

--- a/packages/gatekeeper/src/gatekeeper.ts
+++ b/packages/gatekeeper/src/gatekeeper.ts
@@ -1172,7 +1172,7 @@ export default class Gatekeeper implements GatekeeperInterface {
         return this.db.clearQueue(registry, events);
     }
 
-    async getBlock(registry: string, block: BlockId): Promise<BlockInfo | null> {
+    async getBlock(registry: string, block?: BlockId): Promise<BlockInfo | null> {
         if (!ValidRegistries.includes(registry)) {
             throw new InvalidParameterError(`registry=${registry}`);
         }

--- a/packages/gatekeeper/src/gatekeeper.ts
+++ b/packages/gatekeeper/src/gatekeeper.ts
@@ -8,6 +8,8 @@ import {
 } from '@mdip/common/errors';
 import { IPFSClient } from '@mdip/ipfs/types';
 import {
+    BlockId,
+    BlockInfo,
     GatekeeperDb,
     GatekeeperInterface,
     GatekeeperEvent,
@@ -650,6 +652,14 @@ export default class Gatekeeper implements GatekeeperInterface {
                 }
             }
 
+            let timestamp;
+
+            if (blockchain) {
+                timestamp = {
+                    blockchain,
+                };
+            }
+
             if (operation.type === 'update') {
                 version += 1;
 
@@ -660,7 +670,8 @@ export default class Gatekeeper implements GatekeeperInterface {
                     canonicalId,
                     versionId,
                     version,
-                    confirmed
+                    confirmed,
+                    timestamp,
                 }
                 if (doc.mdip) {
                     doc.mdip.registration = blockchain || undefined;
@@ -680,7 +691,8 @@ export default class Gatekeeper implements GatekeeperInterface {
                     canonicalId,
                     versionId,
                     version,
-                    confirmed
+                    confirmed,
+                    timestamp,
                 }
                 if (doc.mdip) {
                     doc.mdip.registration = blockchain || undefined;
@@ -1158,6 +1170,22 @@ export default class Gatekeeper implements GatekeeperInterface {
         }
 
         return this.db.clearQueue(registry, events);
+    }
+
+    async getBlock(registry: string, block: BlockId): Promise<BlockInfo | null> {
+        if (!ValidRegistries.includes(registry)) {
+            throw new InvalidParameterError(`registry=${registry}`);
+        }
+
+        return this.db.getBlock(registry, block);
+    }
+
+    async addBlock(registry: string, block: BlockInfo): Promise<boolean> {
+        if (!ValidRegistries.includes(registry)) {
+            throw new InvalidParameterError(`registry=${registry}`);
+        }
+
+        return this.db.addBlock(registry, block)
     }
 
     async addText(text: string): Promise<string> {

--- a/packages/gatekeeper/src/gatekeeper.ts
+++ b/packages/gatekeeper/src/gatekeeper.ts
@@ -654,22 +654,45 @@ export default class Gatekeeper implements GatekeeperInterface {
 
             let timestamp;
 
-            if (blockchain && doc.mdip?.registry) {
-                const block = await this.db.getBlock(doc.mdip.registry, blockchain.height);
+            if (doc.mdip?.registry) {
+                let lowerBound;
+                let upperBound;
 
-                if (block) {
-                    timestamp = {
-                        lowerBound: {},
-                        upperBound: {
-                            time: block.time,
-                            blockid: block.hash,
-                            height: block.height,
+                if (operation.blockid) {
+                    const lowerBlock = await this.db.getBlock(doc.mdip.registry, operation.blockid);
+
+                    if (lowerBlock) {
+                        lowerBound = {
+                            time: lowerBlock.time,
+                            timeISO: new Date(lowerBlock.time * 1000).toISOString(),
+                            blockid: lowerBlock.hash,
+                            height: lowerBlock.height,
+                        };
+                    }
+                }
+
+                if (blockchain) {
+                    const upperBlock = await this.db.getBlock(doc.mdip.registry, blockchain.height);
+
+                    if (upperBlock) {
+                        upperBound = {
+                            time: upperBlock.time,
+                            timeISO: new Date(upperBlock.time * 1000).toISOString(),
+                            blockid: upperBlock.hash,
+                            height: upperBlock.height,
                             txid: blockchain.txid,
                             txidx: blockchain.index,
                             batchid: blockchain.batch,
-                            opidx: blockchain.opidx,
                             opid: versionId,
-                        },
+                            opidx: blockchain.opidx,
+                        };
+                    }
+                }
+
+                if (lowerBound || upperBound) {
+                    timestamp = {
+                        lowerBound,
+                        upperBound,
                     };
                 }
             }

--- a/packages/gatekeeper/src/types.ts
+++ b/packages/gatekeeper/src/types.ts
@@ -109,6 +109,8 @@ export interface GatekeeperInterface {
     getJSON(cid: string): Promise<object | null>;
     addText(text: string): Promise<string>;
     getText(cid: string): Promise<string | null>;
+    getBlock(registry: string, block?: BlockId): Promise<BlockInfo | null>;
+    addBlock(registry: string, block: BlockInfo): Promise<boolean>
 }
 
 export interface MdipRegistration {
@@ -179,6 +181,7 @@ export interface Operation {
     previd?: string;
     did?: string,
     data?: unknown;
+    blockid?: string;
 }
 
 export type BlockId = number | string;

--- a/packages/gatekeeper/src/types.ts
+++ b/packages/gatekeeper/src/types.ts
@@ -3,6 +3,8 @@ import { EcdsaJwkPublic } from '@mdip/cipher/types';
 export interface JsonDbFile {
     dids: Record<string, GatekeeperEvent[]>
     queue?: Record<string, Operation[]>
+    blocks?: Record<string, any>
+    hashes?: Record<string, any>
 }
 
 export interface ImportBatchResult {
@@ -80,6 +82,8 @@ export interface GatekeeperDb {
     queueOperation(registry: string, op: Operation): Promise<number>;
     getQueue(registry: string): Promise<Operation[]>;
     clearQueue(registry: string, batch: Operation[]): Promise<boolean>;
+    addBlock(registry: string, blockInfo: BlockInfo): Promise<boolean>;
+    getBlock(registry: string, blockId: BlockId): Promise<BlockInfo | null>;
 }
 
 export interface GatekeeperInterface {
@@ -112,6 +116,7 @@ export interface MdipRegistration {
     index?: number;
     txid?: string;
     batch?: string;
+    opidx?: number;
 }
 
 export interface Mdip {
@@ -134,6 +139,7 @@ export interface DocumentMetadata {
     confirmed?: boolean;
     deactivated?: boolean;
     deleted?: string;
+    timestamp?: any;
 }
 
 export interface MdipDocument {
@@ -173,4 +179,12 @@ export interface Operation {
     previd?: string;
     did?: string,
     data?: unknown;
+}
+
+export type BlockId = number | string;
+
+export interface BlockInfo {
+    height: number;
+    hash: string;
+    time: number;
 }

--- a/packages/gatekeeper/src/types.ts
+++ b/packages/gatekeeper/src/types.ts
@@ -83,7 +83,7 @@ export interface GatekeeperDb {
     getQueue(registry: string): Promise<Operation[]>;
     clearQueue(registry: string, batch: Operation[]): Promise<boolean>;
     addBlock(registry: string, blockInfo: BlockInfo): Promise<boolean>;
-    getBlock(registry: string, blockId: BlockId): Promise<BlockInfo | null>;
+    getBlock(registry: string, blockId?: BlockId): Promise<BlockInfo | null>;
 }
 
 export interface GatekeeperInterface {

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -990,11 +990,14 @@ export default class Keymaster implements KeymasterInterface {
         }
 
         const previd = current.didDocumentMetadata?.versionId;
+        const block = await this.gatekeeper.getBlock(current.mdip!.registry);
+        const blockid = block?.hash;
 
         const operation: Operation = {
             type: "update",
             did,
             previd,
+            blockid,
             doc,
         };
 

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -630,10 +630,13 @@ export default class Keymaster implements KeymasterInterface {
         }
 
         const id = await this.fetchIdInfo(controller);
+        const block = await this.gatekeeper.getBlock(registry);
+        const blockid = block?.hash;
 
         const operation: Operation = {
             type: "create",
             created: new Date().toISOString(),
+            blockid,
             mdip: {
                 version: 1,
                 type: "asset",
@@ -1009,11 +1012,14 @@ export default class Keymaster implements KeymasterInterface {
     async revokeDID(did: string): Promise<boolean> {
         const current = await this.resolveDID(did);
         const previd = current.didDocumentMetadata?.versionId;
+        const block = await this.gatekeeper.getBlock(current.mdip!.registry);
+        const blockid = block?.hash;
 
         const operation: Operation = {
             type: "delete",
             did,
             previd,
+            blockid
         };
 
         const controller = current.didDocument?.controller || current.didDocument?.id;
@@ -1249,10 +1255,13 @@ export default class Keymaster implements KeymasterInterface {
         const path = `m/44'/0'/${account}'/0/${index}`;
         const didkey = hdkey.derive(path);
         const keypair = this.cipher.generateJwk(didkey.privateKey!);
+        const block = await this.gatekeeper.getBlock(registry);
+        const blockid = block?.hash;
 
         const operation: Operation = {
             type: "create",
             created: new Date().toISOString(),
+            blockid,
             mdip: {
                 version: 1,
                 type: "agent",

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -973,18 +973,14 @@ export default class Keymaster implements KeymasterInterface {
         }
 
         const current = await this.resolveDID(did);
+        const previd = current.didDocumentMetadata?.versionId;
 
         // Compare the hashes of the current and updated documents without the metadata
-        const currentHash = this.cipher.hashJSON({
-            didDocument: current.didDocument,
-            didDocumentData: current.didDocumentData,
-            mdip: current.mdip,
-        });
-        const updateHash = this.cipher.hashJSON({
-            didDocument: doc.didDocument,
-            didDocumentData: doc.didDocumentData,
-            mdip: doc.mdip,
-        });
+        current.didDocumentMetadata = {};
+        doc.didDocumentMetadata = {};
+
+        const currentHash = this.cipher.hashJSON(current);
+        const updateHash = this.cipher.hashJSON(doc);
 
         // If no change, return immediately without updating
         // Maybe add a force update option later if needed?
@@ -992,7 +988,6 @@ export default class Keymaster implements KeymasterInterface {
             return true;
         }
 
-        const previd = current.didDocumentMetadata?.versionId;
         const block = await this.gatekeeper.getBlock(current.mdip!.registry);
         const blockid = block?.hash;
 

--- a/scripts/admin-cli.js
+++ b/scripts/admin-cli.js
@@ -449,6 +449,18 @@ program
         }
     });
 
+program
+    .command('get-block <registry> [blockHeightOrHash]')
+    .description('Get block info for registry')
+    .action(async (registry, blockHeightOrHash) => {
+        try {
+            const block = await gatekeeper.getBlock(registry, blockHeightOrHash);
+            console.log(JSON.stringify(block, null, 2));
+        } catch (error) {
+            console.error(error);
+        }
+    });
+
 async function run() {
     gatekeeper.connect({ url: gatekeeperURL });
     program.parse(process.argv);

--- a/services/gatekeeper/server/src/gatekeeper-api.ts
+++ b/services/gatekeeper/server/src/gatekeeper-api.ts
@@ -1713,6 +1713,38 @@ v1router.get('/cas/data/:cid', async (req, res) => {
     }
 });
 
+v1router.get('/block/:registry/latest', async (req, res) => {
+    try {
+        const { registry } = req.params;
+        const block = await gatekeeper.getBlock(registry);
+        res.json(block);
+    } catch (error: any) {
+        res.status(500).send(error.toString());
+    }
+});
+
+v1router.get('/block/:registry/:blockId', async (req, res) => {
+    try {
+        const { registry, blockId } = req.params;
+        const parsedBlockId = /^\d+$/.test(blockId) ? parseInt(blockId, 10) : blockId;
+        const block = await gatekeeper.getBlock(registry, parsedBlockId);
+        res.json(block);
+    } catch (error: any) {
+        res.status(500).send(error.toString());
+    }
+});
+
+v1router.post('/block/:registry', async (req, res) => {
+    try {
+        const { registry } = req.params;
+        const block = req.body;
+        const ok = await gatekeeper.addBlock(registry, block);
+        res.json(ok);
+    } catch (error: any) {
+        res.status(500).send(error.toString());
+    }
+});
+
 app.use('/api/v1', v1router);
 
 app.use((req, res) => {

--- a/services/gatekeeper/server/src/gatekeeper-api.ts
+++ b/services/gatekeeper/server/src/gatekeeper-api.ts
@@ -1713,6 +1713,42 @@ v1router.get('/cas/data/:cid', async (req, res) => {
     }
 });
 
+/**
+ * @swagger
+ * /block/{registry}/latest:
+ *   get:
+ *     summary: Retrieve the latest block for a specific registry
+ *     parameters:
+ *       - in: path
+ *         name: registry
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The name of the registry to retrieve the latest block from.
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved the latest block.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 hash:
+ *                   type: string
+ *                   description: The hash of the latest block.
+ *                 height:
+ *                   type: integer
+ *                   description: The height of the latest block.
+ *                 time:
+ *                   type: integer
+ *                   description: The timestamp of the latest block in seconds since the Unix epoch.
+ *       500:
+ *         description: Internal Server Error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: string
+ */
 v1router.get('/block/:registry/latest', async (req, res) => {
     try {
         const { registry } = req.params;
@@ -1723,6 +1759,57 @@ v1router.get('/block/:registry/latest', async (req, res) => {
     }
 });
 
+/**
+ * @swagger
+ * /block/{registry}/{blockId}:
+ *   get:
+ *     summary: Retrieve a specific block for a given registry
+ *     parameters:
+ *       - in: path
+ *         name: registry
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The name of the registry to retrieve the block from.
+ *       - in: path
+ *         name: blockId
+ *         required: true
+ *         schema:
+ *           oneOf:
+ *             - type: string
+ *               description: The hash of the block.
+ *             - type: integer
+ *               description: The height of the block.
+ *         description: >
+ *           The identifier of the block to retrieve. Can be either a block hash (string) or a block height (integer).
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved the block.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 hash:
+ *                   type: string
+ *                   description: The hash of the block.
+ *                 height:
+ *                   type: integer
+ *                   description: The height of the block.
+ *                 time:
+ *                   type: integer
+ *                   description: The timestamp of the block in seconds since the Unix epoch.
+ *                 timeISO:
+ *                   type: string
+ *                   format: date-time
+ *                   description: The timestamp of the block in ISO 8601 format.
+ *       500:
+ *         description: Internal Server Error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: string
+ */
 v1router.get('/block/:registry/:blockId', async (req, res) => {
     try {
         const { registry, blockId } = req.params;
@@ -1734,6 +1821,53 @@ v1router.get('/block/:registry/:blockId', async (req, res) => {
     }
 });
 
+/**
+ * @swagger
+ * /block/{registry}:
+ *   post:
+ *     summary: Add a new block to a specific registry
+ *     parameters:
+ *       - in: path
+ *         name: registry
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The name of the registry to which the block will be added.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - hash
+ *               - height
+ *               - time
+ *             properties:
+ *               hash:
+ *                 type: string
+ *                 description: The hash of the block.
+ *               height:
+ *                 type: integer
+ *                 description: The height of the block.
+ *               time:
+ *                 type: integer
+ *                 description: The timestamp of the block in seconds since the Unix epoch.
+ *     responses:
+ *       200:
+ *         description: Successfully added the block.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: boolean
+ *               example: true
+ *       500:
+ *         description: Internal Server Error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: string
+ */
 v1router.post('/block/:registry', async (req, res) => {
     try {
         const { registry } = req.params;

--- a/services/mediators/satoshi/src/satoshi-mediator.ts
+++ b/services/mediators/satoshi/src/satoshi-mediator.ts
@@ -148,6 +148,7 @@ async function importBatch(item: DiscoveredItem): Promise<void> {
                 index: item.index,
                 txid: item.txid,
                 batch: item.did,
+                opidx: i,
             }
         });
     }

--- a/services/mediators/satoshi/src/satoshi-mediator.ts
+++ b/services/mediators/satoshi/src/satoshi-mediator.ts
@@ -8,7 +8,7 @@ import JsonSQLite from './db/sqlite.js';
 import config from './config.js';
 import { isValidDID } from '@mdip/ipfs/utils';
 import { MediatorDb, MediatorDbInterface, DiscoveredItem } from './types.js';
-import {GatekeeperEvent, Operation} from '@mdip/gatekeeper/types';
+import { GatekeeperEvent, Operation } from '@mdip/gatekeeper/types';
 
 const REGISTRY = config.chain;
 
@@ -93,6 +93,7 @@ async function fetchBlock(height: number, blockCount: number): Promise<void> {
         db.blockCount = blockCount;
         db.blocksPending = blockCount - height;
         await saveDb(db);
+        await addBlock(height, blockHash, block.time);
 
     } catch (error) {
         console.error(`Error fetching block: ${error}`);
@@ -128,7 +129,7 @@ async function importBatch(item: DiscoveredItem): Promise<void> {
     }
 
     const asset = await keymaster.resolveAsset(item.did);
-    const queue = (asset as { batch?: Operation[]}).batch || asset;
+    const queue = (asset as { batch?: Operation[] }).batch || asset;
 
     // Skip badly formatted batches
     if (!queue || !Array.isArray(queue) || queue.length === 0) {
@@ -444,6 +445,25 @@ async function waitForChain() {
     return true;
 }
 
+async function addBlock(height: number, hash: string, time: number): Promise<void> {
+    await gatekeeper.addBlock(REGISTRY, { hash, height, time });
+}
+
+async function syncBlocks(): Promise<void> {
+    const latest = await gatekeeper.getBlock(REGISTRY);
+    const currentMax = latest ? latest.height : config.startBlock;
+    const blockCount = await btcClient.getBlockCount();
+
+    console.log(`current block height: ${blockCount}`);
+
+    for (let height = currentMax; height <= blockCount; height++) {
+        const blockHash = await btcClient.getBlockHash(height);
+        const block = await btcClient.getBlock(blockHash);
+        console.log(`${height}/${blockCount} blocks (${(100 * height / blockCount).toFixed(2)}%)`);
+        await addBlock(height, blockHash, block.time);
+    }
+}
+
 async function main() {
     if (!config.nodeID) {
         console.log('satoshi-mediator must have a KC_NODE_ID configured');
@@ -509,6 +529,8 @@ async function main() {
         intervalSeconds: 5,
         chatty: true,
     });
+
+    await syncBlocks();
 
     if (config.importInterval > 0) {
         console.log(`Importing operations every ${config.importInterval} minute(s)`);

--- a/tests/gatekeeper-client.test.ts
+++ b/tests/gatekeeper-client.test.ts
@@ -812,3 +812,89 @@ describe('getData', () => {
         }
     });
 });
+
+describe('addBlock', () => {
+    const mockBlock = { hash: 'mockHash', height: 1, time: 1234 };
+    const mockRegistry = 'local';
+
+    it('should add a block', async () => {
+        nock(GatekeeperURL)
+            .post(`/api/v1/block/${mockRegistry}`)
+            .reply(200, 'true');
+
+        const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
+        const ok = await gatekeeper.addBlock(mockRegistry, mockBlock);
+
+        expect(ok).toBe(true);
+    });
+
+    it('should throw exception on addBlock server error', async () => {
+        nock(GatekeeperURL)
+            .post(`/api/v1/block/${mockRegistry}`)
+            .reply(500, ServerError);
+
+        const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
+
+        try {
+            await gatekeeper.addBlock(mockRegistry, mockBlock);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(ServerError.message);
+        }
+    });
+});
+
+describe('getBlock', () => {
+    const mockBlock = { hash: 'mockHash', height: 1, time: 1234 };
+    const mockRegistry = 'local';
+
+    it('should return the latest block', async () => {
+        nock(GatekeeperURL)
+            .get(`/api/v1/block/${mockRegistry}/latest`)
+            .reply(200, mockBlock);
+
+        const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
+        const block = await gatekeeper.getBlock(mockRegistry);
+
+        expect(block).toStrictEqual(mockBlock);
+    });
+
+    it('should return the block by hash', async () => {
+        nock(GatekeeperURL)
+            .get(`/api/v1/block/${mockRegistry}/${mockBlock.hash}`)
+            .reply(200, mockBlock);
+
+        const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
+        const block = await gatekeeper.getBlock(mockRegistry, mockBlock.hash);
+
+        expect(block).toStrictEqual(mockBlock);
+    });
+
+    it('should return the block by height', async () => {
+        nock(GatekeeperURL)
+            .get(`/api/v1/block/${mockRegistry}/${mockBlock.height}`)
+            .reply(200, mockBlock);
+
+        const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
+        const block = await gatekeeper.getBlock(mockRegistry, mockBlock.height);
+
+        expect(block).toStrictEqual(mockBlock);
+    });
+
+    it('should throw exception on getBlock server error', async () => {
+        nock(GatekeeperURL)
+            .get(`/api/v1/block/${mockRegistry}/latest`)
+            .reply(500, ServerError);
+
+        const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
+
+        try {
+            await gatekeeper.getBlock(mockRegistry);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(ServerError.message);
+        }
+    });
+});

--- a/tests/gatekeeper.test.ts
+++ b/tests/gatekeeper.test.ts
@@ -2045,10 +2045,6 @@ describe('processEvents', () => {
 
         expect(response.added).toBe(3);
         expect(response.merged).toBe(0);
-
-        // Also check that blockchain info is added to document metadata for resolveDID coverage...
-        const doc2 = await gatekeeper.resolveDID(did);
-        expect(doc2.mdip!.registration).toStrictEqual(ops[2].blockchain);
     });
 
     it('should resolve as confirmed when DID is imported from its native registry', async () => {

--- a/tests/gatekeeper.test.ts
+++ b/tests/gatekeeper.test.ts
@@ -1,7 +1,7 @@
 import mockFs from 'mock-fs';
 import fs from 'fs';
 import CipherNode from '@mdip/cipher/node';
-import { Operation, MdipDocument } from '@mdip/gatekeeper/types';
+import { Operation, MdipDocument, BlockInfo } from '@mdip/gatekeeper/types';
 import Gatekeeper from '@mdip/gatekeeper';
 import DbJson from '@mdip/gatekeeper/db/json';
 import { copyJSON, compareOrdinals } from '@mdip/common/utils';
@@ -3490,5 +3490,79 @@ describe('getData', () => {
         const data = await gatekeeper.getData(cid);
 
         expect(data).toStrictEqual(mockData);
+    });
+});
+
+const mockBlock: BlockInfo = {
+    height: 100,
+    hash: 'mockHash',
+    time: 999,
+};
+
+describe('addBlock', () => {
+    beforeEach(() => {
+        mockFs({});
+    });
+
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should add a new block', async () => {
+        const ok = await gatekeeper.addBlock('local', mockBlock);
+
+        expect(ok).toStrictEqual(true);
+    });
+
+    it('should throw exception on invalid registry', async () => {
+        try {
+            await gatekeeper.addBlock('mock', mockBlock);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe('Invalid parameter: registry=mock');
+        }
+    });
+});
+
+describe('getBlock', () => {
+    beforeEach(() => {
+        mockFs({});
+    });
+
+    afterEach(() => {
+        mockFs.restore();
+    });
+
+    it('should get a block by height', async () => {
+        await gatekeeper.addBlock('local', mockBlock);
+        const block = await gatekeeper.getBlock('local', mockBlock.height);
+
+        expect(block).toStrictEqual(mockBlock);
+    });
+
+    it('should get a block by hash', async () => {
+        await gatekeeper.addBlock('local', mockBlock);
+        const block = await gatekeeper.getBlock('local', mockBlock.hash);
+
+        expect(block).toStrictEqual(mockBlock);
+    });
+
+    it('should return null for unknown block', async () => {
+        await gatekeeper.addBlock('local', mockBlock);
+        const block = await gatekeeper.getBlock('local', 0);
+
+        expect(block).toStrictEqual(null);
+    });
+
+    it('should throw exception on invalid registry', async () => {
+        try {
+            await gatekeeper.addBlock('local', mockBlock);
+            await gatekeeper.getBlock('mock', mockBlock.height);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe('Invalid parameter: registry=mock');
+        }
     });
 });

--- a/tests/gatekeeper.test.ts
+++ b/tests/gatekeeper.test.ts
@@ -473,6 +473,7 @@ describe('createDID', () => {
         }
     });
 
+    // eslint-disable-next-line
     it('should throw exception on invalid registry', async () => {
         mockFs({});
 

--- a/tests/gatekeeper.test.ts
+++ b/tests/gatekeeper.test.ts
@@ -3497,7 +3497,13 @@ describe('getData', () => {
 const mockBlock: BlockInfo = {
     height: 100,
     hash: 'mockHash',
-    time: 999,
+    time: 100,
+};
+
+const mockBlock2: BlockInfo = {
+    height: 200,
+    hash: 'mockHash2',
+    time: 200,
 };
 
 describe('addBlock', () => {
@@ -3549,9 +3555,30 @@ describe('getBlock', () => {
         expect(block).toStrictEqual(mockBlock);
     });
 
-    it('should return null for unknown block', async () => {
+    it('should get max height block', async () => {
+        await gatekeeper.addBlock('local', mockBlock2);
+        await gatekeeper.addBlock('local', mockBlock);
+        const block = await gatekeeper.getBlock('local');
+
+        expect(block).toStrictEqual(mockBlock2);
+    });
+
+    it('should return null when no blocks', async () => {
+        const block = await gatekeeper.getBlock('local');
+
+        expect(block).toStrictEqual(null);
+    });
+
+    it('should return null for unknown block height', async () => {
         await gatekeeper.addBlock('local', mockBlock);
         const block = await gatekeeper.getBlock('local', 0);
+
+        expect(block).toStrictEqual(null);
+    });
+
+    it('should return null for unknown block hash', async () => {
+        await gatekeeper.addBlock('local', mockBlock);
+        const block = await gatekeeper.getBlock('local', 'zero');
 
         expect(block).toStrictEqual(null);
     });

--- a/tests/gatekeeper.test.ts
+++ b/tests/gatekeeper.test.ts
@@ -2102,7 +2102,7 @@ describe('processEvents', () => {
 
         const doc2 = await gatekeeper.resolveDID(did);
 
-        const exectedTimestamp = {
+        const expectedTimestamp = {
             chain: 'TFTC',
             opid: doc2.didDocumentMetadata!.versionId,
             lowerBound: {
@@ -2122,7 +2122,7 @@ describe('processEvents', () => {
             }
         };
 
-        expect(doc2.didDocumentMetadata!.timestamp).toStrictEqual(exectedTimestamp);
+        expect(doc2.didDocumentMetadata!.timestamp).toStrictEqual(expectedTimestamp);
     });
 
     it('should not overwrite events when verified DID is later synced from another registry', async () => {


### PR DESCRIPTION
Resolves #683 

This PR adds timestamp support to DID metadata by tracking block information throughout the system. Key changes include:

-    Adding block info (blockid, height, time, etc.) to operations in Gatekeeper and Keymaster modules.
-    Introducing new endpoints, CLI commands, and tests to handle block addition and retrieval.
-    Updating database adapters (SQLite, Redis, Mongo, and JSON) to store and retrieve block information.
