### PR TITLE
ci: Added explorer to docker workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -59,6 +59,12 @@ jobs:
           - dockerfile: Dockerfile.cli
             tags: |
               ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/cli:${{ needs.generate.outputs.CALVER }}
+          - dockerfile: Dockerfile.explorer
+            tags: |
+              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/explorer:${{ needs.generate.outputs.CALVER }}
+          - dockerfile: Dockerfile.search-server
+            tags: |
+              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/search-server:${{ needs.generate.outputs.CALVER }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -45,26 +45,19 @@ jobs:
       matrix:
         include:
           - dockerfile: Dockerfile.gatekeeper
-            tags: |
-              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/gatekeeper:${{ needs.generate.outputs.CALVER }}
+            tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/gatekeeper:${{ needs.generate.outputs.CALVER }}
           - dockerfile: Dockerfile.keymaster
-            tags: |
-              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/keymaster:${{ needs.generate.outputs.CALVER }}
+            tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/keymaster:${{ needs.generate.outputs.CALVER }}
           - dockerfile: Dockerfile.hyperswarm
-            tags: |
-              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/hyperswarm-mediator:${{ needs.generate.outputs.CALVER }}
+            tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/hyperswarm-mediator:${{ needs.generate.outputs.CALVER }}
           - dockerfile: Dockerfile.satoshi
-            tags: |
-              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/sat-mediator:${{ needs.generate.outputs.CALVER }}
+            tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/sat-mediator:${{ needs.generate.outputs.CALVER }}
           - dockerfile: Dockerfile.cli
-            tags: |
-              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/cli:${{ needs.generate.outputs.CALVER }}
+            tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/cli:${{ needs.generate.outputs.CALVER }}
           - dockerfile: Dockerfile.explorer
-            tags: |
-              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/explorer:${{ needs.generate.outputs.CALVER }}
+            tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/explorer:${{ needs.generate.outputs.CALVER }}
           - dockerfile: Dockerfile.search-server
-            tags: |
-              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/search-server:${{ needs.generate.outputs.CALVER }}
+            tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/search-server:${{ needs.generate.outputs.CALVER }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,6 +60,12 @@ jobs:
           - dockerfile: Dockerfile.cli
             tags: |
               ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/cli:pre-release
+          - dockerfile: Dockerfile.explorer
+            tags: |
+              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/explorer:pre-release
+          - dockerfile: Dockerfile.search-server
+            tags: |
+              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/search-server:pre-release
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,26 +46,19 @@ jobs:
       matrix:
         include:
           - dockerfile: Dockerfile.gatekeeper
-            tags: |
-              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/gatekeeper:pre-release
+            tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/gatekeeper:pre-release
           - dockerfile: Dockerfile.keymaster
-            tags: |
-              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/keymaster:pre-release
+            tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/keymaster:pre-release
           - dockerfile: Dockerfile.hyperswarm
-            tags: |
-              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/hyperswarm-mediator:pre-release
+            tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/hyperswarm-mediator:pre-release
           - dockerfile: Dockerfile.satoshi
-            tags: |
-              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/sat-mediator:pre-release
+            tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/sat-mediator:pre-release
           - dockerfile: Dockerfile.cli
-            tags: |
-              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/cli:pre-release
+            tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/cli:pre-release
           - dockerfile: Dockerfile.explorer
-            tags: |
-              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/explorer:pre-release
+            tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/explorer:pre-release
           - dockerfile: Dockerfile.search-server
-            tags: |
-              ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/search-server:pre-release
+            tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/search-server:pre-release
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -50,6 +50,10 @@ jobs:
             tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/sat-mediator:${{ needs.generate.outputs.GIT_TAG }}
           - dockerfile: Dockerfile.cli
             tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/cli:${{ needs.generate.outputs.GIT_TAG }}
+          - dockerfile: Dockerfile.explorer
+            tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/explorer:${{ needs.generate.outputs.GIT_TAG }}
+          - dockerfile: Dockerfile.search-server
+            tags: ${{ needs.generate.outputs.REGISTRY }}/keychainmdip/search-server:${{ needs.generate.outputs.GIT_TAG }}
 
     permissions:
       contents: read


### PR DESCRIPTION
This PR adds support for building and publishing two new services—explorer and search-server—in the CI workflows.

-    Updates the release publish workflow to include explorer and search-server docker images.
-    Updates the docker publish workflow to add corresponding pre-release tags for explorer and search-server.
-    Updates the docker build workflow with build instructions for explorer and search-server.
