### PR TITLE
fix: Upgrade node to v18.20.8

### DIFF
--- a/.github/workflows/build-chrome-extension.yml
+++ b/.github/workflows/build-chrome-extension.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Use Node 18.18.2
+      - name: Use Node 18.20.8
         uses: actions/setup-node@v4
         with:
-          node-version: '18.18.2'
+          node-version: '18.20.8'
 
       - name: Install root dependencies
         run: npm install

--- a/.github/workflows/build-explorer.yml
+++ b/.github/workflows/build-explorer.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Use Node 18.18.2
+      - name: Use Node 18.20.8
         uses: actions/setup-node@v4
         with:
-          node-version: '18.18.2'
+          node-version: '18.20.8'
 
       - name: Install root dependencies
         run: npm install

--- a/.github/workflows/swagger-jsdoc.yml
+++ b/.github/workflows/swagger-jsdoc.yml
@@ -14,10 +14,10 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
 
-      - name: Use Node 18.18.2
+      - name: Use Node 18.20.8
         uses: actions/setup-node@v4
         with:
-          node-version: '18.18.2'
+          node-version: '18.20.8'
 
       - name: Install dependencies
         run: npm install

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:18.18.2-bullseye-slim
+FROM node:18.20.8-bullseye-slim
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.explorer
+++ b/Dockerfile.explorer
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:18.18.2-bullseye-slim
+FROM node:18.20.8-bullseye-slim
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.gatekeeper
+++ b/Dockerfile.gatekeeper
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:18.18.2-bullseye-slim
+FROM node:18.20.8-bullseye-slim
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.hyperswarm
+++ b/Dockerfile.hyperswarm
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:18.18.2-bullseye-slim
+FROM node:18.20.8-bullseye-slim
 
 # Install Python and other dependencies
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.keymaster
+++ b/Dockerfile.keymaster
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:18.18.2-bullseye-slim
+FROM node:18.20.8-bullseye-slim
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.satoshi
+++ b/Dockerfile.satoshi
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:18.18.2-bullseye-slim
+FROM node:18.20.8-bullseye-slim
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.search-server
+++ b/Dockerfile.search-server
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:18.18.2-bullseye-slim
+FROM node:18.20.8-bullseye-slim
 
 # Set the working directory
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Details on each command can be found in the [CLI User Manual](https://keychain.o
 Recommended system requirements:
 
 - GNU/Linux OS with [docker](https://www.docker.com/) for containerized operation
-- node 18.18.2 and npm 9.8.1 or newer for manual and local operation
+- node 18.20.8 and npm 9.8.1 or newer for manual and local operation
 - minimum of 8Gb RAM if operating a full trustless node
 
 ```


### PR DESCRIPTION
[node:18.20.8-bullseye-slim](https://hub.docker.com/layers/library/node/18.20.8-bullseye-slim/images/sha256-cf2eabd2977de67144469693e99714631fceb1e7456a6843571b6d78bc824414) has the fewest vulnerabilities for a node v18 base image