### PR TITLE
ci: add new pipeline for releases after tags been created

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,98 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Build & Publish Release
+
+on:
+  push:
+    tags: ['v*']
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    outputs:
+      REGISTRY: ${{ env.REGISTRY }}
+      GIT_TAG: ${{ steps.get_tag.outputs.git_tag }}
+    steps:
+      - name: Checkout Tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Get Git tag
+        id: get_tag
+        run: echo "git_tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+
+  build_test_images:
+    runs-on: ubuntu-latest
+    needs: generate
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: Dockerfile.gatekeeper
+            tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/gatekeeper:${{ needs.generate.outputs.GIT_TAG }}
+          - dockerfile: Dockerfile.keymaster
+            tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/keymaster:${{ needs.generate.outputs.GIT_TAG }}
+          - dockerfile: Dockerfile.hyperswarm
+            tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/hyperswarm-mediator:${{ needs.generate.outputs.GIT_TAG }}
+          - dockerfile: Dockerfile.satoshi
+            tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/sat-mediator:${{ needs.generate.outputs.GIT_TAG }}
+          - dockerfile: Dockerfile.cli
+            tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/cli:${{ needs.generate.outputs.GIT_TAG }}
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@0d4c9c5ea7693da7b068278f7b52bda2a190a446
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: ${{ needs.generate.outputs.GIT_TAG }}
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@1a162644f9a7e87d8f4b053101d1d9a712edc18c
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ matrix.tags }}
+          platforms: linux/amd64,linux/arm64
+
+      - name: Run Anchore vulnerability scanner
+        uses: anchore/scan-action@v3
+        with:
+          image: ${{ matrix.tags }}
+          fail-build: false
+          severity-cutoff: critical
+          output-format: table


### PR DESCRIPTION
Resolves #793. 

This will trigger when a new tag is create in the repo either by push to the repo or when a GH Release is Approved which generates a new tag. This will only trigger for the tag format of : "v*"