### PR TITLE
refactor: Upgrade node to v22.15.0 LTS

### DIFF
--- a/.github/workflows/build-chrome-extension.yml
+++ b/.github/workflows/build-chrome-extension.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Use Node 18.20.8
+      - name: Use Node 20.19.1
         uses: actions/setup-node@v4
         with:
-          node-version: '18.20.8'
+          node-version: '20.19.1'
 
       - name: Install root dependencies
         run: npm install

--- a/.github/workflows/build-chrome-extension.yml
+++ b/.github/workflows/build-chrome-extension.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Use Node 20.19.1
+      - name: Use Node 22.15.0
         uses: actions/setup-node@v4
         with:
-          node-version: '20.19.1'
+          node-version: '22.15.0'
 
       - name: Install root dependencies
         run: npm install

--- a/.github/workflows/build-explorer.yml
+++ b/.github/workflows/build-explorer.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Use Node 18.20.8
+      - name: Use Node 20.19.1
         uses: actions/setup-node@v4
         with:
-          node-version: '18.20.8'
+          node-version: '20.19.1'
 
       - name: Install root dependencies
         run: npm install

--- a/.github/workflows/build-explorer.yml
+++ b/.github/workflows/build-explorer.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Use Node 20.19.1
+      - name: Use Node 22.15.0
         uses: actions/setup-node@v4
         with:
-          node-version: '20.19.1'
+          node-version: '22.15.0'
 
       - name: Install root dependencies
         run: npm install

--- a/.github/workflows/swagger-jsdoc.yml
+++ b/.github/workflows/swagger-jsdoc.yml
@@ -14,10 +14,10 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
 
-      - name: Use Node 20.19.1
+      - name: Use Node 22.15.0
         uses: actions/setup-node@v4
         with:
-          node-version: '20.19.1'
+          node-version: '22.15.0'
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/swagger-jsdoc.yml
+++ b/.github/workflows/swagger-jsdoc.yml
@@ -14,10 +14,10 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
 
-      - name: Use Node 18.20.8
+      - name: Use Node 20.19.1
         uses: actions/setup-node@v4
         with:
-          node-version: '18.20.8'
+          node-version: '20.19.1'
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '18'
+        node-version: '22'
 
     - name: Install dependencies
       run: npm install
@@ -28,7 +28,7 @@ jobs:
 
     - name: Run unit tests
       run: npm test
-    
+
     - name: Generate Code Coverage report
       id: code-coverage
       uses: barecheck/code-coverage-action@v1

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:20.19.1-bullseye-slim
+FROM node:22.15.0-bullseye-slim
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.cli
+++ b/Dockerfile.cli
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:18.20.8-bullseye-slim
+FROM node:20.19.1-bullseye-slim
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.explorer
+++ b/Dockerfile.explorer
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:20.19.1-bullseye-slim
+FROM node:22.15.0-bullseye-slim
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.explorer
+++ b/Dockerfile.explorer
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:18.20.8-bullseye-slim
+FROM node:20.19.1-bullseye-slim
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.gatekeeper
+++ b/Dockerfile.gatekeeper
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:20.19.1-bullseye-slim
+FROM node:22.15.0-bullseye-slim
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.gatekeeper
+++ b/Dockerfile.gatekeeper
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:18.20.8-bullseye-slim
+FROM node:20.19.1-bullseye-slim
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.hyperswarm
+++ b/Dockerfile.hyperswarm
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:18.20.8-bullseye-slim
+FROM node:20.19.1-bullseye-slim
 
 # Install Python and other dependencies
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.hyperswarm
+++ b/Dockerfile.hyperswarm
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:20.19.1-bullseye-slim
+FROM node:22.15.0-bullseye-slim
 
 # Install Python and other dependencies
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.keymaster
+++ b/Dockerfile.keymaster
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:20.19.1-bullseye-slim
+FROM node:22.15.0-bullseye-slim
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.keymaster
+++ b/Dockerfile.keymaster
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:18.20.8-bullseye-slim
+FROM node:20.19.1-bullseye-slim
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.satoshi
+++ b/Dockerfile.satoshi
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:20.19.1-bullseye-slim
+FROM node:22.15.0-bullseye-slim
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.satoshi
+++ b/Dockerfile.satoshi
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:18.20.8-bullseye-slim
+FROM node:20.19.1-bullseye-slim
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.search-server
+++ b/Dockerfile.search-server
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:20.19.1-bullseye-slim
+FROM node:22.15.0-bullseye-slim
 
 # Set the working directory
 WORKDIR /app

--- a/Dockerfile.search-server
+++ b/Dockerfile.search-server
@@ -1,5 +1,5 @@
 # Use the official Node.js as the base image
-FROM node:18.20.8-bullseye-slim
+FROM node:20.19.1-bullseye-slim
 
 # Set the working directory
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Details on each command can be found in the [CLI User Manual](https://keychain.o
 Recommended system requirements:
 
 - GNU/Linux OS with [docker](https://www.docker.com/) for containerized operation
-- node 20.19.1 and npm 10.8.2 or newer for manual and local operation
+- node 22.15.0 and npm 10.8.2 or newer for manual and local operation
 - minimum of 8Gb RAM if operating a full trustless node
 
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Details on each command can be found in the [CLI User Manual](https://keychain.o
 Recommended system requirements:
 
 - GNU/Linux OS with [docker](https://www.docker.com/) for containerized operation
-- node 18.20.8 and npm 9.8.1 or newer for manual and local operation
+- node 20.19.1 and npm 10.8.2 or newer for manual and local operation
 - minimum of 8Gb RAM if operating a full trustless node
 
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,25 +44,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@achingbrain/http-parser-js": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@achingbrain/http-parser-js/-/http-parser-js-0.5.9.tgz",
+      "integrity": "sha512-nPuMf2zVzBAGRigH/1jFpb/6HmJsps+15f4BPlGDp3vsjYB2ZgruAErUpKpcFiVRz3DHLXcGNmuwmqZx/sVI7A==",
+      "license": "MIT",
+      "dependencies": {
+        "uint8arrays": "^5.1.0"
+      }
+    },
     "node_modules/@achingbrain/nat-port-mapper": {
-      "version": "1.0.13",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@achingbrain/nat-port-mapper/-/nat-port-mapper-4.0.2.tgz",
+      "integrity": "sha512-cOV/mPL8ouLko487f37LXl6t76NwksLbyib2Y2T72HK2bm7y2QP0+3+1xxqKqaffoo30CJm8E8IHN9hmJ/LiSA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@achingbrain/ssdp": "^4.0.1",
-        "@libp2p/logger": "^4.0.1",
-        "default-gateway": "^7.2.2",
+        "@achingbrain/ssdp": "^4.1.0",
+        "@chainsafe/is-ip": "^2.0.2",
+        "@libp2p/logger": "^5.0.1",
+        "abort-error": "^1.0.0",
         "err-code": "^3.0.1",
-        "it-first": "^3.0.1",
+        "netmask": "^2.0.2",
         "p-defer": "^4.0.0",
-        "p-timeout": "^6.1.1",
+        "race-signal": "^1.1.0",
         "xml2js": "^0.6.0"
       }
     },
     "node_modules/@achingbrain/ssdp": {
-      "version": "4.0.6",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@achingbrain/ssdp/-/ssdp-4.2.2.tgz",
+      "integrity": "sha512-Lp/IKQY4Gu+2yKmUtlSKYAEdjtP7Zz1MZ3ihDE3o2IdU5WgSBHDi+gOcbmCI74v8PWCqAGT/CYxwMOWqtDgbUg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "event-iterator": "^2.0.0",
+        "abort-error": "^1.0.0",
         "freeport-promise": "^2.0.0",
         "merge-options": "^3.0.4",
         "xml2js": "^0.6.2"
@@ -238,12 +252,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.2.tgz",
-      "integrity": "sha512-zevQbhbau95nkoxSq3f/DC/SC+EEOUZd3DYqfSkMhY2/wfSeaHV1Ew4vk8e+x8lja31IbyuUa2uQ3JONqKbysw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.1.tgz",
+      "integrity": "sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.26.2",
-        "@babel/types": "^7.26.0",
+        "@babel/parser": "^7.27.1",
+        "@babel/types": "^7.27.1",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -256,6 +271,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
       "integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.25.9"
       },
@@ -265,6 +281,7 @@
     },
     "node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
       "version": "7.22.15",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.22.15"
@@ -299,6 +316,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.9.tgz",
       "integrity": "sha512-UTZQMvt0d/rSz6KI+qdu7GQze5TIajwTS++GUozlw8VBJDEOAqSXwm1WvmYEZwqdqSGQshRocPDqrt4HBZB3fQ==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-member-expression-to-functions": "^7.25.9",
@@ -317,6 +335,7 @@
     },
     "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
       "version": "6.3.1",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -326,6 +345,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.25.9.tgz",
       "integrity": "sha512-ORPNZ3h6ZRkOyAa/SaHU+XsLZr0UQzRwuDQ0cczIA17nAzZ+85G5cVkOJIj7QavLZGSe8QXUmNFxSZzjcZF9bw==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "regexpu-core": "^6.1.1",
@@ -340,6 +360,7 @@
     },
     "node_modules/@babel/helper-create-regexp-features-plugin/node_modules/semver": {
       "version": "6.3.1",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -347,6 +368,7 @@
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
       "version": "0.4.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.22.6",
@@ -361,6 +383,7 @@
     },
     "node_modules/@babel/helper-environment-visitor": {
       "version": "7.24.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.24.7"
@@ -371,6 +394,7 @@
     },
     "node_modules/@babel/helper-hoist-variables": {
       "version": "7.24.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.24.7"
@@ -383,6 +407,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
       "integrity": "sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==",
+      "dev": true,
       "dependencies": {
         "@babel/traverse": "^7.25.9",
         "@babel/types": "^7.25.9"
@@ -423,6 +448,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz",
       "integrity": "sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.25.9"
       },
@@ -442,6 +468,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.9.tgz",
       "integrity": "sha512-IZtukuUeBbhgOcaW2s06OXTzVNJR0ybm4W5xC1opWFFJMZbwRj5LCk+ByYH7WdZPZTt8KnFwA8pvjN2yqcPlgw==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-wrap-function": "^7.25.9",
@@ -458,6 +485,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.9.tgz",
       "integrity": "sha512-IiDqTOTBQy0sWyeXyGSC5TBJpGFXBkRynjBeXsvbhQFKj2viwJC76Epz35YLU1fpe/Am6Vppb7W7zM4fPQzLsQ==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.25.9",
         "@babel/helper-optimise-call-expression": "^7.25.9",
@@ -474,6 +502,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.25.9.tgz",
       "integrity": "sha512-c6WHXuiaRsJTyHYLJV75t9IqsmTbItYfdj99PnzYGQZkYKvan5/2jKJ7gu31J3/BJ/A18grImSPModuyG/Eo0Q==",
+      "dev": true,
       "dependencies": {
         "@babel/traverse": "^7.25.9",
         "@babel/types": "^7.25.9"
@@ -486,6 +515,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz",
       "integrity": "sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==",
+      "dev": true,
       "dependencies": {
         "@babel/traverse": "^7.25.9",
         "@babel/types": "^7.25.9"
@@ -524,6 +554,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.25.9.tgz",
       "integrity": "sha512-ETzz9UTjQSTmw39GboatdymDq4XIQbR8ySgVrylRhPOFpsd+JrKHIuF0de7GCWmem+T4uC5z7EZguod7Wj4A4g==",
+      "dev": true,
       "dependencies": {
         "@babel/template": "^7.25.9",
         "@babel/traverse": "^7.25.9",
@@ -563,6 +594,7 @@
     },
     "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -576,6 +608,7 @@
     },
     "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -591,6 +624,7 @@
     },
     "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
       "version": "7.23.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
@@ -605,6 +639,7 @@
     },
     "node_modules/@babel/plugin-proposal-class-properties": {
       "version": "7.18.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.18.6",
@@ -633,23 +668,9 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-proposal-export-default-from": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.25.9.tgz",
-      "integrity": "sha512-ykqgwNfSnNOB+C8fV5X4mG3AVmvu+WVxcaU9xHHtBb7PCrPeweMmPjGsn8eMaeJg6SJuoUuZENeeSWaarWqonQ==",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
       "version": "7.18.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6",
@@ -679,6 +700,7 @@
     },
     "node_modules/@babel/plugin-proposal-optional-chaining": {
       "version": "7.21.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.20.2",
@@ -756,6 +778,7 @@
     },
     "node_modules/@babel/plugin-syntax-class-static-block": {
       "version": "7.14.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -783,6 +806,7 @@
     },
     "node_modules/@babel/plugin-syntax-dynamic-import": {
       "version": "7.8.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -791,23 +815,9 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-syntax-export-default-from": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.25.9.tgz",
-      "integrity": "sha512-9MhJ/SMTsVqsd69GyQg89lYR4o9T+oDGv5F6IsigxxqFVOyR/IflDLYP8WDI1l8fkhNGGktqkvL5qwNCtGEpgQ==",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-syntax-export-namespace-from": {
       "version": "7.8.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.3"
@@ -820,6 +830,7 @@
       "version": "7.26.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.26.0.tgz",
       "integrity": "sha512-B+O2DnPc0iG+YXFqOxv2WNuNU97ToWjOomUQ78DouOENWUaM5sVrmet9mcomUGQFwpJd//gvUagXBSdzO1fRKg==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -832,6 +843,7 @@
     },
     "node_modules/@babel/plugin-syntax-import-assertions": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -845,6 +857,7 @@
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -880,6 +893,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
       "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -952,6 +966,7 @@
     },
     "node_modules/@babel/plugin-syntax-private-property-in-object": {
       "version": "7.14.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -980,6 +995,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
       "integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -992,6 +1008,7 @@
     },
     "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
       "version": "7.18.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.18.6",
@@ -1008,6 +1025,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.25.9.tgz",
       "integrity": "sha512-6jmooXYIwn9ca5/RylZADJ+EnSxVUS5sjeJ9UPk6RWRzXCmOJCy6dqItPJFpw2cuCangPK4OYr5uhGKcmrm5Qg==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1022,6 +1040,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.9.tgz",
       "integrity": "sha512-RXV6QAzTBbhDMO9fWwOmwwTuYaiPbggWQ9INdZqAYeSHyG7FzQ+nOZaUUjNwKv9pV3aE4WFqFm1Hnbci5tBCAw==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-remap-async-to-generator": "^7.25.9",
@@ -1038,6 +1057,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.25.9.tgz",
       "integrity": "sha512-NT7Ejn7Z/LjUH0Gv5KsBCxh7BH3fbLTV0ptHvpeMvrt3cPThHfJfst9Wrb7S8EvJ7vRTFI7z+VAvFVEQn/m5zQ==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -1052,6 +1072,7 @@
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -1067,6 +1088,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.25.9.tgz",
       "integrity": "sha512-1F05O7AYjymAtqbsFETboN1NvBdcnzMerO+zlMyJBEz6WkMdejvGWw9p05iTSjC85RLlBseHHQpYaM4gzJkBGg==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1081,6 +1103,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.9.tgz",
       "integrity": "sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1094,6 +1117,7 @@
     },
     "node_modules/@babel/plugin-transform-class-static-block": {
       "version": "7.23.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.22.15",
@@ -1111,6 +1135,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.9.tgz",
       "integrity": "sha512-mD8APIXmseE7oZvZgGABDyM34GUmK45Um2TXiBUt7PnuAxrgoSVf123qUzPxEr/+/BHrRn5NMZCdE2m/1F8DGg==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-compilation-targets": "^7.25.9",
@@ -1130,6 +1155,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.25.9.tgz",
       "integrity": "sha512-HnBegGqXZR12xbcTHlJ9HGxw1OniltT26J5YpfruGqtUHlz/xKf/G2ak9e+t0rVqrjXa9WOhvYPz1ERfMj23AA==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/template": "^7.25.9"
@@ -1145,6 +1171,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.25.9.tgz",
       "integrity": "sha512-WkCGb/3ZxXepmMiX101nnGiU+1CAdut8oHyEOHxkKuS1qKpU2SMXE2uSvfz8PBuLd49V6LEsbtyPhWC7fnkgvQ==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1157,6 +1184,7 @@
     },
     "node_modules/@babel/plugin-transform-dotall-regex": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.22.15",
@@ -1171,6 +1199,7 @@
     },
     "node_modules/@babel/plugin-transform-duplicate-keys": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -1184,6 +1213,7 @@
     },
     "node_modules/@babel/plugin-transform-dynamic-import": {
       "version": "7.23.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1198,6 +1228,7 @@
     },
     "node_modules/@babel/plugin-transform-exponentiation-operator": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-builder-binary-assignment-operator-visitor": "^7.22.15",
@@ -1212,6 +1243,7 @@
     },
     "node_modules/@babel/plugin-transform-export-namespace-from": {
       "version": "7.23.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1228,6 +1260,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.25.9.tgz",
       "integrity": "sha512-/VVukELzPDdci7UUsWQaSkhgnjIWXnIyRpM02ldxaVoFK96c41So8JcKT3m0gYjyv7j5FNPGS5vfELrWalkbDA==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/plugin-syntax-flow": "^7.25.9"
@@ -1243,6 +1276,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.25.9.tgz",
       "integrity": "sha512-LqHxduHoaGELJl2uhImHwRQudhCM50pT46rIBNvtT/Oql3nqiS3wOwP+5ten7NpYSXrrVLgtZU3DZmPtWZo16A==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
@@ -1258,6 +1292,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.9.tgz",
       "integrity": "sha512-8lP+Yxjv14Vc5MuWBpJsoUCd3hD6V9DgBon2FVYL4jJgbnVQ9fTgYmonchzZJOVNgzEgbxp4OwAf6xz6M/14XA==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -1272,6 +1307,7 @@
     },
     "node_modules/@babel/plugin-transform-json-strings": {
       "version": "7.23.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1288,6 +1324,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.9.tgz",
       "integrity": "sha512-9N7+2lFziW8W9pBl2TzaNht3+pgMIRP74zizeCSrtnSKVdUl8mAjjOP2OOVQAfZ881P2cNjDj1uAMEdeD50nuQ==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1302,6 +1339,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.25.9.tgz",
       "integrity": "sha512-wI4wRAzGko551Y8eVf6iOY9EouIDTtPb0ByZx+ktDGHwv6bHFimrgJM/2T021txPZ2s4c7bqvHbd+vXG6K948Q==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1314,6 +1352,7 @@
     },
     "node_modules/@babel/plugin-transform-member-expression-literals": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -1327,6 +1366,7 @@
     },
     "node_modules/@babel/plugin-transform-modules-amd": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.23.3",
@@ -1343,6 +1383,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.25.9.tgz",
       "integrity": "sha512-dwh2Ol1jWwL2MgkCzUSOvfmKElqQcuswAZypBSUsScMXvgdT8Ekq5YA6TtqpTVWH+4903NmboMuH1o9i8Rxlyg==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-module-transforms": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -1357,6 +1398,7 @@
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-hoist-variables": "^7.22.5",
@@ -1373,6 +1415,7 @@
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.23.3",
@@ -1389,6 +1432,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.25.9.tgz",
       "integrity": "sha512-oqB6WHdKTGl3q/ItQhpLSnWWOpjUJLsOCLVyeFgeTktkBSCiurvPOsyt93gibI9CmuKvTUEtWmG5VhZD+5T/KA==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1402,6 +1446,7 @@
     },
     "node_modules/@babel/plugin-transform-new-target": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -1417,6 +1462,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.25.9.tgz",
       "integrity": "sha512-ENfftpLZw5EItALAD4WsY/KUWvhUlZndm5GC7G3evUsVeSJB6p0pBeLQUnRnBCBx7zV0RKQjR9kCuwrsIrjWog==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1431,6 +1477,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.25.9.tgz",
       "integrity": "sha512-TlprrJ1GBZ3r6s96Yq8gEQv82s8/5HnCVHtEJScUj90thHQbwe+E5MLhi2bbNHBEJuzrvltXSru+BUxHDoog7Q==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1445,6 +1492,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.25.9.tgz",
       "integrity": "sha512-fSaXafEE9CVHPweLYw4J0emp1t8zYTXyzN3UuG+lylqkvYd7RMrsOQ8TYx5RF231be0vqtFC6jnx3UmpJmKBYg==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -1459,6 +1507,7 @@
     },
     "node_modules/@babel/plugin-transform-object-super": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1475,6 +1524,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.25.9.tgz",
       "integrity": "sha512-qM/6m6hQZzDcZF3onzIhZeDHDO43bkNNlOX0i8n3lR6zLbu0GN2d8qfM/IERJZYauhAHSLHy39NF0Ctdvcid7g==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1489,6 +1539,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.25.9.tgz",
       "integrity": "sha512-6AvV0FsLULbpnXeBjrY4dmWF8F7gf8QnvTEoO/wX/5xm/xE1Xo8oPuD3MPS+KS9f9XBEAWN7X1aWr4z9HdOr7A==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
@@ -1504,6 +1555,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.25.9.tgz",
       "integrity": "sha512-wzz6MKwpnshBAiRmn4jR8LYz/g8Ksg0o80XmwZDlordjwEk9SxBzTWC7F5ef1jhbrbOW2DJ5J6ayRukrJmnr0g==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1518,6 +1570,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.9.tgz",
       "integrity": "sha512-D/JUozNpQLAPUVusvqMxyvjzllRaF8/nSrP1s2YGQT/W4LHK4xxsMcHjhOGTS01mp9Hda8nswb+FblLdJornQw==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1533,6 +1586,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.25.9.tgz",
       "integrity": "sha512-Evf3kcMqzXA3xfYJmZ9Pg1OvKdtqsDMSWBDzZOPLvHiTt36E75jLDQo5w1gtRU95Q4E5PDttrTf25Fw8d/uWLw==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-create-class-features-plugin": "^7.25.9",
@@ -1547,6 +1601,7 @@
     },
     "node_modules/@babel/plugin-transform-property-literals": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -1560,6 +1615,7 @@
     },
     "node_modules/@babel/plugin-transform-react-display-name": {
       "version": "7.24.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.7"
@@ -1575,6 +1631,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.9.tgz",
       "integrity": "sha512-s5XwpQYCqGerXl+Pu6VDL3x0j2d82eiV77UJ8a2mDHAW7j9SWRqQ2y1fNo1Z74CdcYipl5Z41zvjj4Nfzq36rw==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-module-imports": "^7.25.9",
@@ -1603,36 +1660,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.25.9.tgz",
-      "integrity": "sha512-y8quW6p0WHkEhmErnfe58r7x0A70uKphQm8Sp8cV7tjNQwK56sNVK0M73LK3WuYmsuyrftut4xAkjjgU0twaMg==",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.25.9.tgz",
-      "integrity": "sha512-+iqjT8xmXhhYv4/uiYd8FNQsraMFZIfxVSqxxVSZP0WbbSAWvBXAul0m/zu+7Vv4O/3WtApy9pmaTMiumEZgfg==",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-transform-react-pure-annotations": {
       "version": "7.24.7",
       "dev": true,
@@ -1652,6 +1679,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.25.9.tgz",
       "integrity": "sha512-vwDcDNsgMPDGP0nMqzahDWE5/MLcX8sv96+wfX7as7LoF/kr97Bo/7fI00lXY4wUXYfVmwIIyG80fGZ1uvt2qg==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "regenerator-transform": "^0.15.2"
@@ -1665,6 +1693,7 @@
     },
     "node_modules/@babel/plugin-transform-reserved-words": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -1680,6 +1709,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.25.9.tgz",
       "integrity": "sha512-nZp7GlEl+yULJrClz0SwHPqir3lc0zsPrDHQUcxGspSL7AKrexNSEfTbfqnDNJUO13bgKyfuOLMF8Xqtu8j3YQ==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9",
@@ -1699,6 +1729,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.3.tgz",
       "integrity": "sha512-HK7Bi+Hj6H+VTHA3ZvBis7V/6hu9QuTrnMXNybfUf2iiuU/N97I8VjB+KbhFF8Rld/Lx5MzoCwPCpPjfK+n8Cg==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.22.6",
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1714,6 +1745,7 @@
       "version": "0.10.6",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
       "integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.2",
         "core-js-compat": "^3.38.0"
@@ -1726,6 +1758,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.3.tgz",
       "integrity": "sha512-LiWSbl4CRSIa5x/JAU6jZiG9eit9w6mz+yVMFwDE83LAWvt0AfGBoZ7HS/mkhrKuh2ZlzfVZYKoLjXdqw6Yt7Q==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.6.3"
       },
@@ -1735,6 +1768,7 @@
     },
     "node_modules/@babel/plugin-transform-runtime/node_modules/semver": {
       "version": "6.3.1",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1744,6 +1778,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.25.9.tgz",
       "integrity": "sha512-MUv6t0FhO5qHnS/W8XCbHmiRWOphNufpE1IVxhK5kuN3Td9FT1x4rx4K42s3RYdMXCXpfWkGSbCSd0Z64xA7Ng==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1758,6 +1793,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.25.9.tgz",
       "integrity": "sha512-oNknIB0TbURU5pqJFVbOOFspVlrpVwo2H1+HUIsVDvp5VauGGDP1ZEvO8Nn5xyMEs3dakajOxlmkNW7kNgSm6A==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
@@ -1773,6 +1809,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.25.9.tgz",
       "integrity": "sha512-WqBUSgeVwucYDP9U/xNRQam7xV8W5Zf+6Eo7T2SRVUFlhRiMNFdFz58u0KZmCVVqs2i7SHgpRnAhzRNmKfi2uA==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.25.9"
       },
@@ -1785,6 +1822,7 @@
     },
     "node_modules/@babel/plugin-transform-template-literals": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -1798,6 +1836,7 @@
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -1813,6 +1852,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.9.tgz",
       "integrity": "sha512-7PbZQZP50tzv2KGGnhh82GSyMB01yKY9scIjf1a+GfZCtInOWqUH5+1EBU4t9fyR5Oykkkc9vFTs4OHrhHXljQ==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.9",
         "@babel/helper-create-class-features-plugin": "^7.25.9",
@@ -1829,6 +1869,7 @@
     },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
@@ -1842,6 +1883,7 @@
     },
     "node_modules/@babel/plugin-transform-unicode-property-regex": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.22.15",
@@ -1858,6 +1900,7 @@
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.25.9.tgz",
       "integrity": "sha512-yoxstj7Rg9dlNn9UQxzk4fcNivwv4nUYz7fYXBaKxvw/lnmPuOm/ikoELygbYq68Bls3D/D+NBPHiLwZdZZ4HA==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.25.9",
         "@babel/helper-plugin-utils": "^7.25.9"
@@ -1871,6 +1914,7 @@
     },
     "node_modules/@babel/plugin-transform-unicode-sets-regex": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.22.15",
@@ -1885,6 +1929,7 @@
     },
     "node_modules/@babel/preset-env": {
       "version": "7.23.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.23.5",
@@ -1977,6 +2022,7 @@
     },
     "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.0-placeholder-for-preset-env.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1987,30 +2033,15 @@
     },
     "node_modules/@babel/preset-env/node_modules/semver": {
       "version": "6.3.1",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/@babel/preset-flow": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.25.9.tgz",
-      "integrity": "sha512-EASHsAhE+SSlEzJ4bzfusnXSHiU+JfAYzj+jbw2vgQKgq5HrUr8qs+vgtiEL5dOH6sEweI+PNt2D7AqrDSHyqQ==",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.25.9",
-        "@babel/helper-validator-option": "^7.25.9",
-        "@babel/plugin-transform-flow-strip-types": "^7.25.9"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/preset-modules": {
       "version": "0.1.6-no-external-plugins",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -2042,6 +2073,7 @@
     },
     "node_modules/@babel/preset-typescript": {
       "version": "7.23.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -2049,25 +2081,6 @@
         "@babel/plugin-syntax-jsx": "^7.23.3",
         "@babel/plugin-transform-modules-commonjs": "^7.23.3",
         "@babel/plugin-transform-typescript": "^7.23.3"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/register": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.25.9.tgz",
-      "integrity": "sha512-8D43jXtGsYmEeDvm4MWHYUpWf8iiXgWYx3fW7E7Wb7Oe6FWqJPl5K6TuFW0dOwNZzEE5rjlaSJYH9JjrUKJszA==",
-      "peer": true,
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "find-cache-dir": "^2.0.0",
-        "make-dir": "^2.1.0",
-        "pirates": "^4.0.6",
-        "source-map-support": "^0.5.16"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2118,16 +2131,17 @@
     },
     "node_modules/@babel/traverse--for-generate-function-map": {
       "name": "@babel/traverse",
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.9.tgz",
-      "integrity": "sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.1.tgz",
+      "integrity": "sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/generator": "^7.25.9",
-        "@babel/parser": "^7.25.9",
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.25.9",
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.27.1",
+        "@babel/parser": "^7.27.1",
+        "@babel/template": "^7.27.1",
+        "@babel/types": "^7.27.1",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -2155,101 +2169,70 @@
     },
     "node_modules/@chainsafe/as-chacha20poly1305": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/as-chacha20poly1305/-/as-chacha20poly1305-0.1.0.tgz",
+      "integrity": "sha512-BpNcL8/lji/GM3+vZ/bgRWqJ1q5kwvTFmGPk7pxm/QQZDbaMI98waOHjEymTjq2JmdD/INdNBFOVSyJofXg7ew==",
       "license": "Apache-2.0"
     },
     "node_modules/@chainsafe/as-sha256": {
-      "version": "0.4.1",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/as-sha256/-/as-sha256-1.0.1.tgz",
+      "integrity": "sha512-4Y/kQm0LsJ6QRtGcMq6gOdQP+fZhWDfIV2eIqP6oFJZBWYGmdh3wm8YbrXDPLJO87X2Fu6koRLdUS00O3k14Hw==",
       "license": "Apache-2.0"
     },
     "node_modules/@chainsafe/is-ip": {
       "version": "2.0.2",
       "license": "MIT"
     },
-    "node_modules/@chainsafe/libp2p-gossipsub": {
-      "version": "11.0.1",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@libp2p/crypto": "^3.0.1",
-        "@libp2p/interface": "^1.0.1",
-        "@libp2p/interface-internal": "^1.0.1",
-        "@libp2p/peer-id": "^4.0.1",
-        "@libp2p/pubsub": "^9.0.0",
-        "@multiformats/multiaddr": "^12.1.3",
-        "abortable-iterator": "^5.0.1",
-        "denque": "^2.1.0",
-        "it-length-prefixed": "^9.0.1",
-        "it-pipe": "^3.0.1",
-        "it-pushable": "^3.2.0",
-        "multiformats": "^12.0.1",
-        "protobufjs": "^7.2.4",
-        "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^4.0.4"
-      },
-      "engines": {
-        "npm": ">=8.7.0"
-      }
-    },
-    "node_modules/@chainsafe/libp2p-gossipsub/node_modules/multiformats": {
-      "version": "12.1.3",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@chainsafe/libp2p-gossipsub/node_modules/uint8arrays": {
-      "version": "4.0.10",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^12.0.1"
-      }
-    },
     "node_modules/@chainsafe/libp2p-noise": {
-      "version": "14.1.0",
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-16.1.3.tgz",
+      "integrity": "sha512-YLonKdIUFk/0keKRfzlmdrsObi8r0EaZC14Vjh3qdLy4+W7NaQAs1sSMt8aDP07oE78pa51NyejmQLKOnt7tOw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@chainsafe/as-chacha20poly1305": "^0.1.0",
-        "@chainsafe/as-sha256": "^0.4.1",
-        "@libp2p/crypto": "^3.0.0",
-        "@libp2p/interface": "^1.0.0",
-        "@libp2p/peer-id": "^4.0.0",
-        "@noble/ciphers": "^0.4.0",
+        "@chainsafe/as-sha256": "^1.0.0",
+        "@libp2p/crypto": "^5.0.0",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/peer-id": "^5.0.0",
+        "@noble/ciphers": "^1.1.3",
         "@noble/curves": "^1.1.0",
         "@noble/hashes": "^1.3.1",
-        "it-byte-stream": "^1.0.0",
-        "it-length-prefixed": "^9.0.1",
-        "it-length-prefixed-stream": "^1.0.0",
+        "it-length-prefixed": "^10.0.1",
+        "it-length-prefixed-stream": "^2.0.1",
         "it-pair": "^2.0.6",
         "it-pipe": "^3.0.1",
         "it-stream-types": "^2.0.1",
-        "protons-runtime": "^5.0.0",
+        "protons-runtime": "^5.5.0",
         "uint8arraylist": "^2.4.3",
         "uint8arrays": "^5.0.0",
         "wherearewe": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
       }
     },
-    "node_modules/@chainsafe/libp2p-noise/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
+    "node_modules/@chainsafe/libp2p-noise/node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@chainsafe/libp2p-yamux": {
-      "version": "6.0.1",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-yamux/-/libp2p-yamux-7.0.1.tgz",
+      "integrity": "sha512-949MI0Ll0AsYq1gUETZmL/MijwX0jilOQ1i4s8wDEXGiMhuPWWiMsPgEnX6n+VzFmTrfNYyGaaJj5/MqxV9y/g==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^1.0.0",
-        "@libp2p/utils": "^5.0.0",
+        "@libp2p/interface": "^2.0.0",
+        "@libp2p/utils": "^6.0.0",
         "get-iterator": "^2.0.1",
-        "it-foreach": "^2.0.3",
-        "it-pipe": "^3.0.1",
-        "it-pushable": "^3.2.0",
-        "uint8arraylist": "^2.4.3"
+        "it-foreach": "^2.0.6",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.1",
+        "uint8arraylist": "^2.4.8"
       }
     },
     "node_modules/@chainsafe/netmask": {
@@ -2400,145 +2383,154 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/@helia/delegated-routing-v1-http-api-client": {
-      "version": "1.1.2",
+    "node_modules/@helia/bitswap": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@helia/bitswap/-/bitswap-2.0.5.tgz",
+      "integrity": "sha512-LdvjagmArJ6d67yFKIxU+H29be+u8teP3yQzL8CLPU2J6uG66Pwh0Bb7bU+D1uUyUcfLS4TqDrRh1VKR+EghYw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^0.1.2",
-        "@libp2p/logger": "^3.0.2",
-        "@libp2p/peer-id": "^3.0.3",
-        "@multiformats/multiaddr": "^12.1.3",
+        "@helia/interface": "^5.2.1",
+        "@helia/utils": "^1.2.2",
+        "@libp2p/interface": "^2.2.1",
+        "@libp2p/logger": "^5.1.4",
+        "@libp2p/peer-collections": "^6.0.12",
+        "@libp2p/utils": "^6.2.1",
+        "@multiformats/multiaddr": "^12.3.3",
         "any-signal": "^4.1.1",
-        "browser-readablestream-to-it": "^2.0.3",
-        "ipns": "^7.0.1",
-        "it-first": "^3.0.3",
-        "it-map": "^3.0.4",
-        "it-ndjson": "^1.0.4",
-        "multiformats": "^12.1.1",
-        "p-defer": "^4.0.0",
-        "p-queue": "^7.3.4",
-        "uint8arrays": "^4.0.6"
+        "interface-blockstore": "^5.3.1",
+        "interface-store": "^6.0.2",
+        "it-drain": "^3.0.7",
+        "it-length-prefixed": "^10.0.1",
+        "it-length-prefixed-stream": "^1.2.0",
+        "it-map": "^3.1.1",
+        "it-pipe": "^3.0.1",
+        "it-take": "^3.0.6",
+        "multiformats": "^13.3.1",
+        "p-defer": "^4.0.1",
+        "progress-events": "^1.0.1",
+        "protons-runtime": "^5.5.0",
+        "race-event": "^1.3.0",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
       }
     },
-    "node_modules/@helia/delegated-routing-v1-http-api-client/node_modules/@libp2p/crypto": {
-      "version": "2.0.8",
+    "node_modules/@helia/bitswap/node_modules/it-byte-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/it-byte-stream/-/it-byte-stream-1.1.1.tgz",
+      "integrity": "sha512-OIOb8PvK9ZV7MHvyxIDNyN3jmrxrJdx99G0RIYYb3Tzo1OWv+O1C6mfg7nnlDuuTQz2POYFXe87AShKAEl+POw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^0.1.6",
-        "@noble/curves": "^1.1.0",
-        "@noble/hashes": "^1.3.1",
-        "multiformats": "^12.0.1",
-        "node-forge": "^1.1.0",
-        "protons-runtime": "^5.0.0",
-        "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^4.0.6"
+        "it-queueless-pushable": "^1.0.0",
+        "it-stream-types": "^2.0.2",
+        "uint8arraylist": "^2.4.8"
       }
     },
-    "node_modules/@helia/delegated-routing-v1-http-api-client/node_modules/@libp2p/interface": {
-      "version": "0.1.6",
+    "node_modules/@helia/bitswap/node_modules/it-length-prefixed-stream": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed-stream/-/it-length-prefixed-stream-1.2.1.tgz",
+      "integrity": "sha512-FYqlxc2toUoK+aPO5r3KDBIUG1mOvk2DzmjQcsfLUTHRWMJP4Va9855tVzg/22Bj+VUUaT7gxBg7HmbiCxTK4w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@multiformats/multiaddr": "^12.1.5",
-        "abortable-iterator": "^5.0.1",
-        "it-pushable": "^3.2.0",
-        "it-stream-types": "^2.0.1",
-        "multiformats": "^12.0.1",
-        "p-defer": "^4.0.0",
-        "race-signal": "^1.0.0",
-        "uint8arraylist": "^2.4.3"
+        "it-byte-stream": "^1.0.0",
+        "it-stream-types": "^2.0.2",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8"
       }
     },
-    "node_modules/@helia/delegated-routing-v1-http-api-client/node_modules/@libp2p/logger": {
-      "version": "3.1.0",
+    "node_modules/@helia/block-brokers": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@helia/block-brokers/-/block-brokers-4.1.0.tgz",
+      "integrity": "sha512-pzIhJeDLdF0VFkj9+LeLI6ZZORdH6/FwV7Q+IlIi2m5kAExqaYh8Oob6Dc7J5luu1atf69q4PWNIPYRiySmsmg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^0.1.6",
-        "@multiformats/multiaddr": "^12.1.5",
-        "debug": "^4.3.4",
-        "interface-datastore": "^8.2.0",
-        "multiformats": "^12.0.1"
+        "@helia/bitswap": "^2.0.5",
+        "@helia/interface": "^5.2.1",
+        "@helia/utils": "^1.2.2",
+        "@libp2p/interface": "^2.2.1",
+        "@libp2p/utils": "^6.2.1",
+        "@multiformats/multiaddr": "^12.3.3",
+        "@multiformats/multiaddr-matcher": "^1.6.0",
+        "@multiformats/multiaddr-to-uri": "^11.0.0",
+        "interface-blockstore": "^5.3.1",
+        "interface-store": "^6.0.2",
+        "multiformats": "^13.3.1",
+        "progress-events": "^1.0.1"
       }
     },
-    "node_modules/@helia/delegated-routing-v1-http-api-client/node_modules/@libp2p/peer-id": {
-      "version": "3.0.6",
+    "node_modules/@helia/delegated-routing-v1-http-api-client": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@helia/delegated-routing-v1-http-api-client/-/delegated-routing-v1-http-api-client-4.2.5.tgz",
+      "integrity": "sha512-fFqVhs7a4TnpKQ1cZ4im3tj53v+8UZLFkQo85otl/GpbIVBmBoGbjkDHGPv4UdjJ2lmYM/cRdnHsYbfjuc5pwA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^0.1.6",
-        "multiformats": "^12.0.1",
-        "uint8arrays": "^4.0.6"
-      }
-    },
-    "node_modules/@helia/delegated-routing-v1-http-api-client/node_modules/ipns": {
-      "version": "7.0.2",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@libp2p/crypto": "^2.0.3",
-        "@libp2p/interface": "^0.1.2",
-        "@libp2p/logger": "^3.0.2",
-        "@libp2p/peer-id": "^3.0.2",
-        "cborg": "^4.0.1",
-        "err-code": "^3.0.1",
-        "interface-datastore": "^8.1.0",
-        "multiformats": "^12.0.1",
-        "protons-runtime": "^5.0.0",
-        "timestamp-nano": "^1.0.0",
-        "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^5.0.1"
-      }
-    },
-    "node_modules/@helia/delegated-routing-v1-http-api-client/node_modules/ipns/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
-    "node_modules/@helia/delegated-routing-v1-http-api-client/node_modules/ipns/node_modules/uint8arrays/node_modules/multiformats": {
-      "version": "13.0.1",
-      "license": "Apache-2.0 OR MIT"
-    },
-    "node_modules/@helia/delegated-routing-v1-http-api-client/node_modules/multiformats": {
-      "version": "12.1.3",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@helia/delegated-routing-v1-http-api-client/node_modules/uint8arrays": {
-      "version": "4.0.10",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^12.0.1"
+        "@libp2p/interface": "^2.2.0",
+        "@libp2p/logger": "^5.0.1",
+        "@libp2p/peer-id": "^5.0.1",
+        "@multiformats/multiaddr": "^12.3.1",
+        "any-signal": "^4.1.1",
+        "browser-readablestream-to-it": "^2.0.7",
+        "ipns": "^10.0.0",
+        "it-first": "^3.0.6",
+        "it-map": "^3.1.1",
+        "it-ndjson": "^1.0.7",
+        "multiformats": "^13.3.0",
+        "p-defer": "^4.0.1",
+        "p-queue": "^8.0.1",
+        "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@helia/interface": {
-      "version": "3.0.0",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@helia/interface/-/interface-5.2.1.tgz",
+      "integrity": "sha512-8eH3wOoOAHqcux2erXOm33oFBtKdpfHclepzn28bBYEl5wXhrc9JFeo2X3SYJeE0o/jxq0L39BprkYjgSSC91Q==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^1.0.1",
-        "interface-blockstore": "^5.0.0",
-        "interface-datastore": "^8.0.0",
-        "interface-store": "^5.0.1",
-        "ipfs-bitswap": "^20.0.0",
-        "multiformats": "^13.0.0",
-        "progress-events": "^1.0.0"
+        "@libp2p/interface": "^2.2.1",
+        "@multiformats/dns": "^1.0.6",
+        "interface-blockstore": "^5.3.1",
+        "interface-datastore": "^8.3.1",
+        "interface-store": "^6.0.2",
+        "multiformats": "^13.3.1",
+        "progress-events": "^1.0.1"
       }
     },
     "node_modules/@helia/json": {
-      "version": "2.0.0",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@helia/json/-/json-4.0.3.tgz",
+      "integrity": "sha512-DjVNzIF4dqjUJqS5+lfoQKVEBGsklZVrerDnIp3g7CStJdzBuV+zPVpvLdLItGx+cMUV17dQKQYQ7afZhN3Pbw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@helia/interface": "^3.0.0",
-        "@libp2p/interfaces": "^3.3.1",
-        "multiformats": "^13.0.0",
-        "progress-events": "^1.0.0"
+        "@helia/interface": "^5.2.1",
+        "@libp2p/interface": "^2.2.1",
+        "interface-blockstore": "^5.3.1",
+        "multiformats": "^13.3.1",
+        "progress-events": "^1.0.1"
+      }
+    },
+    "node_modules/@helia/routers": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@helia/routers/-/routers-3.0.1.tgz",
+      "integrity": "sha512-Eshr/8XJU4c0H8s1m5oBFB2YM0n3HBbxB3ny8DbsRFS8cAQ/L8ujnQomniMjZuuOhcNz8EEGwkUc07HCtAqAFA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@helia/delegated-routing-v1-http-api-client": "^4.2.1",
+        "@helia/interface": "^5.2.1",
+        "@libp2p/interface": "^2.2.1",
+        "@libp2p/peer-id": "^5.0.8",
+        "@multiformats/uri-to-multiaddr": "^8.0.0",
+        "ipns": "^10.0.0",
+        "it-first": "^3.0.6",
+        "it-map": "^3.1.1",
+        "multiformats": "^13.3.1",
+        "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@helia/unixfs": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@helia/unixfs/-/unixfs-5.0.0.tgz",
       "integrity": "sha512-wIv9Zf4vM7UN2A7jNiOa5rOfO1Hl/9AarKSFQeV09I1NflclSSu6EHaiNcH1K6LBhRJ36/w2RHXE8DK3+DK8hw==",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@helia/interface": "^5.2.1",
         "@ipld/dag-pb": "^4.1.3",
@@ -2563,98 +2555,35 @@
         "uint8arrays": "^5.1.0"
       }
     },
-    "node_modules/@helia/unixfs/node_modules/@helia/interface": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@helia/interface/-/interface-5.2.1.tgz",
-      "integrity": "sha512-8eH3wOoOAHqcux2erXOm33oFBtKdpfHclepzn28bBYEl5wXhrc9JFeo2X3SYJeE0o/jxq0L39BprkYjgSSC91Q==",
+    "node_modules/@helia/utils": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@helia/utils/-/utils-1.2.2.tgz",
+      "integrity": "sha512-f8TC+gTQkMTVPaSDB8sSV+8W5/QIMX9XNWY2Xf0Y/WVzGm+Nz5o5wpVTT1kgBpILngXHSs4Xo+6aBQlafL15EA==",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^2.2.1",
+        "@helia/interface": "^5.2.1",
+        "@ipld/dag-cbor": "^9.2.2",
+        "@ipld/dag-json": "^10.2.3",
+        "@ipld/dag-pb": "^4.1.3",
+        "@libp2p/interface": "^2.5.0",
+        "@libp2p/logger": "^5.1.8",
+        "@libp2p/utils": "^6.5.1",
         "@multiformats/dns": "^1.0.6",
+        "any-signal": "^4.1.1",
+        "blockstore-core": "^5.0.2",
+        "cborg": "^4.2.6",
         "interface-blockstore": "^5.3.1",
         "interface-datastore": "^8.3.1",
         "interface-store": "^6.0.2",
-        "multiformats": "^13.3.1",
-        "progress-events": "^1.0.1"
-      }
-    },
-    "node_modules/@helia/unixfs/node_modules/@libp2p/crypto": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.0.15.tgz",
-      "integrity": "sha512-28xYMOn3fs8flsNgCVVxp27gEmDTtZHbz+qEVv3v7cWfGRipaVhNXFV9tQJHWXHQ8mN8v/PQvgcfCcWu5jkrTg==",
-      "dependencies": {
-        "@libp2p/interface": "^2.7.0",
-        "@noble/curves": "^1.7.0",
-        "@noble/hashes": "^1.6.1",
-        "multiformats": "^13.3.1",
-        "protons-runtime": "^5.5.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.1.0"
-      }
-    },
-    "node_modules/@helia/unixfs/node_modules/@libp2p/interface": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-2.7.0.tgz",
-      "integrity": "sha512-lWmfIGzbSaw//yoEWWJh8dXNDGSCwUyXwC7P1Q6jCFWNoEtCaB1pvwOGBtri7Db/aNFZryMzN5covoq5ulldnA==",
-      "dependencies": {
-        "@multiformats/multiaddr": "^12.3.3",
-        "it-pushable": "^3.2.3",
-        "it-stream-types": "^2.0.2",
-        "multiformats": "^13.3.1",
-        "progress-events": "^1.0.1",
-        "uint8arraylist": "^2.4.8"
-      }
-    },
-    "node_modules/@helia/unixfs/node_modules/@libp2p/logger": {
-      "version": "5.1.13",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-5.1.13.tgz",
-      "integrity": "sha512-JKyMlySG8T+LpItsj9Vma57yap/A0HqJ8ZdaHvgdoThhSOfqcRs8oRWO/2EG0Q5hUXugw//EAT+Ptj8MyNdbjQ==",
-      "dependencies": {
-        "@libp2p/interface": "^2.7.0",
-        "@multiformats/multiaddr": "^12.3.3",
-        "interface-datastore": "^8.3.1",
-        "multiformats": "^13.3.1",
-        "weald": "^1.0.4"
-      }
-    },
-    "node_modules/@helia/unixfs/node_modules/@libp2p/utils": {
-      "version": "6.6.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-6.6.0.tgz",
-      "integrity": "sha512-QjS1+r+jInOxULjdATBc1N/gorUWUoJqEKxpqTcB2wOwCipzB58RYR3n3QPeoRHj1mVMhZujE1dTbmK/Nafhqg==",
-      "dependencies": {
-        "@chainsafe/is-ip": "^2.0.2",
-        "@chainsafe/netmask": "^2.0.0",
-        "@libp2p/crypto": "^5.0.15",
-        "@libp2p/interface": "^2.7.0",
-        "@libp2p/logger": "^5.1.13",
-        "@multiformats/multiaddr": "^12.3.3",
-        "@sindresorhus/fnv1a": "^3.1.0",
-        "any-signal": "^4.1.1",
-        "delay": "^6.0.0",
-        "get-iterator": "^2.0.1",
-        "is-loopback-addr": "^2.0.2",
+        "it-drain": "^3.0.7",
+        "it-filter": "^3.1.1",
         "it-foreach": "^2.1.1",
-        "it-pipe": "^3.0.1",
-        "it-pushable": "^3.2.3",
-        "it-stream-types": "^2.0.2",
-        "netmask": "^2.0.2",
+        "it-merge": "^3.0.5",
+        "mortice": "^3.0.6",
+        "multiformats": "^13.3.1",
         "p-defer": "^4.0.1",
-        "race-event": "^1.3.0",
-        "race-signal": "^1.1.2",
-        "uint8arraylist": "^2.4.8",
+        "progress-events": "^1.0.1",
         "uint8arrays": "^5.1.0"
-      }
-    },
-    "node_modules/@helia/unixfs/node_modules/interface-store": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-6.0.2.tgz",
-      "integrity": "sha512-KSFCXtBlNoG0hzwNa0RmhHtrdhzexp+S+UY2s0rWTBJyfdEIgn6i6Zl9otVqrcFYbYrneBT7hbmHQ8gE0C3umA=="
-    },
-    "node_modules/@helia/unixfs/node_modules/uint8arrays": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
-      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
-      "dependencies": {
-        "multiformats": "^13.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3072,10 +3001,48 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@ipshipyard/libp2p-auto-tls": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@ipshipyard/libp2p-auto-tls/-/libp2p-auto-tls-1.0.0.tgz",
+      "integrity": "sha512-wV1smnqbg3xUCHmPB8KWFuP8G9MKlx8KDuiJvhCWPi7B03xJq2FMybMDPI8tM9boa9sHD+5+NFu+Teo3Lz76fw==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.2",
+        "@libp2p/crypto": "^5.0.9",
+        "@libp2p/http-fetch": "^2.1.0",
+        "@libp2p/interface": "^2.4.0",
+        "@libp2p/interface-internal": "^2.2.2",
+        "@libp2p/keychain": "^5.0.12",
+        "@libp2p/utils": "^6.3.1",
+        "@multiformats/multiaddr": "^12.3.3",
+        "@multiformats/multiaddr-matcher": "^1.6.0",
+        "@peculiar/x509": "^1.12.3",
+        "acme-client": "^5.4.0",
+        "any-signal": "^4.1.1",
+        "delay": "^6.0.0",
+        "interface-datastore": "^8.3.1",
+        "multiformats": "^13.3.1",
+        "uint8arrays": "^5.1.0"
+      }
+    },
+    "node_modules/@ipshipyard/node-datachannel": {
+      "version": "0.26.6",
+      "resolved": "https://registry.npmjs.org/@ipshipyard/node-datachannel/-/node-datachannel-0.26.6.tgz",
+      "integrity": "sha512-70HdhYMyAGXEMuCUq9ATO1Rx/JmiENM5LrGN94KT/q/Et2VsMjJpOWbyFzgodtkQJjDG5saNXTOiQpYZ1AnvEg==",
+      "hasInstallScript": true,
+      "license": "MPL 2.0",
+      "dependencies": {
+        "prebuild-install": "^7.1.3"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
     "node_modules/@isaacs/ttlcache": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
       "integrity": "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA==",
+      "license": "ISC",
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -3180,6 +3147,8 @@
     },
     "node_modules/@jest/create-cache-key-function": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
+      "integrity": "sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -3435,6 +3404,7 @@
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
       "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -3464,571 +3434,561 @@
       "license": "MIT"
     },
     "node_modules/@libp2p/autonat": {
-      "version": "1.0.7",
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/@libp2p/autonat/-/autonat-2.0.30.tgz",
+      "integrity": "sha512-IDFZHKiENZw35ejKr6gj8D9tMZe5hRNPapa0qwuClK2Ca3v7ihNktEUWD3hb+Wn4dBCZepqXCZtJWtu2pJSrGQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/interface-internal": "^1.0.5",
-        "@libp2p/peer-id": "^4.0.4",
-        "@libp2p/peer-id-factory": "^4.0.3",
-        "@multiformats/multiaddr": "^12.1.10",
-        "it-first": "^3.0.3",
-        "it-length-prefixed": "^9.0.3",
-        "it-map": "^3.0.4",
-        "it-parallel": "^3.0.0",
-        "it-pipe": "^3.0.1",
-        "private-ip": "^3.0.1",
-        "protons-runtime": "^5.0.0",
-        "uint8arraylist": "^2.4.3"
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/interface-internal": "^2.3.11",
+        "@libp2p/peer-collections": "^6.0.27",
+        "@libp2p/peer-id": "^5.1.2",
+        "@libp2p/utils": "^6.6.2",
+        "@multiformats/multiaddr": "^12.3.3",
+        "any-signal": "^4.1.1",
+        "it-protobuf-stream": "^2.0.1",
+        "multiformats": "^13.3.1",
+        "protons-runtime": "^5.5.0",
+        "uint8arraylist": "^2.4.8"
       }
     },
     "node_modules/@libp2p/bootstrap": {
-      "version": "10.0.10",
+      "version": "11.0.35",
+      "resolved": "https://registry.npmjs.org/@libp2p/bootstrap/-/bootstrap-11.0.35.tgz",
+      "integrity": "sha512-fv9PNsWTrsGQmRqMv31scB2F/wr2NXgwrTUvtxaxZPJBLN2YVa3HksUP5vh/A8gRedrFsWcpXFGcwY4rO3W8FA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/peer-id": "^4.0.4",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/interface-internal": "^2.3.11",
+        "@libp2p/peer-id": "^5.1.2",
         "@multiformats/mafmt": "^12.1.6",
-        "@multiformats/multiaddr": "^12.1.10"
+        "@multiformats/multiaddr": "^12.3.3"
       }
     },
     "node_modules/@libp2p/circuit-relay-v2": {
-      "version": "1.0.10",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/circuit-relay-v2/-/circuit-relay-v2-3.2.11.tgz",
+      "integrity": "sha512-cSIYAupIDy/nDWc69FYvJp1fbLZaq3CycPzv1bl0lVDySvoVU6MsgOCXn+M8nKcuEXZrmuJGu28hAuor3noNfQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/interface-internal": "^1.0.5",
-        "@libp2p/peer-collections": "^5.1.3",
-        "@libp2p/peer-id": "^4.0.4",
-        "@libp2p/peer-record": "^7.0.4",
-        "@libp2p/utils": "^5.2.0",
-        "@multiformats/mafmt": "^12.1.6",
-        "@multiformats/multiaddr": "^12.1.10",
+        "@libp2p/crypto": "^5.1.1",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/interface-internal": "^2.3.11",
+        "@libp2p/peer-collections": "^6.0.27",
+        "@libp2p/peer-id": "^5.1.2",
+        "@libp2p/peer-record": "^8.0.27",
+        "@libp2p/utils": "^6.6.2",
+        "@multiformats/multiaddr": "^12.3.3",
+        "@multiformats/multiaddr-matcher": "^1.6.0",
         "any-signal": "^4.1.1",
-        "it-protobuf-stream": "^1.0.2",
-        "it-stream-types": "^2.0.1",
-        "multiformats": "^13.0.0",
-        "p-defer": "^4.0.0",
-        "p-retry": "^6.1.0",
-        "protons-runtime": "^5.0.0",
-        "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^5.0.0"
+        "it-protobuf-stream": "^2.0.1",
+        "it-stream-types": "^2.0.2",
+        "multiformats": "^13.3.1",
+        "nanoid": "^5.0.9",
+        "progress-events": "^1.0.1",
+        "protons-runtime": "^5.5.0",
+        "retimeable-signal": "^1.0.0",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
       }
     },
-    "node_modules/@libp2p/circuit-relay-v2/node_modules/uint8arrays": {
-      "version": "5.0.1",
+    "node_modules/@libp2p/config": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/config/-/config-1.1.6.tgz",
+      "integrity": "sha512-vFS1mKkyZR+OsGk29rus/Hvzbqup+Eqd+F0kHb32QWl/fbTscnkA9xXcctgH/LI+jS6dEjU/7we5hd3aIm9Avw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "multiformats": "^13.0.0"
+        "@libp2p/crypto": "^5.1.1",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/keychain": "^5.2.1",
+        "@libp2p/logger": "^5.1.15",
+        "interface-datastore": "^8.3.1"
       }
     },
     "node_modules/@libp2p/crypto": {
-      "version": "3.0.4",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.1.1.tgz",
+      "integrity": "sha512-feByJ5ypBfl7Dp+jLBmieHDY/249hqCiDn8u6DNSZrpDhefn2l/NE03fS2mW6pLOnY3QIqB372TfLtx3/EPU+w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^1.1.1",
-        "@noble/curves": "^1.1.0",
-        "@noble/hashes": "^1.3.1",
-        "multiformats": "^13.0.0",
-        "node-forge": "^1.1.0",
-        "protons-runtime": "^5.0.0",
-        "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/@libp2p/crypto/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
+        "@libp2p/interface": "^2.9.0",
+        "@noble/curves": "^1.7.0",
+        "@noble/hashes": "^1.6.1",
+        "multiformats": "^13.3.1",
+        "protons-runtime": "^5.5.0",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/dcutr": {
-      "version": "1.0.7",
+      "version": "2.0.29",
+      "resolved": "https://registry.npmjs.org/@libp2p/dcutr/-/dcutr-2.0.29.tgz",
+      "integrity": "sha512-xL7HixS3C9a92DI4VOw/KOKvWrgEAEYUt1zraTt56uR5Uk4SefZl84+xeukv4Rjup55Yk7UkP0df6E4jWKH4cQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/interface-internal": "^1.0.5",
-        "@multiformats/multiaddr": "^12.1.10",
-        "@multiformats/multiaddr-matcher": "^1.1.0",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/interface-internal": "^2.3.11",
+        "@libp2p/utils": "^6.6.2",
+        "@multiformats/multiaddr": "^12.3.3",
+        "@multiformats/multiaddr-matcher": "^1.6.0",
         "delay": "^6.0.0",
-        "it-protobuf-stream": "^1.0.2",
-        "private-ip": "^3.0.1",
-        "protons-runtime": "^5.0.0",
-        "uint8arraylist": "^2.4.3"
+        "it-protobuf-stream": "^2.0.1",
+        "protons-runtime": "^5.5.0",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/@libp2p/http-fetch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/http-fetch/-/http-fetch-2.2.2.tgz",
+      "integrity": "sha512-dMPo2pe2h/AHAljgwDEErdiB8JbiJM5b0LzuF/Yq4HcplfJZf33VtzUHN1n8x+3K+F8fntWUKN30SwSisSoVaw==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@achingbrain/http-parser-js": "^0.5.8",
+        "@libp2p/crypto": "^5.0.6",
+        "@libp2p/interface": "^2.2.0",
+        "@libp2p/interface-internal": "^2.0.10",
+        "@libp2p/peer-id": "^5.0.7",
+        "@multiformats/multiaddr": "^12.3.0",
+        "@multiformats/multiaddr-to-uri": "^11.0.0",
+        "http-cookie-agent": "^6.0.7",
+        "p-defer": "^4.0.1",
+        "tough-cookie": "^5.0.0",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0",
+        "undici": "^6.21.0"
       }
     },
     "node_modules/@libp2p/identify": {
-      "version": "1.0.9",
+      "version": "3.0.29",
+      "resolved": "https://registry.npmjs.org/@libp2p/identify/-/identify-3.0.29.tgz",
+      "integrity": "sha512-yhprl9F0G28lTyDyZdy8/0B4cJOmeffgXLCJSivVzR2kQo9mWwjX0Aj4E/3XnEu1d9b38ipL6TfQySjpBOUy+w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/interface-internal": "^1.0.5",
-        "@libp2p/peer-id": "^4.0.4",
-        "@libp2p/peer-record": "^7.0.4",
-        "@multiformats/multiaddr": "^12.1.10",
-        "@multiformats/multiaddr-matcher": "^1.1.0",
-        "it-protobuf-stream": "^1.0.2",
-        "protons-runtime": "^5.0.0",
-        "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^5.0.0",
-        "wherearewe": "^2.0.1"
-      }
-    },
-    "node_modules/@libp2p/identify/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
+        "@libp2p/crypto": "^5.1.1",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/interface-internal": "^2.3.11",
+        "@libp2p/peer-id": "^5.1.2",
+        "@libp2p/peer-record": "^8.0.27",
+        "@libp2p/utils": "^6.6.2",
+        "@multiformats/multiaddr": "^12.3.3",
+        "@multiformats/multiaddr-matcher": "^1.6.0",
+        "it-drain": "^3.0.7",
+        "it-parallel": "^3.0.8",
+        "it-protobuf-stream": "^2.0.1",
+        "protons-runtime": "^5.5.0",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/interface": {
-      "version": "1.1.1",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-2.9.0.tgz",
+      "integrity": "sha512-L/0Z5H0mjaECA0jkZG+OJmEhB/OIJ07gzZYljU7C19XjL3dSkBvhA9il+G3FpHyHgqAOVGuQU5qkbv2Edj8FIA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@multiformats/multiaddr": "^12.1.10",
-        "it-pushable": "^3.2.1",
-        "it-stream-types": "^2.0.1",
-        "multiformats": "^13.0.0",
-        "progress-events": "^1.0.0",
-        "uint8arraylist": "^2.4.3"
+        "@multiformats/multiaddr": "^12.3.3",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.2",
+        "multiformats": "^13.3.1",
+        "progress-events": "^1.0.1",
+        "uint8arraylist": "^2.4.8"
       }
     },
     "node_modules/@libp2p/interface-internal": {
-      "version": "1.0.5",
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-2.3.11.tgz",
+      "integrity": "sha512-/7GMkn8F9ojFgUmgkiyP0LeVQ4AKinyn2PdFCPOzQszcN3rVHOi6mtZYXNsGjftoP3QZQ4udadbytzGE3pmVYA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/peer-collections": "^5.1.3",
-        "@multiformats/multiaddr": "^12.1.10",
-        "uint8arraylist": "^2.4.3"
-      }
-    },
-    "node_modules/@libp2p/interfaces": {
-      "version": "3.3.2",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/peer-collections": "^6.0.27",
+        "@multiformats/multiaddr": "^12.3.3",
+        "progress-events": "^1.0.1"
       }
     },
     "node_modules/@libp2p/kad-dht": {
-      "version": "12.0.2",
+      "version": "14.2.15",
+      "resolved": "https://registry.npmjs.org/@libp2p/kad-dht/-/kad-dht-14.2.15.tgz",
+      "integrity": "sha512-iARZsaKrm9LlOE0nRTsqMasYGfWbh+zw1TAMWOY/QHTszFGb9ol7FZoI9WUzoif9ltKLu3BjJpy00b8CVofCBw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^3.0.4",
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/interface-internal": "^1.0.5",
-        "@libp2p/peer-collections": "^5.1.3",
-        "@libp2p/peer-id": "^4.0.4",
-        "@libp2p/utils": "^5.2.0",
-        "@multiformats/multiaddr": "^12.1.10",
-        "@types/sinon": "^17.0.0",
+        "@libp2p/crypto": "^5.0.15",
+        "@libp2p/interface": "^2.7.0",
+        "@libp2p/interface-internal": "^2.3.9",
+        "@libp2p/peer-collections": "^6.0.25",
+        "@libp2p/peer-id": "^5.1.0",
+        "@libp2p/record": "^4.0.5",
+        "@libp2p/utils": "^6.6.0",
+        "@multiformats/multiaddr": "^12.3.3",
         "any-signal": "^4.1.1",
-        "hashlru": "^2.3.0",
-        "interface-datastore": "^8.2.0",
-        "it-drain": "^3.0.2",
-        "it-length": "^3.0.1",
-        "it-length-prefixed": "^9.0.3",
-        "it-map": "^3.0.4",
-        "it-merge": "^3.0.0",
-        "it-parallel": "^3.0.0",
+        "interface-datastore": "^8.3.1",
+        "it-all": "^3.0.6",
+        "it-drain": "^3.0.7",
+        "it-length": "^3.0.6",
+        "it-length-prefixed": "^10.0.1",
+        "it-map": "^3.1.1",
+        "it-merge": "^3.0.5",
+        "it-parallel": "^3.0.8",
         "it-pipe": "^3.0.1",
-        "it-protobuf-stream": "^1.0.2",
-        "it-pushable": "^3.2.1",
-        "it-take": "^3.0.1",
-        "multiformats": "^13.0.0",
-        "p-defer": "^4.0.0",
-        "p-event": "^6.0.0",
-        "p-queue": "^8.0.0",
-        "private-ip": "^3.0.1",
-        "progress-events": "^1.0.0",
-        "protons-runtime": "^5.0.0",
-        "race-signal": "^1.0.2",
-        "uint8-varint": "^2.0.0",
-        "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^5.0.0"
+        "it-protobuf-stream": "^1.1.5",
+        "it-take": "^3.0.6",
+        "mortice": "^3.0.6",
+        "multiformats": "^13.3.1",
+        "p-defer": "^4.0.1",
+        "p-event": "^6.0.1",
+        "progress-events": "^1.0.1",
+        "protons-runtime": "^5.5.0",
+        "race-signal": "^1.1.2",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
       }
     },
-    "node_modules/@libp2p/kad-dht/node_modules/p-queue": {
-      "version": "8.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "p-timeout": "^6.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@libp2p/kad-dht/node_modules/uint8arrays": {
-      "version": "5.0.1",
+    "node_modules/@libp2p/kad-dht/node_modules/it-byte-stream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/it-byte-stream/-/it-byte-stream-1.1.1.tgz",
+      "integrity": "sha512-OIOb8PvK9ZV7MHvyxIDNyN3jmrxrJdx99G0RIYYb3Tzo1OWv+O1C6mfg7nnlDuuTQz2POYFXe87AShKAEl+POw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "multiformats": "^13.0.0"
+        "it-queueless-pushable": "^1.0.0",
+        "it-stream-types": "^2.0.2",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/it-length-prefixed-stream": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed-stream/-/it-length-prefixed-stream-1.2.1.tgz",
+      "integrity": "sha512-FYqlxc2toUoK+aPO5r3KDBIUG1mOvk2DzmjQcsfLUTHRWMJP4Va9855tVzg/22Bj+VUUaT7gxBg7HmbiCxTK4w==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "it-byte-stream": "^1.0.0",
+        "it-stream-types": "^2.0.2",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/@libp2p/kad-dht/node_modules/it-protobuf-stream": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/it-protobuf-stream/-/it-protobuf-stream-1.1.6.tgz",
+      "integrity": "sha512-TxqgDHXTBt1XkYhrGKP8ubNsYD4zuTClSg6S1M0xTPsskGKA4nPFOGM60zrkh4NMB1Wt3EnsqM5U7kXkx60EXQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "it-length-prefixed-stream": "^1.0.0",
+        "it-stream-types": "^2.0.2",
+        "uint8arraylist": "^2.4.8"
       }
     },
     "node_modules/@libp2p/keychain": {
-      "version": "4.0.5",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/keychain/-/keychain-5.2.1.tgz",
+      "integrity": "sha512-yIYtGUaWUlZ6z+g5dIPa2+xkzFVfouTujIuTChTEUqahEty3a4sQmWs+Ewk/GTTDk29Gfi0/VHpx178ob5A5XA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^3.0.4",
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/peer-id": "^4.0.4",
-        "interface-datastore": "^8.2.0",
+        "@libp2p/crypto": "^5.1.1",
+        "@libp2p/interface": "^2.9.0",
+        "@noble/hashes": "^1.6.1",
+        "asn1js": "^3.0.5",
+        "interface-datastore": "^8.3.1",
         "merge-options": "^3.0.4",
-        "multiformats": "^13.0.0",
+        "multiformats": "^13.3.1",
         "sanitize-filename": "^1.6.3",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/@libp2p/keychain/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
+        "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/logger": {
-      "version": "4.0.4",
+      "version": "5.1.15",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-5.1.15.tgz",
+      "integrity": "sha512-0+rOHEXXDNZvsb9p04jVAFQB0WcvMxFfqzSe271/tg4yVlPF5H99l5BwOqeb+EYhHV1lTk+zrJdPK9easHr1fQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^1.1.1",
-        "@multiformats/multiaddr": "^12.1.10",
-        "debug": "^4.3.4",
-        "interface-datastore": "^8.2.0",
-        "multiformats": "^13.0.0"
+        "@libp2p/interface": "^2.9.0",
+        "@multiformats/multiaddr": "^12.3.3",
+        "interface-datastore": "^8.3.1",
+        "multiformats": "^13.3.1",
+        "weald": "^1.0.4"
       }
     },
     "node_modules/@libp2p/mdns": {
-      "version": "10.0.10",
+      "version": "11.0.35",
+      "resolved": "https://registry.npmjs.org/@libp2p/mdns/-/mdns-11.0.35.tgz",
+      "integrity": "sha512-7jbPYXVoMrREELzD87OQZzpsAXdglgYuMUCxDfshmu0NPIiPVUZBoPMFpj5IuqIUsAxT32IuHIbv9VnkXB0QmQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/interface-internal": "^1.0.5",
-        "@libp2p/peer-id": "^4.0.4",
-        "@libp2p/utils": "^5.2.0",
-        "@multiformats/multiaddr": "^12.1.10",
-        "@types/multicast-dns": "^7.2.1",
-        "dns-packet": "^5.4.0",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/interface-internal": "^2.3.11",
+        "@libp2p/peer-id": "^5.1.2",
+        "@libp2p/utils": "^6.6.2",
+        "@multiformats/multiaddr": "^12.3.3",
+        "@types/multicast-dns": "^7.2.4",
+        "dns-packet": "^5.6.1",
         "multicast-dns": "^7.2.5"
       }
     },
     "node_modules/@libp2p/mplex": {
-      "version": "10.0.10",
+      "version": "11.0.35",
+      "resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-11.0.35.tgz",
+      "integrity": "sha512-aOG/uBiAE1eRwhtZlow1LvxSREbQW9LBTGzUVtVYHBPVl+tNv/hzjAEssVEMnA8y2ckMDM3G+sCpoCAsaYzNow==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/utils": "^5.2.0",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/utils": "^6.6.2",
         "it-pipe": "^3.0.1",
-        "it-pushable": "^3.2.1",
-        "it-stream-types": "^2.0.1",
-        "rate-limiter-flexible": "^4.0.0",
-        "uint8-varint": "^2.0.0",
-        "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/@libp2p/mplex/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.2",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/multistream-select": {
-      "version": "5.1.1",
+      "version": "6.0.22",
+      "resolved": "https://registry.npmjs.org/@libp2p/multistream-select/-/multistream-select-6.0.22.tgz",
+      "integrity": "sha512-SCSnLKNvqulYYN52mG/b5INGlmj3rMAxtH9zVb1e9rq5WflJu7CGaV8CJsxOjRoJ7YqPgx1meywkeG989OdwDA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^1.1.1",
-        "it-length-prefixed": "^9.0.3",
-        "it-length-prefixed-stream": "^1.1.1",
-        "it-stream-types": "^2.0.1",
-        "p-defer": "^4.0.0",
-        "race-signal": "^1.0.2",
-        "uint8-varint": "^2.0.2",
-        "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/@libp2p/multistream-select/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
+        "@libp2p/interface": "^2.9.0",
+        "it-length-prefixed": "^10.0.1",
+        "it-length-prefixed-stream": "^2.0.1",
+        "it-stream-types": "^2.0.2",
+        "p-defer": "^4.0.1",
+        "race-signal": "^1.1.2",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/peer-collections": {
-      "version": "5.1.3",
+      "version": "6.0.27",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-6.0.27.tgz",
+      "integrity": "sha512-JLA7N9OgcxfxnSU3IpZ1DLXHCW64VH/WgJm/lFtPXjIfknO0hU2feerdB2sz/QBAAmehJHqBBSlao57BKo7KLg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/peer-id": "^4.0.4"
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/peer-id": "^5.1.2",
+        "@libp2p/utils": "^6.6.2",
+        "multiformats": "^13.3.1"
       }
     },
     "node_modules/@libp2p/peer-id": {
-      "version": "4.0.4",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-5.1.2.tgz",
+      "integrity": "sha512-K4tjLi+OIHJSeMMqw28xnBxDfklfWCsR423Jm6GxZ5avIj2xm7WIq5oUhCntGGDIQWW/8qdf8v3tYK36JxwLOA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^1.1.1",
-        "multiformats": "^13.0.0",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-id-factory": {
-      "version": "4.0.3",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@libp2p/crypto": "^3.0.4",
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/peer-id": "^4.0.4",
-        "protons-runtime": "^5.0.0",
-        "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-id-factory/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-id/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
+        "@libp2p/crypto": "^5.1.1",
+        "@libp2p/interface": "^2.9.0",
+        "multiformats": "^13.3.1",
+        "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/peer-record": {
-      "version": "7.0.4",
+      "version": "8.0.27",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-8.0.27.tgz",
+      "integrity": "sha512-F2sWv0++WrHRuEYtqqvFOa+748rCekQuEBj9OKvDCxS3gtQeEgVLfsNAvM/vRPN0Lx3m4OF44tui2KpV7NU6jA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^3.0.4",
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/peer-id": "^4.0.4",
-        "@libp2p/utils": "^5.2.0",
-        "@multiformats/multiaddr": "^12.1.10",
-        "protons-runtime": "^5.0.0",
-        "uint8-varint": "^2.0.0",
-        "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-record/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
+        "@libp2p/crypto": "^5.1.1",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/peer-id": "^5.1.2",
+        "@libp2p/utils": "^6.6.2",
+        "@multiformats/multiaddr": "^12.3.3",
+        "multiformats": "^13.3.1",
+        "protons-runtime": "^5.5.0",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/peer-store": {
-      "version": "10.0.5",
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-store/-/peer-store-11.1.4.tgz",
+      "integrity": "sha512-KUfY0GJLUUYrPGLsiGRWliNNFPGlC0bY4BE25jhp1MEsjrimkTl6TcksqCQ8SzR0Cn4HMRRPJs4H2AzdaQexZA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/peer-collections": "^5.1.3",
-        "@libp2p/peer-id": "^4.0.4",
-        "@libp2p/peer-record": "^7.0.4",
-        "@multiformats/multiaddr": "^12.1.10",
-        "interface-datastore": "^8.2.0",
-        "it-all": "^3.0.2",
-        "mortice": "^3.0.1",
-        "multiformats": "^13.0.0",
-        "protons-runtime": "^5.0.0",
-        "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/@libp2p/peer-store/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
+        "@libp2p/crypto": "^5.1.1",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/peer-id": "^5.1.2",
+        "@libp2p/peer-record": "^8.0.27",
+        "@multiformats/multiaddr": "^12.3.3",
+        "interface-datastore": "^8.3.1",
+        "it-all": "^3.0.6",
+        "mortice": "^3.0.6",
+        "multiformats": "^13.3.1",
+        "protons-runtime": "^5.5.0",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/ping": {
-      "version": "1.0.8",
+      "version": "2.0.29",
+      "resolved": "https://registry.npmjs.org/@libp2p/ping/-/ping-2.0.29.tgz",
+      "integrity": "sha512-0iZOtdm7tM2NAZ06Tgh9avPMUO2xavaUH7HNXBHCG13FCiKLjPKpjKOcic47jOI2RGPQ9Fv5MNr/3OCl29bZKA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^3.0.4",
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/interface-internal": "^1.0.5",
-        "@multiformats/multiaddr": "^12.1.10",
-        "it-first": "^3.0.3",
-        "it-pipe": "^3.0.1",
-        "uint8arrays": "^5.0.0"
+        "@libp2p/crypto": "^5.1.1",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/interface-internal": "^2.3.11",
+        "@multiformats/multiaddr": "^12.3.3",
+        "it-byte-stream": "^2.0.1",
+        "uint8arrays": "^5.1.0"
       }
     },
-    "node_modules/@libp2p/ping/node_modules/uint8arrays": {
-      "version": "5.0.1",
+    "node_modules/@libp2p/record": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@libp2p/record/-/record-4.0.5.tgz",
+      "integrity": "sha512-HfKugY+ZKizhxE/hbLqI8zcFLfYly2gakaL0k8wBXCfmOTrAV7UajeJWkWqrKkIEMHASUyapm746KF+i9e7Xmw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
-    "node_modules/@libp2p/pubsub": {
-      "version": "9.0.5",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@libp2p/crypto": "^3.0.4",
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/interface-internal": "^1.0.5",
-        "@libp2p/peer-collections": "^5.1.3",
-        "@libp2p/peer-id": "^4.0.4",
-        "@libp2p/utils": "^5.2.0",
-        "it-length-prefixed": "^9.0.3",
-        "it-pipe": "^3.0.1",
-        "it-pushable": "^3.2.1",
-        "multiformats": "^13.0.0",
-        "p-queue": "^8.0.0",
-        "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/@libp2p/pubsub/node_modules/p-queue": {
-      "version": "8.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "p-timeout": "^6.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@libp2p/pubsub/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
+        "protons-runtime": "^5.5.0",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/tcp": {
-      "version": "9.0.10",
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/tcp/-/tcp-10.1.10.tgz",
+      "integrity": "sha512-OpzojfJQgg8Cy9g/c/OqI2y5M58stvpbEqh+zWdgLn6J7iJaIigL5M3Hls6Fn7KZtxshfqaKDIrD/x/Le8+A8w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/utils": "^5.2.0",
-        "@multiformats/mafmt": "^12.1.6",
-        "@multiformats/multiaddr": "^12.1.10",
-        "@types/sinon": "^17.0.0",
-        "stream-to-it": "^0.2.2"
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/utils": "^6.6.2",
+        "@multiformats/multiaddr": "^12.3.3",
+        "@multiformats/multiaddr-matcher": "^1.6.0",
+        "@types/sinon": "^17.0.3",
+        "p-defer": "^4.0.1",
+        "p-event": "^6.0.1",
+        "progress-events": "^1.0.1",
+        "race-event": "^1.3.0",
+        "stream-to-it": "^1.0.1"
+      }
+    },
+    "node_modules/@libp2p/tls": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/tls/-/tls-2.2.0.tgz",
+      "integrity": "sha512-voFfELej1sKVgA9X8zz1aH2Xz3WSn2YyoBCGDFPFQf/1xVhRsTn0nPgu9RK393yq/W2NuEXQWosc41ChSGOYHg==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@libp2p/crypto": "^5.1.1",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/peer-id": "^5.1.2",
+        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/asn1-x509": "^2.3.13",
+        "@peculiar/webcrypto": "^1.5.0",
+        "@peculiar/x509": "^1.12.3",
+        "asn1js": "^3.0.5",
+        "it-queueless-pushable": "^1.0.2",
+        "it-stream-types": "^2.0.2",
+        "protons-runtime": "^5.5.0",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/upnp-nat": {
-      "version": "1.0.8",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/@libp2p/upnp-nat/-/upnp-nat-3.1.13.tgz",
+      "integrity": "sha512-y/ROYY+CNi2TCcNYF/ed2rriwxtL2ZHeiINJ3cPg4b1EmQhg6A/VHA9mQyGFjd+g5ADqitDdd++6majjuat+bQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@achingbrain/nat-port-mapper": "^1.0.12",
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/interface-internal": "^1.0.5",
-        "@libp2p/utils": "^5.2.0",
-        "@multiformats/multiaddr": "^12.1.10",
-        "private-ip": "^3.0.1",
-        "wherearewe": "^2.0.1"
+        "@achingbrain/nat-port-mapper": "^4.0.0",
+        "@chainsafe/is-ip": "^2.0.2",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/interface-internal": "^2.3.11",
+        "@libp2p/utils": "^6.6.2",
+        "@multiformats/multiaddr": "^12.3.3",
+        "@multiformats/multiaddr-matcher": "^1.6.0",
+        "p-defer": "^4.0.1",
+        "race-signal": "^1.1.2"
       }
     },
     "node_modules/@libp2p/utils": {
-      "version": "5.2.0",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-6.6.2.tgz",
+      "integrity": "sha512-PjbKA0+l+8mmM7quOnG0D7XKdlF/3Hi5Aco3D0ZQXW68QnzmjEEeTbky1gzrZUgnMBmb2ZYrBlZd0GpsJ7Rc9Q==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.2",
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/logger": "^4.0.4",
-        "@multiformats/multiaddr": "^12.1.10",
-        "@multiformats/multiaddr-matcher": "^1.1.0",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/crypto": "^5.1.1",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/logger": "^5.1.15",
+        "@multiformats/multiaddr": "^12.3.3",
+        "@sindresorhus/fnv1a": "^3.1.0",
+        "any-signal": "^4.1.1",
+        "delay": "^6.0.0",
         "get-iterator": "^2.0.1",
-        "is-loopback-addr": "^2.0.1",
-        "it-pushable": "^3.2.2",
-        "it-stream-types": "^2.0.1",
-        "p-defer": "^4.0.0",
-        "private-ip": "^3.0.1",
-        "race-event": "^1.1.0",
-        "race-signal": "^1.0.1",
-        "uint8arraylist": "^2.4.3"
+        "is-loopback-addr": "^2.0.2",
+        "it-foreach": "^2.1.1",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.2",
+        "netmask": "^2.0.2",
+        "p-defer": "^4.0.1",
+        "race-event": "^1.3.0",
+        "race-signal": "^1.1.2",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/webrtc": {
-      "version": "4.0.14",
+      "version": "5.2.12",
+      "resolved": "https://registry.npmjs.org/@libp2p/webrtc/-/webrtc-5.2.12.tgz",
+      "integrity": "sha512-ObmCeK28PmN1vqgJ52YPNHfMFrTWBlXEGAXzJlgMuuvJ4Y94of7Ej1kZWhsfGWyfrhELEcFtioPCzeaSdbeB7A==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@chainsafe/libp2p-noise": "^14.0.0",
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/interface-internal": "^1.0.5",
-        "@libp2p/peer-id": "^4.0.4",
-        "@libp2p/utils": "^5.2.0",
-        "@multiformats/mafmt": "^12.1.6",
-        "@multiformats/multiaddr": "^12.1.10",
-        "@multiformats/multiaddr-matcher": "^1.1.0",
+        "@chainsafe/is-ip": "^2.0.2",
+        "@chainsafe/libp2p-noise": "^16.0.0",
+        "@ipshipyard/node-datachannel": "^0.26.4",
+        "@libp2p/crypto": "^5.1.1",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/interface-internal": "^2.3.11",
+        "@libp2p/keychain": "^5.2.1",
+        "@libp2p/peer-id": "^5.1.2",
+        "@libp2p/utils": "^6.6.2",
+        "@multiformats/multiaddr": "^12.4.0",
+        "@multiformats/multiaddr-matcher": "^1.6.0",
+        "@peculiar/webcrypto": "^1.5.0",
+        "@peculiar/x509": "^1.11.0",
+        "any-signal": "^4.1.1",
         "detect-browser": "^5.3.0",
-        "it-length-prefixed": "^9.0.3",
-        "it-protobuf-stream": "^1.0.2",
-        "it-pushable": "^3.2.1",
-        "it-stream-types": "^2.0.1",
-        "multiformats": "^13.0.0",
-        "multihashes": "^4.0.3",
-        "node-datachannel": "^0.5.3",
-        "p-defer": "^4.0.0",
-        "p-event": "^6.0.0",
-        "p-timeout": "^6.1.2",
-        "protons-runtime": "^5.0.0",
-        "race-signal": "^1.0.0",
-        "react-native-webrtc": "^118.0.0",
-        "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/@libp2p/webrtc/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
+        "get-port": "^7.1.0",
+        "interface-datastore": "^8.3.1",
+        "it-length-prefixed": "^10.0.1",
+        "it-protobuf-stream": "^2.0.1",
+        "it-pushable": "^3.2.3",
+        "it-stream-types": "^2.0.2",
+        "multiformats": "^13.3.1",
+        "p-defer": "^4.0.1",
+        "p-timeout": "^6.1.3",
+        "p-wait-for": "^5.0.2",
+        "progress-events": "^1.0.1",
+        "protons-runtime": "^5.5.0",
+        "race-event": "^1.3.0",
+        "race-signal": "^1.1.2",
+        "react-native-webrtc": "^124.0.4",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8",
+        "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/@libp2p/websockets": {
-      "version": "8.0.10",
+      "version": "9.2.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-9.2.10.tgz",
+      "integrity": "sha512-3UUG8SdTr2pe5Jpv86zu0R8AKXVTtIgBWjIISghjeMDhEEz8lakYGtlUYndWiGe7sICG2EaAQcr/SFwMmzItIg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/utils": "^5.2.0",
-        "@multiformats/mafmt": "^12.1.6",
-        "@multiformats/multiaddr": "^12.1.10",
-        "@multiformats/multiaddr-to-uri": "^9.0.2",
-        "@types/ws": "^8.5.4",
-        "it-ws": "^6.1.0",
-        "p-defer": "^4.0.0",
-        "wherearewe": "^2.0.1",
-        "ws": "^8.12.1"
-      }
-    },
-    "node_modules/@libp2p/webtransport": {
-      "version": "4.0.14",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@chainsafe/libp2p-noise": "^14.0.0",
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/peer-id": "^4.0.4",
-        "@multiformats/multiaddr": "^12.1.10",
-        "@multiformats/multiaddr-matcher": "^1.1.0",
-        "it-stream-types": "^2.0.1",
-        "multiformats": "^13.0.0",
-        "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/@libp2p/webtransport/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/utils": "^6.6.2",
+        "@multiformats/multiaddr": "^12.3.3",
+        "@multiformats/multiaddr-matcher": "^1.6.0",
+        "@multiformats/multiaddr-to-uri": "^11.0.0",
+        "@types/ws": "^8.5.13",
+        "it-ws": "^6.1.5",
+        "p-defer": "^4.0.1",
+        "p-event": "^6.0.1",
+        "progress-events": "^1.0.1",
+        "race-signal": "^1.1.2",
+        "ws": "^8.18.0"
       }
     },
     "node_modules/@mdip/browser-hdkey": {
@@ -4109,10 +4069,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@multiformats/base-x": {
-      "version": "4.0.1",
-      "license": "MIT"
-    },
     "node_modules/@multiformats/dns": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.6.tgz",
@@ -4127,31 +4083,10 @@
         "uint8arrays": "^5.0.2"
       }
     },
-    "node_modules/@multiformats/dns/node_modules/p-queue": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.0.1.tgz",
-      "integrity": "sha512-NXzu9aQJTAzbBqOt2hwsR63ea7yvxJc0PwN/zobNAudYfb1B7R08SzB4TsLeSbUCuG467NhnoT0oO6w1qRO+BA==",
-      "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "p-timeout": "^6.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@multiformats/dns/node_modules/uint8arrays": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
-      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
     "node_modules/@multiformats/mafmt": {
       "version": "12.1.6",
+      "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-12.1.6.tgz",
+      "integrity": "sha512-tlJRfL21X+AKn9b5i5VnaTD6bNttpSpcqwKVmDmSHLwxoz97fAHaepqFOk/l1fIu94nImIXneNbhsJx/RQNIww==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@multiformats/multiaddr": "^12.0.0"
@@ -4171,7 +4106,9 @@
       }
     },
     "node_modules/@multiformats/multiaddr-matcher": {
-      "version": "1.1.2",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-matcher/-/multiaddr-matcher-1.7.0.tgz",
+      "integrity": "sha512-WfobrJy7XLaYL7PQ3IcFoXdGN5jmdv5FsuKQkZIIreC1pSR4Q9PSOWu2ULxP/M2JT738Xny0PFoCke0ENbyfww==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
@@ -4180,21 +4117,12 @@
       }
     },
     "node_modules/@multiformats/multiaddr-to-uri": {
-      "version": "9.0.7",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-11.0.0.tgz",
+      "integrity": "sha512-9RNmlIGwZbBLsHekT50dbt4o4u8Iciw9kGjv+WHiGxQdsJ6xKKjU1+C0Vbas6RilMbaVOAOnEyfNcXbUmTkLxQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@multiformats/multiaddr": "^12.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/@multiformats/multiaddr/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
+        "@multiformats/multiaddr": "^12.3.0"
       }
     },
     "node_modules/@multiformats/murmur3": {
@@ -4208,6 +4136,16 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@multiformats/uri-to-multiaddr": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/uri-to-multiaddr/-/uri-to-multiaddr-8.1.0.tgz",
+      "integrity": "sha512-NHFqdKEwJ0A6JDXzC645Lgyw72zWhbM1QfaaD00ZYRrNvtx64p1bD9aIrWZIhLWZN87/lsV4QkJSNRF3Fd3ryw==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.1.14",
+        "is-ip": "^5.0.0"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -4330,17 +4268,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@npmcli/move-file/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@open-draft/deferred-promise": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
@@ -4363,122 +4290,201 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true
     },
-    "node_modules/@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/base64": {
-      "version": "1.1.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/fetch": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause",
+    "node_modules/@peculiar/asn1-cms": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.3.15.tgz",
+      "integrity": "sha512-B+DoudF+TCrxoJSTjjcY8Mmu+lbv8e7pXGWrhNp2/EGJp9EEcpzjBCar7puU57sGifyzaRVM03oD5L7t7PghQg==",
+      "license": "MIT",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
+        "@peculiar/asn1-schema": "^2.3.15",
+        "@peculiar/asn1-x509": "^2.3.15",
+        "@peculiar/asn1-x509-attr": "^2.3.15",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.8.1"
       }
     },
-    "node_modules/@protobufjs/float": {
-      "version": "1.0.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/path": {
-      "version": "1.1.2",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/pool": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@react-native/assets-registry": {
-      "version": "0.76.2",
-      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.76.2.tgz",
-      "integrity": "sha512-0CTWv/FqJzU1vsyx2JpCkyLSUOePU7DdKgFvtHdwOxFpOw3aBecszqZDGJADYV9WSZQlq6RV0HmIaWycGYCOMA==",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
+    "node_modules/@peculiar/asn1-csr": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.3.15.tgz",
+      "integrity": "sha512-caxAOrvw2hUZpxzhz8Kp8iBYKsHbGXZPl2KYRMIPvAfFateRebS3136+orUpcVwHRmpXWX2kzpb6COlIrqCumA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.15",
+        "@peculiar/asn1-x509": "^2.3.15",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.8.1"
       }
     },
-    "node_modules/@react-native/babel-plugin-codegen": {
-      "version": "0.76.2",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.76.2.tgz",
-      "integrity": "sha512-a1IfRho/ZUVbvzSu3JWkxsvqyEI7IXApPQikhGWw4e24QYsIYHdlIULs3rb0840lqpO1dbbuudfO7lmkpkbkMg==",
-      "peer": true,
+    "node_modules/@peculiar/asn1-ecc": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.3.15.tgz",
+      "integrity": "sha512-/HtR91dvgog7z/WhCVdxZJ/jitJuIu8iTqiyWVgRE9Ac5imt2sT/E4obqIVGKQw7PIy+X6i8lVBoT6wC73XUgA==",
+      "license": "MIT",
       "dependencies": {
-        "@react-native/codegen": "0.76.2"
+        "@peculiar/asn1-schema": "^2.3.15",
+        "@peculiar/asn1-x509": "^2.3.15",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pfx": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.3.15.tgz",
+      "integrity": "sha512-E3kzQe3J2xV9DP6SJS4X6/N1e4cYa2xOAK46VtvpaRk8jlheNri8v0rBezKFVPB1rz/jW8npO+u1xOvpATFMWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.3.15",
+        "@peculiar/asn1-pkcs8": "^2.3.15",
+        "@peculiar/asn1-rsa": "^2.3.15",
+        "@peculiar/asn1-schema": "^2.3.15",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs8": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.3.15.tgz",
+      "integrity": "sha512-/PuQj2BIAw1/v76DV1LUOA6YOqh/UvptKLJHtec/DQwruXOCFlUo7k6llegn8N5BTeZTWMwz5EXruBw0Q10TMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.15",
+        "@peculiar/asn1-x509": "^2.3.15",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-pkcs9": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.3.15.tgz",
+      "integrity": "sha512-yiZo/1EGvU1KiQUrbcnaPGWc0C7ElMMskWn7+kHsCFm+/9fU0+V1D/3a5oG0Jpy96iaXggQpA9tzdhnYDgjyFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.3.15",
+        "@peculiar/asn1-pfx": "^2.3.15",
+        "@peculiar/asn1-pkcs8": "^2.3.15",
+        "@peculiar/asn1-schema": "^2.3.15",
+        "@peculiar/asn1-x509": "^2.3.15",
+        "@peculiar/asn1-x509-attr": "^2.3.15",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-rsa": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.3.15.tgz",
+      "integrity": "sha512-p6hsanvPhexRtYSOHihLvUUgrJ8y0FtOM97N5UEpC+VifFYyZa0iZ5cXjTkZoDwxJ/TTJ1IJo3HVTB2JJTpXvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.15",
+        "@peculiar/asn1-x509": "^2.3.15",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.15.tgz",
+      "integrity": "sha512-QPeD8UA8axQREpgR5UTAfu2mqQmm97oUqahDtNdBcfj3qAnoXzFdQW+aNf/tD2WVXF8Fhmftxoj0eMIT++gX2w==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.3.15.tgz",
+      "integrity": "sha512-0dK5xqTqSLaxv1FHXIcd4Q/BZNuopg+u1l23hT9rOmQ1g4dNtw0g/RnEi+TboB0gOwGtrWn269v27cMgchFIIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.15",
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.6",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/asn1-x509-attr": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.3.15.tgz",
+      "integrity": "sha512-TWJVJhqc+IS4MTEML3l6W1b0sMowVqdsnI4dnojg96LvTuP8dga9f76fjP07MUuss60uSyT2ckoti/2qHXA10A==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.15",
+        "@peculiar/asn1-x509": "^2.3.15",
+        "asn1js": "^3.0.5",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
       },
       "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.5.0.tgz",
+      "integrity": "sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2",
+        "webcrypto-core": "^1.8.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/@peculiar/x509": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.12.3.tgz",
+      "integrity": "sha512-+Mzq+W7cNEKfkNZzyLl6A6ffqc3r21HGZUezgfKxpZrkORfOqgRXnS80Zu0IV6a9Ue9QBJeKD7kN0iWfc3bhRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-cms": "^2.3.13",
+        "@peculiar/asn1-csr": "^2.3.13",
+        "@peculiar/asn1-ecc": "^2.3.14",
+        "@peculiar/asn1-pkcs9": "^2.3.13",
+        "@peculiar/asn1-rsa": "^2.3.13",
+        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/asn1-x509": "^2.3.13",
+        "pvtsutils": "^1.3.5",
+        "reflect-metadata": "^0.2.2",
+        "tslib": "^2.7.0",
+        "tsyringe": "^4.8.0"
+      }
+    },
+    "node_modules/@react-native/assets-registry": {
+      "version": "0.79.2",
+      "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.79.2.tgz",
+      "integrity": "sha512-5h2Z7/+/HL/0h88s0JHOdRCW4CXMCJoROxqzHqxdrjGL6EBD1DdaB4ZqkCOEVSW4Vjhir5Qb97C8i/MPWEYPtg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/@react-native/babel-preset": {
-      "version": "0.76.2",
-      "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.76.2.tgz",
-      "integrity": "sha512-/kbxZqy70mGONv23uZg7lm7ZCE4dO5dgMzVPz6QsveXIRHQBRLsSC+9w2iZEnYWpLayoWFmTbq8ZG+4W32D3bA==",
+    "node_modules/@react-native/codegen": {
+      "version": "0.79.2",
+      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.79.2.tgz",
+      "integrity": "sha512-8JTlGLuLi1p8Jx2N/enwwEd7/2CfrqJpv90Cp77QLRX3VHF2hdyavRIxAmXMwN95k+Me7CUuPtqn2X3IBXOWYg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@babel/plugin-proposal-export-default-from": "^7.24.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-syntax-export-default-from": "^7.24.7",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-transform-arrow-functions": "^7.24.7",
-        "@babel/plugin-transform-async-generator-functions": "^7.25.4",
-        "@babel/plugin-transform-async-to-generator": "^7.24.7",
-        "@babel/plugin-transform-block-scoping": "^7.25.0",
-        "@babel/plugin-transform-class-properties": "^7.25.4",
-        "@babel/plugin-transform-classes": "^7.25.4",
-        "@babel/plugin-transform-computed-properties": "^7.24.7",
-        "@babel/plugin-transform-destructuring": "^7.24.8",
-        "@babel/plugin-transform-flow-strip-types": "^7.25.2",
-        "@babel/plugin-transform-for-of": "^7.24.7",
-        "@babel/plugin-transform-function-name": "^7.25.1",
-        "@babel/plugin-transform-literals": "^7.25.2",
-        "@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
-        "@babel/plugin-transform-modules-commonjs": "^7.24.8",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
-        "@babel/plugin-transform-numeric-separator": "^7.24.7",
-        "@babel/plugin-transform-object-rest-spread": "^7.24.7",
-        "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
-        "@babel/plugin-transform-optional-chaining": "^7.24.8",
-        "@babel/plugin-transform-parameters": "^7.24.7",
-        "@babel/plugin-transform-private-methods": "^7.24.7",
-        "@babel/plugin-transform-private-property-in-object": "^7.24.7",
-        "@babel/plugin-transform-react-display-name": "^7.24.7",
-        "@babel/plugin-transform-react-jsx": "^7.25.2",
-        "@babel/plugin-transform-react-jsx-self": "^7.24.7",
-        "@babel/plugin-transform-react-jsx-source": "^7.24.7",
-        "@babel/plugin-transform-regenerator": "^7.24.7",
-        "@babel/plugin-transform-runtime": "^7.24.7",
-        "@babel/plugin-transform-shorthand-properties": "^7.24.7",
-        "@babel/plugin-transform-spread": "^7.24.7",
-        "@babel/plugin-transform-sticky-regex": "^7.24.7",
-        "@babel/plugin-transform-typescript": "^7.25.2",
-        "@babel/plugin-transform-unicode-regex": "^7.24.7",
-        "@babel/template": "^7.25.0",
-        "@react-native/babel-plugin-codegen": "0.76.2",
-        "babel-plugin-syntax-hermes-parser": "^0.25.1",
-        "babel-plugin-transform-flow-enums": "^0.0.2",
-        "react-refresh": "^0.14.0"
+        "glob": "^7.1.1",
+        "hermes-parser": "0.25.1",
+        "invariant": "^2.2.4",
+        "nullthrows": "^1.1.1",
+        "yargs": "^17.6.2"
       },
       "engines": {
         "node": ">=18"
@@ -4487,196 +4493,78 @@
         "@babel/core": "*"
       }
     },
-    "node_modules/@react-native/babel-preset/node_modules/babel-plugin-syntax-hermes-parser": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.25.1.tgz",
-      "integrity": "sha512-IVNpGzboFLfXZUAwkLFcI/bnqVbwky0jP3eBno4HKtqvQJAHBLdgxiG6lQ4to0+Q/YCN3PO0od5NZwIKyY4REQ==",
-      "peer": true,
-      "dependencies": {
-        "hermes-parser": "0.25.1"
-      }
-    },
-    "node_modules/@react-native/babel-preset/node_modules/hermes-estree": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
-      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
-      "peer": true
-    },
-    "node_modules/@react-native/babel-preset/node_modules/hermes-parser": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
-      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
-      "peer": true,
-      "dependencies": {
-        "hermes-estree": "0.25.1"
-      }
-    },
-    "node_modules/@react-native/codegen": {
-      "version": "0.76.2",
-      "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.76.2.tgz",
-      "integrity": "sha512-rIgdI5mHHnNTzAeDYH+ivKMIcv6vr04Ol+TmX77n1HjJkzMhQqSHWcX+Pq9oiu7l2zKkymadrw6OPD8VPgre8g==",
-      "peer": true,
-      "dependencies": {
-        "@babel/parser": "^7.25.3",
-        "glob": "^7.1.1",
-        "hermes-parser": "0.23.1",
-        "invariant": "^2.2.4",
-        "jscodeshift": "^0.14.0",
-        "mkdirp": "^0.5.1",
-        "nullthrows": "^1.1.1",
-        "yargs": "^17.6.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@babel/preset-env": "^7.1.6"
-      }
-    },
     "node_modules/@react-native/community-cli-plugin": {
-      "version": "0.76.2",
-      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.76.2.tgz",
-      "integrity": "sha512-ZRL8oTGSMwXqTsVkRL9AVW8C/AZRnxCcFfhestsx//SrQt3J/hbtDOHTIGkkt5AEA0zEvb/UAAyIAN/wuN4llw==",
+      "version": "0.79.2",
+      "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.79.2.tgz",
+      "integrity": "sha512-E+YEY2dL+68HyR2iahsZdyBKBUi9QyPyaN9vsnda1jNgCjNpSPk2yAF5cXsho+zKK5ZQna3JSeE1Kbi2IfGJbw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@react-native/dev-middleware": "0.76.2",
-        "@react-native/metro-babel-transformer": "0.76.2",
+        "@react-native/dev-middleware": "0.79.2",
         "chalk": "^4.0.0",
-        "execa": "^5.1.1",
+        "debug": "^2.2.0",
         "invariant": "^2.2.4",
-        "metro": "^0.81.0",
-        "metro-config": "^0.81.0",
-        "metro-core": "^0.81.0",
-        "node-fetch": "^2.2.0",
-        "readline": "^1.3.0",
+        "metro": "^0.82.0",
+        "metro-config": "^0.82.0",
+        "metro-core": "^0.82.0",
         "semver": "^7.1.3"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@react-native-community/cli-server-api": "*"
+        "@react-native-community/cli": "*"
       },
       "peerDependenciesMeta": {
-        "@react-native-community/cli-server-api": {
+        "@react-native-community/cli": {
           "optional": true
         }
       }
     },
-    "node_modules/@react-native/community-cli-plugin/node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+    "node_modules/@react-native/community-cli-plugin/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+        "ms": "2.0.0"
       }
     },
-    "node_modules/@react-native/community-cli-plugin/node_modules/human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "peer": true,
-      "engines": {
-        "node": ">=10.17.0"
-      }
-    },
-    "node_modules/@react-native/community-cli-plugin/node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@react-native/community-cli-plugin/node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@react-native/community-cli-plugin/node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "peer": true,
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@react-native/community-cli-plugin/node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "peer": true,
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@react-native/community-cli-plugin/node_modules/strip-final-newline": {
+    "node_modules/@react-native/community-cli-plugin/node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@react-native/debugger-frontend": {
-      "version": "0.76.2",
-      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.76.2.tgz",
-      "integrity": "sha512-FIcz24Oya2wIO7rZD3dxVyK8t5ZD6Fojl9o7lrjnTWqMedcevRTtdSOIAf4ypksYH/x7HypovE2Zp8U65Xv0Mw==",
+      "version": "0.79.2",
+      "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.79.2.tgz",
+      "integrity": "sha512-cGmC7X6kju76DopSBNc+PRAEetbd7TWF9J9o84hOp/xL3ahxR2kuxJy0oJX8Eg8oehhGGEXTuMKHzNa3rDBeSg==",
+      "license": "BSD-3-Clause",
       "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/dev-middleware": {
-      "version": "0.76.2",
-      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.76.2.tgz",
-      "integrity": "sha512-qiowXpxofLk0lpIZps7fyyp9NiKlqBwh0R0yVub5l4EJcqjLonjsznYAHbusnPW9kb9MQSdovGPNv5b8RadJww==",
+      "version": "0.79.2",
+      "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.79.2.tgz",
+      "integrity": "sha512-9q4CpkklsAs1L0Bw8XYCoqqyBSrfRALGEw4/r0EkR38Y/6fVfNfdsjSns0pTLO6h0VpxswK34L/hm4uK3MoLHw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@isaacs/ttlcache": "^1.4.1",
-        "@react-native/debugger-frontend": "0.76.2",
+        "@react-native/debugger-frontend": "0.79.2",
         "chrome-launcher": "^0.15.2",
         "chromium-edge-launcher": "^0.2.0",
         "connect": "^3.6.5",
         "debug": "^2.2.0",
+        "invariant": "^2.2.4",
         "nullthrows": "^1.1.1",
         "open": "^7.0.3",
-        "selfsigned": "^2.4.1",
-        "serve-static": "^1.13.1",
+        "serve-static": "^1.16.2",
         "ws": "^6.2.3"
       },
       "engines": {
@@ -4687,6 +4575,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ms": "2.0.0"
@@ -4696,63 +4585,51 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/@react-native/dev-middleware/node_modules/ws": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
       "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "async-limiter": "~1.0.0"
       }
     },
     "node_modules/@react-native/gradle-plugin": {
-      "version": "0.76.2",
-      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.76.2.tgz",
-      "integrity": "sha512-KC5/uAeLoeD1dOjymx6gnNFHGGLB22xNYjrjrJNK5r0bw2O2KXp4rpB5VCT/2H5B48cVC0xPB7RIKOFrDHr5bQ==",
+      "version": "0.79.2",
+      "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.79.2.tgz",
+      "integrity": "sha512-6MJFemrwR0bOT0QM+2BxX9k3/pvZQNmJ3Js5pF/6owsA0cUDiCO57otiEU8Fz+UywWEzn1FoQfOfQ8vt2GYmoA==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@react-native/js-polyfills": {
-      "version": "0.76.2",
-      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.76.2.tgz",
-      "integrity": "sha512-OXunyNn33fa7gQ6iU5rQcYZQsO7OkJIAr/TgVdoHxpOB4i+ZGsfv6df3JKriBVT1ZZm6ZTlKyIa4QpLq3p0dmw==",
+      "version": "0.79.2",
+      "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.79.2.tgz",
+      "integrity": "sha512-IaY87Ckd4GTPMkO1/Fe8fC1IgIx3vc3q9Tyt/6qS3Mtk9nC0x9q4kSR5t+HHq0/MuvGtu8HpdxXGy5wLaM+zUw==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@react-native/metro-babel-transformer": {
-      "version": "0.76.2",
-      "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.76.2.tgz",
-      "integrity": "sha512-OIYhmWfN+HDyQLzoEg+2P0h7OopYk4djggg0M+k5e1a+g2dFNJILO/BsDobM8uLA8hAzClAJyJLZbPo5jeqdMA==",
-      "peer": true,
-      "dependencies": {
-        "@babel/core": "^7.25.2",
-        "@react-native/babel-preset": "0.76.2",
-        "hermes-parser": "0.23.1",
-        "nullthrows": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@babel/core": "*"
       }
     },
     "node_modules/@react-native/normalize-colors": {
-      "version": "0.76.2",
-      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.76.2.tgz",
-      "integrity": "sha512-ICoOpaTLPsFQjNLSM00NgQr6wal300cZZonHVSDXKntX+BfkLeuCHRtr/Mn+klTtW+/1v2/2FRm9dXjvyGf9Dw==",
+      "version": "0.79.2",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.2.tgz",
+      "integrity": "sha512-+b+GNrupWrWw1okHnEENz63j7NSMqhKeFMOyzYLBwKcprG8fqJQhDIGXfizKdxeIa5NnGSAevKL1Ev1zJ56X8w==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/@react-native/virtualized-lists": {
-      "version": "0.76.2",
-      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.76.2.tgz",
-      "integrity": "sha512-FzXvkHgKvJGf0pSuLy6878cxJ6mxWKgZsH9s2kO4LWJocI8Bi3ViDx7IGAWYuvN+Fnue5TKaqGPhfD+4XrKtYQ==",
+      "version": "0.79.2",
+      "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.79.2.tgz",
+      "integrity": "sha512-9G6ROJeP+rdw9Bvr5ruOlag11ET7j1z/En1riFFNo6W3xZvJY+alCuH1ttm12y9+zBm4n8jwCk4lGhjYaV4dKw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "invariant": "^2.2.4",
@@ -4762,7 +4639,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@types/react": "^18.2.6",
+        "@types/react": "^19.0.0",
         "react": "*",
         "react-native": "*"
       },
@@ -4960,6 +4837,8 @@
     },
     "node_modules/@types/multicast-dns": {
       "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/@types/multicast-dns/-/multicast-dns-7.2.4.tgz",
+      "integrity": "sha512-ib5K4cIDR4Ro5SR3Sx/LROkMDa0BHz0OPaCBL/OSPDsAXEGZ3/KQeS6poBKYVN7BfjXDL9lWNwzyHVgt/wkyCw==",
       "license": "MIT",
       "dependencies": {
         "@types/dns-packet": "*",
@@ -4984,15 +4863,6 @@
         "undici-types": "~6.20.0"
       }
     },
-    "node_modules/@types/node-forge": {
-      "version": "1.3.11",
-      "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.11.tgz",
-      "integrity": "sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "dev": true,
@@ -5000,6 +4870,8 @@
     },
     "node_modules/@types/retry": {
       "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
       "license": "MIT"
     },
     "node_modules/@types/semver": {
@@ -5008,7 +4880,9 @@
       "license": "MIT"
     },
     "node_modules/@types/sinon": {
-      "version": "17.0.3",
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
       "license": "MIT",
       "dependencies": {
         "@types/sinonjs__fake-timers": "*"
@@ -5016,6 +4890,8 @@
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
       "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
@@ -5034,7 +4910,9 @@
       }
     },
     "node_modules/@types/ws": {
-      "version": "8.5.10",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -5274,10 +5152,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/@vascosantos/moving-average": {
-      "version": "1.1.0",
-      "license": "MIT"
-    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "license": "ISC",
@@ -5285,6 +5159,8 @@
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5294,22 +5170,17 @@
         "node": ">=6.5"
       }
     },
-    "node_modules/abortable-iterator": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "get-iterator": "^2.0.0",
-        "it-stream-types": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
+    "node_modules/abort-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/abort-error/-/abort-error-1.0.1.tgz",
+      "integrity": "sha512-fxqCblJiIPdSXIUrxI0PL+eJG49QdP9SQ70qtB65MVAoMr2rASlOyAbJFOylfB467F/f+5BCLJJq58RYi7mGfg==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "mime-types": "~2.1.34",
@@ -5318,6 +5189,45 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/acme-client": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/acme-client/-/acme-client-5.4.0.tgz",
+      "integrity": "sha512-mORqg60S8iML6XSmVjqjGHJkINrCGLMj2QvDmFzI9vIlv1RGlyjmw3nrzaINJjkNsYXC41XhhD5pfy7CtuGcbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/x509": "^1.11.0",
+        "asn1js": "^3.0.5",
+        "axios": "^1.7.2",
+        "debug": "^4.3.5",
+        "node-forge": "^1.3.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/acme-client/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/acme-client/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/acorn": {
       "version": "8.11.3",
@@ -5388,6 +5298,8 @@
     },
     "node_modules/anser": {
       "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
+      "integrity": "sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==",
       "license": "MIT",
       "peer": true
     },
@@ -5640,19 +5552,23 @@
     },
     "node_modules/asap": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT",
       "peer": true
     },
-    "node_modules/ast-types": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.15.2.tgz",
-      "integrity": "sha512-c27loCv9QkZinsa5ProX751khO9DJl/AcB5c2KNtA6NRvHKS0PgLfcftz72KVq504vB0Gku5s2kUZzDBvQWvHg==",
-      "peer": true,
+    "node_modules/asn1js": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.6.tgz",
+      "integrity": "sha512-UOCGPYbl0tv8+006qks/dTgV9ajs97X2p0FAbyS2iyCRrmLSRolDaHdp+v/CLgnzHc3fVB+CwYiUmei7ndFcgA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "tslib": "^2.0.1"
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
       },
       "engines": {
-        "node": ">=4"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/ast-types-flow": {
@@ -5668,6 +5584,8 @@
     },
     "node_modules/async-limiter": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "license": "MIT",
       "peer": true
     },
@@ -5714,15 +5632,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "deep-equal": "^2.0.5"
-      }
-    },
-    "node_modules/babel-core": {
-      "version": "7.0.0-bridge.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
-      "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "peer": true,
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/babel-jest": {
@@ -5873,6 +5782,7 @@
       "version": "0.4.12",
       "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.12.tgz",
       "integrity": "sha512-CPWT6BwvhrTO2d8QVorhTCQw9Y43zOu7G9HigcfxvepOU6b8o3tcWad6oVgZIsZCTt42FFv97aA7ZJsbM4+8og==",
+      "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.22.6",
         "@babel/helper-define-polyfill-provider": "^0.6.3",
@@ -5886,6 +5796,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.3.tgz",
       "integrity": "sha512-HK7Bi+Hj6H+VTHA3ZvBis7V/6hu9QuTrnMXNybfUf2iiuU/N97I8VjB+KbhFF8Rld/Lx5MzoCwPCpPjfK+n8Cg==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-compilation-targets": "^7.22.6",
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -5899,6 +5810,7 @@
     },
     "node_modules/babel-plugin-polyfill-corejs2/node_modules/semver": {
       "version": "6.3.1",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5906,6 +5818,7 @@
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
       "version": "0.8.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.4.4",
@@ -5917,6 +5830,7 @@
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
       "version": "0.5.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-define-polyfill-provider": "^0.4.4"
@@ -5926,21 +5840,13 @@
       }
     },
     "node_modules/babel-plugin-syntax-hermes-parser": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.23.1.tgz",
-      "integrity": "sha512-uNLD0tk2tLUjGFdmCk+u/3FEw2o+BAwW4g+z2QVlxJrzZYOOPADroEcNtTPt5lNiScctaUmnsTkVEnOwZUOLhA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-IVNpGzboFLfXZUAwkLFcI/bnqVbwky0jP3eBno4HKtqvQJAHBLdgxiG6lQ4to0+Q/YCN3PO0od5NZwIKyY4REQ==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "hermes-parser": "0.23.1"
-      }
-    },
-    "node_modules/babel-plugin-transform-flow-enums": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-enums/-/babel-plugin-transform-flow-enums-0.0.2.tgz",
-      "integrity": "sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==",
-      "peer": true,
-      "dependencies": {
-        "@babel/plugin-syntax-flow": "^7.12.1"
+        "hermes-parser": "0.25.1"
       }
     },
     "node_modules/babel-plugin-transform-react-remove-prop-types": {
@@ -6110,26 +6016,19 @@
       }
     },
     "node_modules/blockstore-core": {
-      "version": "4.3.10",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/blockstore-core/-/blockstore-core-5.0.2.tgz",
+      "integrity": "sha512-y7/BHdYLO3YCpJMg6Ue7b4Oz4FT1HWSZoHHdlsaJTsvoE8XieXb6kUCB9UkkUBDw2x4neRDwlgYBpyK77+Ro2Q==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/logger": "^4.0.1",
-        "err-code": "^3.0.1",
+        "@libp2p/logger": "^5.0.1",
         "interface-blockstore": "^5.0.0",
-        "interface-store": "^5.0.0",
-        "it-drain": "^3.0.1",
-        "it-filter": "^3.0.0",
-        "it-merge": "^3.0.1",
-        "it-pushable": "^3.0.0",
-        "multiformats": "^13.0.0",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/blockstore-core/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
+        "interface-store": "^6.0.0",
+        "it-drain": "^3.0.7",
+        "it-filter": "^3.1.1",
+        "it-merge": "^3.0.5",
+        "it-pushable": "^3.2.3",
+        "multiformats": "^13.2.3"
       }
     },
     "node_modules/blockstore-fs": {
@@ -6145,11 +6044,6 @@
         "multiformats": "^13.2.3",
         "steno": "^4.0.2"
       }
-    },
-    "node_modules/blockstore-fs/node_modules/interface-store": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-6.0.2.tgz",
-      "integrity": "sha512-KSFCXtBlNoG0hzwNa0RmhHtrdhzexp+S+UY2s0rWTBJyfdEIgn6i6Zl9otVqrcFYbYrneBT7hbmHQ8gE0C3umA=="
     },
     "node_modules/bn.js": {
       "version": "4.12.0",
@@ -6178,7 +6072,9 @@
       "license": "MIT"
     },
     "node_modules/browser-readablestream-to-it": {
-      "version": "2.0.5",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-2.0.8.tgz",
+      "integrity": "sha512-+aDq+8QoTxIklc9m21oVg96Bm18EpeVke4/8vWPNu+9Ktd+G4PYavitE4gv/pjIndw1q+vxE/Rcnv1zYHrEQbQ==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/browserslist": {
@@ -6327,17 +6223,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/cacache/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/cacache/node_modules/yallist": {
       "version": "4.0.0",
       "license": "ISC",
@@ -6400,6 +6285,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
       "integrity": "sha512-JuG3qI4QOftFsZyOn1qq87fq5grLIyk1JYd5lJmdA+fG7aQ9pA/i3JIJGcO3q0MrRcHlOt1U+ZeHW8Dq9axALQ==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "callsites": "^2.0.0"
@@ -6412,6 +6298,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
       "integrity": "sha512-MCL3sf6nCSXOwCTzvPKhN18TU7AHTvdtam8DAogxcrJ8Rjfbbg7Lgng64H9Iy+vUV6VGFClN/TyxBkAebLRR4A==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "caller-callsite": "^2.0.0"
@@ -6424,6 +6311,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
       "integrity": "sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=4"
@@ -6463,7 +6351,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/cborg": {
-      "version": "4.0.7",
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-4.2.10.tgz",
+      "integrity": "sha512-ZVA0xrVn8uBfDJYgfKKZzB/93z/Uiz7YtRdBPsZi/gyHNyqFdHMLHURVEk9dejOHepaX0zhcMyNva2/vF972SA==",
       "license": "Apache-2.0",
       "bin": {
         "cborg": "lib/bin.js"
@@ -6500,6 +6390,7 @@
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
       "integrity": "sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==",
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@types/node": "*",
@@ -6518,6 +6409,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-0.2.0.tgz",
       "integrity": "sha512-JfJjUnq25y9yg4FABRRVPmBGWPZZi+AQXT4mxupb67766/0UlhG8PAZCz6xzEMXTbW3CsSoE8PcCWA49n35mKg==",
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@types/node": "*",
@@ -6526,18 +6418,6 @@
         "lighthouse-logger": "^1.0.0",
         "mkdirp": "^1.0.4",
         "rimraf": "^3.0.2"
-      }
-    },
-    "node_modules/chromium-edge-launcher/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "peer": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ci-info": {
@@ -6586,18 +6466,19 @@
         "node": ">=12"
       }
     },
-    "node_modules/clone-deep": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-      "peer": true,
+    "node_modules/clone-regexp": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-3.0.0.tgz",
+      "integrity": "sha512-ujdnoq2Kxb8s3ItNBtnYeXdm07FcU0u8ARAT1lQ2YdMwQC+cdiXX8KoqMVuglztILivceTtp4ivqGSmEmhBUJw==",
+      "license": "MIT",
       "dependencies": {
-        "is-plain-object": "^2.0.4",
-        "kind-of": "^6.0.2",
-        "shallow-clone": "^3.0.0"
+        "is-regexp": "^3.0.0"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cluster-key-slot": {
@@ -6684,12 +6565,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
-      "peer": true
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "license": "MIT"
@@ -6703,6 +6578,7 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
       "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "debug": "2.6.9",
@@ -6718,6 +6594,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ms": "2.0.0"
@@ -6727,12 +6604,25 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/convert-hrtime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+      "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -6742,6 +6632,7 @@
       "version": "3.39.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.39.0.tgz",
       "integrity": "sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==",
+      "dev": true,
       "dependencies": {
         "browserslist": "^4.24.2"
       },
@@ -6750,16 +6641,11 @@
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "peer": true
-    },
     "node_modules/cosmiconfig": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
       "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "import-fresh": "^2.0.0",
@@ -6806,6 +6692,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -6883,29 +6770,22 @@
       }
     },
     "node_modules/datastore-core": {
-      "version": "9.2.7",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-10.0.2.tgz",
+      "integrity": "sha512-B3WXxI54VxJkpXxnYibiF17si3bLXE1XOjrJB7wM5co9fx2KOEkiePDGiCCEtnapFHTnmAnYCPdA7WZTIpdn/A==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/logger": "^4.0.1",
-        "err-code": "^3.0.1",
-        "interface-store": "^5.0.0",
-        "it-all": "^3.0.1",
-        "it-drain": "^3.0.1",
-        "it-filter": "^3.0.0",
-        "it-map": "^3.0.1",
-        "it-merge": "^3.0.1",
-        "it-pipe": "^3.0.0",
-        "it-pushable": "^3.0.0",
-        "it-sort": "^3.0.1",
-        "it-take": "^3.0.1",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/datastore-core/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
+        "@libp2p/logger": "^5.0.1",
+        "interface-datastore": "^8.0.0",
+        "interface-store": "^6.0.0",
+        "it-drain": "^3.0.7",
+        "it-filter": "^3.1.1",
+        "it-map": "^3.1.1",
+        "it-merge": "^3.0.5",
+        "it-pipe": "^3.0.1",
+        "it-pushable": "^3.2.3",
+        "it-sort": "^3.0.6",
+        "it-take": "^3.0.6"
       }
     },
     "node_modules/debug": {
@@ -7005,16 +6885,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/default-gateway": {
-      "version": "7.2.2",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "execa": "^7.1.1"
-      },
-      "engines": {
-        "node": ">= 16"
-      }
-    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "dev": true,
@@ -7069,12 +6939,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/denodeify": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
-      "integrity": "sha512-KNTihKNmQENUZeKu5fzfpzRqR5S2VMp4gl9RFHiWzj9DfvYQPMJ6XHKNaQxaGCXwPk6y9yme3aUoaiAe+KX+vg==",
-      "peer": true
-    },
     "node_modules/denque": {
       "version": "2.1.0",
       "license": "Apache-2.0",
@@ -7086,6 +6950,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 0.8"
@@ -7095,6 +6960,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 0.8",
@@ -7103,6 +6969,8 @@
     },
     "node_modules/detect-browser": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w==",
       "license": "MIT"
     },
     "node_modules/detect-libc": {
@@ -7189,6 +7057,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/ejs": {
@@ -7255,6 +7124,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 0.8"
@@ -7307,6 +7177,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
       "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "stackframe": "^1.3.4"
@@ -7496,6 +7367,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/escape-string-regexp": {
@@ -8057,6 +7929,7 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -8066,6 +7939,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 0.6"
@@ -8073,10 +7947,14 @@
     },
     "node_modules/event-iterator": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/event-iterator/-/event-iterator-2.0.0.tgz",
+      "integrity": "sha512-KGft0ldl31BZVV//jj+IAIGCxkvvUkkON+ScH6zfoX+l+omX6001ggyRSpI0Io2Hlro0ThXotswCtfzS8UkIiQ==",
       "license": "MIT"
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -8086,34 +7964,6 @@
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "license": "MIT"
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
-    "node_modules/execa": {
-      "version": "7.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.1",
-        "human-signals": "^4.3.0",
-        "is-stream": "^3.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^5.1.0",
-        "onetime": "^6.0.0",
-        "signal-exit": "^3.0.7",
-        "strip-final-newline": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
     },
     "node_modules/exit": {
       "version": "0.1.2",
@@ -8145,9 +7995,10 @@
       }
     },
     "node_modules/exponential-backoff": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz",
-      "integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
+      "integrity": "sha512-8QxYTVXUkuy7fIIoitQkPwGonB8F3Zj8eEO8Sqg9Zv/bkI7RJAzowee4gr81Hak/dUTpA2Z7VfQgoijjPNlUZA==",
+      "license": "Apache-2.0",
       "peer": true
     },
     "node_modules/fast-deep-equal": {
@@ -8266,6 +8117,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
       "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "debug": "2.6.9",
@@ -8284,6 +8136,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ms": "2.0.0"
@@ -8293,21 +8146,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT",
       "peer": true
-    },
-    "node_modules/find-cache-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-      "peer": true,
-      "dependencies": {
-        "commondir": "^1.0.1",
-        "make-dir": "^2.0.0",
-        "pkg-dir": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/find-up": {
       "version": "4.1.0",
@@ -8340,17 +8180,10 @@
     },
     "node_modules/flow-enums-runtime": {
       "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz",
+      "integrity": "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/flow-parser": {
-      "version": "0.252.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.252.0.tgz",
-      "integrity": "sha512-z8hKPUjZ33VLn4HVntifqmEhmolUMopysnMNzazoDqo1GLUkBsreLNsxETlKJMPotUWStQnen6SGvUNe1j4Hlg==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.9",
@@ -8392,6 +8225,8 @@
     },
     "node_modules/freeport-promise": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/freeport-promise/-/freeport-promise-2.0.0.tgz",
+      "integrity": "sha512-dwWpT1DdQcwrhmRwnDnPM/ZFny+FtzU+k50qF2eid3KxaQDsMiBrwo1i0G3qSugkN5db6Cb0zgfc68QeTOpEFg==",
       "license": "Apache-2.0 OR MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -8402,6 +8237,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 0.6"
@@ -8440,9 +8276,22 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function-timeout": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-0.1.1.tgz",
+      "integrity": "sha512-0NVVC0TaP7dSTvn1yMiy6d6Q8gifzbvQafO46RtLG/kHJUBNd+pVRGOBoK44wNBvtSPUJRfdVvkFdD3p0xvyZg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/function.prototype.name": {
@@ -8537,6 +8386,18 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/get-port": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.1.0.tgz",
+      "integrity": "sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -8552,6 +8413,7 @@
     },
     "node_modules/get-stream": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -8680,14 +8542,6 @@
         "uint8arrays": "^5.0.1"
       }
     },
-    "node_modules/hamt-sharding/node_modules/uint8arrays": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
-      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
     "node_modules/has-bigints": {
       "version": "1.0.2",
       "dev": true,
@@ -8783,6 +8637,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -8802,74 +8657,61 @@
       }
     },
     "node_modules/helia": {
-      "version": "3.0.0",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/helia/-/helia-5.3.0.tgz",
+      "integrity": "sha512-mSM/zQqdoQWUicf90NEcVO1MPSjrzPro5vMe90cKdU0mv10BDk6aJDEImgQlN2x7EsmHCf+hOgmA9K3gZizK4w==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@chainsafe/libp2p-gossipsub": "^11.0.0",
-        "@chainsafe/libp2p-noise": "^14.0.0",
-        "@chainsafe/libp2p-yamux": "^6.0.1",
-        "@helia/delegated-routing-v1-http-api-client": "^1.1.0",
-        "@helia/interface": "^3.0.0",
-        "@ipld/dag-cbor": "^9.0.0",
-        "@ipld/dag-json": "^10.0.1",
-        "@ipld/dag-pb": "^4.0.3",
-        "@libp2p/autonat": "^1.0.1",
-        "@libp2p/bootstrap": "^10.0.2",
-        "@libp2p/circuit-relay-v2": "^1.0.2",
-        "@libp2p/dcutr": "^1.0.1",
-        "@libp2p/identify": "^1.0.1",
-        "@libp2p/interface": "^1.0.1",
-        "@libp2p/kad-dht": "^12.0.1",
-        "@libp2p/keychain": "^4.0.2",
-        "@libp2p/logger": "^4.0.1",
-        "@libp2p/mdns": "^10.0.2",
-        "@libp2p/mplex": "^10.0.2",
-        "@libp2p/ping": "^1.0.1",
-        "@libp2p/tcp": "^9.0.2",
-        "@libp2p/upnp-nat": "^1.0.1",
-        "@libp2p/utils": "^5.2.0",
-        "@libp2p/webrtc": "^4.0.3",
-        "@libp2p/websockets": "^8.0.2",
-        "@libp2p/webtransport": "^4.0.3",
-        "any-signal": "^4.1.1",
-        "blockstore-core": "^4.0.0",
-        "cborg": "^4.0.1",
-        "datastore-core": "^9.0.0",
-        "interface-blockstore": "^5.0.0",
-        "interface-datastore": "^8.0.0",
-        "interface-store": "^5.0.1",
-        "ipfs-bitswap": "^20.0.0",
-        "ipns": "^8.0.0",
-        "it-drain": "^3.0.1",
-        "it-filter": "^3.0.1",
-        "it-foreach": "^2.0.2",
-        "libp2p": "^1.0.3",
-        "mortice": "^3.0.1",
-        "multiformats": "^13.0.0",
-        "progress-events": "^1.0.0",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/helia/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
+        "@chainsafe/libp2p-noise": "^16.0.1",
+        "@chainsafe/libp2p-yamux": "^7.0.1",
+        "@helia/block-brokers": "^4.1.0",
+        "@helia/delegated-routing-v1-http-api-client": "^4.2.1",
+        "@helia/interface": "^5.2.1",
+        "@helia/routers": "^3.0.1",
+        "@helia/utils": "^1.2.2",
+        "@ipshipyard/libp2p-auto-tls": "^1.0.0",
+        "@libp2p/autonat": "^2.0.19",
+        "@libp2p/bootstrap": "^11.0.20",
+        "@libp2p/circuit-relay-v2": "^3.1.10",
+        "@libp2p/config": "^1.0.3",
+        "@libp2p/dcutr": "^2.0.18",
+        "@libp2p/identify": "^3.0.18",
+        "@libp2p/interface": "^2.5.0",
+        "@libp2p/kad-dht": "^14.2.3",
+        "@libp2p/keychain": "^5.0.14",
+        "@libp2p/mdns": "^11.0.20",
+        "@libp2p/mplex": "^11.0.20",
+        "@libp2p/ping": "^2.0.18",
+        "@libp2p/tcp": "^10.0.18",
+        "@libp2p/tls": "^2.0.15",
+        "@libp2p/upnp-nat": "^3.1.1",
+        "@libp2p/webrtc": "^5.1.0",
+        "@libp2p/websockets": "^9.1.5",
+        "@multiformats/dns": "^1.0.6",
+        "blockstore-core": "^5.0.2",
+        "datastore-core": "^10.0.2",
+        "interface-blockstore": "^5.3.1",
+        "interface-datastore": "^8.3.1",
+        "ipns": "^10.0.0",
+        "libp2p": "^2.3.1",
+        "multiformats": "^13.3.1"
       }
     },
     "node_modules/hermes-estree": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.23.1.tgz",
-      "integrity": "sha512-eT5MU3f5aVhTqsfIReZ6n41X5sYn4IdQL0nvz6yO+MMlPxw49aSARHLg/MSehQftyjnrE8X6bYregzSumqc6cg==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/hermes-parser": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.23.1.tgz",
-      "integrity": "sha512-oxl5h2DkFW83hT4DAUJorpah8ou4yvmweUzLJmmr6YV2cezduCdlil1AvU/a/xSsAFo4WUcNA4GoV5Bvq6JffA==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "hermes-estree": "0.23.1"
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/hmac-drbg": {
@@ -8891,10 +8733,44 @@
       "license": "BSD-2-Clause",
       "optional": true
     },
+    "node_modules/http-cookie-agent": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-6.0.8.tgz",
+      "integrity": "sha512-qnYh3yLSr2jBsTYkw11elq+T361uKAJaZ2dR4cfYZChw1dt9uL5t3zSUwehoqqVb4oldk1BpkXKm2oat8zV+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/3846masa"
+      },
+      "peerDependencies": {
+        "tough-cookie": "^4.0.0 || ^5.0.0",
+        "undici": "^5.11.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "undici": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-cookie-agent/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "depd": "2.0.0",
@@ -8911,6 +8787,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 0.8"
@@ -8939,13 +8816,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/human-signals": {
-      "version": "4.3.1",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14.18.0"
       }
     },
     "node_modules/humanize-ms": {
@@ -9002,6 +8872,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
       "integrity": "sha512-eZ5H8rcgYazHbKC3PG4ClHNykCSxtAhxSSEM+2mb+7evD2CKF5V7c0dNum7AdpDh0ZdICwZY9sRSn8f+KH96sg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "caller-path": "^2.0.0",
@@ -9085,11 +8956,6 @@
         "multiformats": "^13.2.3"
       }
     },
-    "node_modules/interface-blockstore/node_modules/interface-store": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-6.0.2.tgz",
-      "integrity": "sha512-KSFCXtBlNoG0hzwNa0RmhHtrdhzexp+S+UY2s0rWTBJyfdEIgn6i6Zl9otVqrcFYbYrneBT7hbmHQ8gE0C3umA=="
-    },
     "node_modules/interface-datastore": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.3.1.tgz",
@@ -9099,21 +8965,10 @@
         "uint8arrays": "^5.1.0"
       }
     },
-    "node_modules/interface-datastore/node_modules/interface-store": {
+    "node_modules/interface-store": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-6.0.2.tgz",
-      "integrity": "sha512-KSFCXtBlNoG0hzwNa0RmhHtrdhzexp+S+UY2s0rWTBJyfdEIgn6i6Zl9otVqrcFYbYrneBT7hbmHQ8gE0C3umA=="
-    },
-    "node_modules/interface-datastore/node_modules/uint8arrays": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
-      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
-    "node_modules/interface-store": {
-      "version": "5.1.7",
+      "integrity": "sha512-KSFCXtBlNoG0hzwNa0RmhHtrdhzexp+S+UY2s0rWTBJyfdEIgn6i6Zl9otVqrcFYbYrneBT7hbmHQ8gE0C3umA==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/internal-slot": {
@@ -9133,6 +8988,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "loose-envify": "^1.0.0"
@@ -9185,6 +9041,8 @@
     },
     "node_modules/ip-regex": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-5.0.0.tgz",
+      "integrity": "sha512-fOCG6lhoKKakwv+C6KdsOnGvgXnmgfmp0myi3bcNwj3qfwPAxRKWEuFhvEFF7ceYIz6+1jRZ+yguLFAmUNPEfw==",
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -9192,63 +9050,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/ipaddr.js": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/ipfs-bitswap": {
-      "version": "20.0.0",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "@libp2p/identify": "^1.0.0",
-        "@libp2p/interface": "^1.0.0",
-        "@libp2p/logger": "^4.0.0",
-        "@libp2p/utils": "^5.0.0",
-        "@multiformats/multiaddr": "^12.1.0",
-        "@vascosantos/moving-average": "^1.1.0",
-        "any-signal": "^4.1.1",
-        "blockstore-core": "^4.0.0",
-        "events": "^3.3.0",
-        "interface-blockstore": "^5.0.0",
-        "interface-store": "^5.1.0",
-        "it-foreach": "^2.0.2",
-        "it-length-prefixed": "^9.0.0",
-        "it-map": "^3.0.2",
-        "it-pipe": "^3.0.1",
-        "it-take": "^3.0.1",
-        "just-debounce-it": "^3.0.1",
-        "multiformats": "^12.0.1",
-        "progress-events": "^1.0.0",
-        "protons-runtime": "^5.0.0",
-        "timeout-abort-controller": "^3.0.0",
-        "uint8arraylist": "^2.4.3",
-        "uint8arrays": "^4.0.2",
-        "varint": "^6.0.0",
-        "varint-decoder": "^1.0.0"
-      }
-    },
-    "node_modules/ipfs-bitswap/node_modules/multiformats": {
-      "version": "12.1.3",
-      "license": "Apache-2.0 OR MIT",
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/ipfs-bitswap/node_modules/uint8arrays": {
-      "version": "4.0.10",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^12.0.1"
-      }
-    },
-    "node_modules/ipfs-bitswap/node_modules/varint": {
-      "version": "6.0.0",
-      "license": "MIT"
     },
     "node_modules/ipfs-unixfs": {
       "version": "11.2.1",
@@ -9282,21 +9083,6 @@
         "progress-events": "^1.0.1"
       }
     },
-    "node_modules/ipfs-unixfs-exporter/node_modules/p-queue": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.0.tgz",
-      "integrity": "sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==",
-      "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "p-timeout": "^6.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ipfs-unixfs-importer": {
       "version": "15.3.2",
       "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-15.3.2.tgz",
@@ -9319,42 +9105,22 @@
         "uint8arrays": "^5.1.0"
       }
     },
-    "node_modules/ipfs-unixfs-importer/node_modules/interface-store": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/interface-store/-/interface-store-6.0.2.tgz",
-      "integrity": "sha512-KSFCXtBlNoG0hzwNa0RmhHtrdhzexp+S+UY2s0rWTBJyfdEIgn6i6Zl9otVqrcFYbYrneBT7hbmHQ8gE0C3umA=="
-    },
-    "node_modules/ipfs-unixfs-importer/node_modules/uint8arrays": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
-      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
     "node_modules/ipns": {
-      "version": "8.0.0",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-10.0.2.tgz",
+      "integrity": "sha512-tokCgz9X678zvHnAabVG91K64X7HnHdWOrop0ghUcXkzH5XNsmxHwVpqVATNqq/w62h7fRDhWURHU/WOfYmCpA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^3.0.3",
-        "@libp2p/interface": "^1.1.0",
-        "@libp2p/logger": "^4.0.3",
-        "@libp2p/peer-id": "^4.0.3",
-        "cborg": "^4.0.1",
-        "err-code": "^3.0.1",
-        "interface-datastore": "^8.1.0",
-        "multiformats": "^13.0.0",
-        "protons-runtime": "^5.2.1",
-        "timestamp-nano": "^1.0.0",
+        "@libp2p/crypto": "^5.0.0",
+        "@libp2p/interface": "^2.0.0",
+        "@libp2p/logger": "^5.0.0",
+        "cborg": "^4.2.3",
+        "interface-datastore": "^8.3.0",
+        "multiformats": "^13.2.2",
+        "protons-runtime": "^5.5.0",
+        "timestamp-nano": "^1.0.1",
         "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.1"
-      }
-    },
-    "node_modules/ipns/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
+        "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/is-arguments": {
@@ -9444,6 +9210,7 @@
     },
     "node_modules/is-core-module": {
       "version": "2.13.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.0"
@@ -9484,6 +9251,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
       "integrity": "sha512-yVChGzahRFvbkscn2MlwGismPO12i9+znNruC5gVEntG3qu0xQMzsGg/JFbrsqDOHtHFPci+V5aP5T9I+yeKqw==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -9493,6 +9261,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
       "peer": true,
       "bin": {
         "is-docker": "cli.js"
@@ -9558,6 +9327,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-ip": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.1.tgz",
+      "integrity": "sha512-FCsGHdlrOnZQcp0+XT5a+pYowf33itBalCl+7ovNXC/7o5BhIpG14M3OrpPPdBSIQJCm+0M5+9mO7S9VVTTCFw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-regex": "^5.0.0",
+        "super-regex": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-lambda": {
       "version": "1.0.1",
       "license": "MIT",
@@ -9590,7 +9375,9 @@
       }
     },
     "node_modules/is-network-error": {
-      "version": "1.0.1",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.1.0.tgz",
+      "integrity": "sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==",
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -9641,18 +9428,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "peer": true,
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "dev": true,
@@ -9666,6 +9441,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regexp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
+      "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-set": {
@@ -9691,16 +9478,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-stream": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -9786,6 +9563,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "is-docker": "^2.0.0"
@@ -9794,14 +9572,9 @@
         "node": ">=8"
       }
     },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "peer": true
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/iso-url": {
@@ -9810,15 +9583,6 @@
       "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng==",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/istanbul-lib-coverage": {
@@ -9914,19 +9678,34 @@
       "integrity": "sha512-pQAAlSvJ4aV6xM/6LRvkPdKSKXxS4my2fGzNUxJyAQ8ccFdxPmK1bUuF5OoeUDkcdrbs8jtsmc4DypCMrGY6sg=="
     },
     "node_modules/it-byte-stream": {
-      "version": "1.0.7",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-byte-stream/-/it-byte-stream-2.0.1.tgz",
+      "integrity": "sha512-WccB179tWRNjTyXJ9wLshQdKSLdVIexmnNjLfCT7UnsiLisTVUY092YqFhkL+da1WFR0paGzB24L+pAzFhRI4Q==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "it-stream-types": "^2.0.1",
-        "p-defer": "^4.0.0",
-        "race-signal": "^1.0.1",
-        "uint8arraylist": "^2.4.1"
+        "abort-error": "^1.0.1",
+        "it-queueless-pushable": "^2.0.0",
+        "it-stream-types": "^2.0.2",
+        "race-signal": "^1.1.3",
+        "uint8arraylist": "^2.4.8"
+      }
+    },
+    "node_modules/it-byte-stream/node_modules/it-queueless-pushable": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/it-queueless-pushable/-/it-queueless-pushable-2.0.0.tgz",
+      "integrity": "sha512-MlNnefWT/ntv5fesrHpxwVIu6ZdtlkN0A4aaJiE5wnmPMBv9ttiwX3UEMf78dFwIj5ZNaU9usYXg4swMEpUNJQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "abort-error": "^1.0.1",
+        "p-defer": "^4.0.1",
+        "race-signal": "^1.1.3"
       }
     },
     "node_modules/it-drain": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-3.0.7.tgz",
-      "integrity": "sha512-vy6S1JKjjHSIFHgBpLpD1zhkCRl3z1zYWUxE14+kAYf+BL9ssWSFImJfhl361IIcwr0ofw8etzg11VqqB+ntUA=="
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/it-drain/-/it-drain-3.0.8.tgz",
+      "integrity": "sha512-eeOz+WwKc11ou1UuqZympcXPLCjpTn5ALcYFJiHeTEiYEZ2py/J1vq41XWYj88huCUiqp9iNHfObOKrbIk5Izw==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-filter": {
       "version": "3.1.1",
@@ -9963,14 +9742,17 @@
       "integrity": "sha512-qG4BTveE6Wzsz5voqaOtZAfZgXTJT+yiaj45vp5S0Vi8oOdgKlRqUeolfvWoMCJ9vwSc/z9pAaNYIza7gA851w=="
     },
     "node_modules/it-length": {
-      "version": "3.0.4",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/it-length/-/it-length-3.0.7.tgz",
+      "integrity": "sha512-URrszwrzPrUn6PtsSFcixG4NwHydaARmPubO0UUnFH+NSNylBaGtair1fnxX7Zf2qVJQltPBVs3PZvcmFPTLXA==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-length-prefixed": {
-      "version": "9.0.4",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-10.0.1.tgz",
+      "integrity": "sha512-BhyluvGps26u9a7eQIpOI1YN7mFgi8lFwmiPi07whewbBARKAG9LE09Odc8s1Wtbt2MB6rNUrl7j9vvfXTJwdQ==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "err-code": "^3.0.1",
         "it-reader": "^6.0.1",
         "it-stream-types": "^2.0.1",
         "uint8-varint": "^2.0.1",
@@ -9983,21 +9765,16 @@
       }
     },
     "node_modules/it-length-prefixed-stream": {
-      "version": "1.1.5",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed-stream/-/it-length-prefixed-stream-2.0.1.tgz",
+      "integrity": "sha512-TFohjVrQKRLQgRrPdVL9ARqP4CHUHnsRkbkX4nEhSOBjOvZtVV/pHh5Z2C8EH50MnfNDjVSKvEbaIFVLS3/QMA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "it-byte-stream": "^1.0.0",
-        "it-length-prefixed": "^9.0.1",
-        "it-stream-types": "^2.0.1",
-        "uint8-varint": "^2.0.1",
-        "uint8arraylist": "^2.4.1"
-      }
-    },
-    "node_modules/it-length-prefixed/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
+        "abort-error": "^1.0.1",
+        "it-byte-stream": "^2.0.0",
+        "it-stream-types": "^2.0.2",
+        "uint8-varint": "^2.0.4",
+        "uint8arraylist": "^2.4.8"
       }
     },
     "node_modules/it-map": {
@@ -10017,11 +9794,18 @@
       }
     },
     "node_modules/it-ndjson": {
-      "version": "1.0.5",
-      "license": "Apache-2.0 OR MIT"
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/it-ndjson/-/it-ndjson-1.1.2.tgz",
+      "integrity": "sha512-TPKpdYSNKjDdroCPnLamM5Up6XnPQ7F1KgNP3Ib5y5O4ayOVP+DHac/pzjUigcg9Kf9gkGVXDz8+FFKpWwoB3w==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8arraylist": "^2.4.8"
+      }
     },
     "node_modules/it-pair": {
       "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/it-pair/-/it-pair-2.0.6.tgz",
+      "integrity": "sha512-5M0t5RAcYEQYNG5BV7d7cqbdwbCAp5yLdzvkxsZmkuZsLbTdZzah6MQySYfaAQjNDCq6PUnDt0hqBZ4NwMfW6g==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-stream-types": "^2.0.1",
@@ -10066,13 +9850,15 @@
       }
     },
     "node_modules/it-protobuf-stream": {
-      "version": "1.1.2",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/it-protobuf-stream/-/it-protobuf-stream-2.0.1.tgz",
+      "integrity": "sha512-szhw8w2aIENUa1yv0vFgGZDs7e81dQ/7dM10c4Rf6+rs5tqzWVCSLbpgxIYM0cA8KlcI66XGdzu6lyYp6jKdvw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "it-length-prefixed-stream": "^1.0.0",
-        "it-stream-types": "^2.0.1",
-        "protons-runtime": "^5.0.0",
-        "uint8arraylist": "^2.4.1"
+        "abort-error": "^1.0.1",
+        "it-length-prefixed-stream": "^2.0.0",
+        "it-stream-types": "^2.0.2",
+        "uint8arraylist": "^2.4.8"
       }
     },
     "node_modules/it-pushable": {
@@ -10082,8 +9868,20 @@
         "p-defer": "^4.0.0"
       }
     },
+    "node_modules/it-queueless-pushable": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-queueless-pushable/-/it-queueless-pushable-1.0.2.tgz",
+      "integrity": "sha512-BFIm48C4O8+i+oVEPQpZ70+CaAsVUircvZtZCrpG2Q64933aLp+tDmas1mTBwqVBfIUUlg09d+e6SWW1CBuykQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "p-defer": "^4.0.1",
+        "race-signal": "^1.1.3"
+      }
+    },
     "node_modules/it-reader": {
       "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/it-reader/-/it-reader-6.0.4.tgz",
+      "integrity": "sha512-XCWifEcNFFjjBHtor4Sfaj8rcpt+FkY0L6WdhD578SCDhV4VUm7fCkF3dv5a+fTcfQqvN9BsxBTvWbYO6iCjTg==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-stream-types": "^2.0.1",
@@ -10095,7 +9893,9 @@
       }
     },
     "node_modules/it-sort": {
-      "version": "3.0.4",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/it-sort/-/it-sort-3.0.7.tgz",
+      "integrity": "sha512-PsaKSd2Z0uhq8Mq5htdfsE/UagmdLCLWdBXPwi3FZGR4BTG180pFamhK+O+luFtBCNGRoqKAdtbZGTyGwA9uzw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "it-all": "^3.0.0"
@@ -10107,7 +9907,9 @@
       "integrity": "sha512-Rz/DEZ6Byn/r9+/SBCuJhpPATDF9D+dz5pbgSUyBsCDtza6wtNATrz/jz1gDyNanC3XdLboriHnOC925bZRBww=="
     },
     "node_modules/it-take": {
-      "version": "3.0.4",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/it-take/-/it-take-3.0.7.tgz",
+      "integrity": "sha512-0+EbsTvH1XCpwhhFkjWdqJTjzS5XP3KL69woBqwANNhMLKn0j39jk/WHIlvbg9XW2vEm7cZz4p8w5DkBZR8LoA==",
       "license": "Apache-2.0 OR MIT"
     },
     "node_modules/it-to-stream": {
@@ -10137,7 +9939,9 @@
       }
     },
     "node_modules/it-ws": {
-      "version": "6.1.1",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-6.1.5.tgz",
+      "integrity": "sha512-uWjMtpy5HqhSd/LlrlP3fhYrr7rUfJFFMABv0F5d6n13Q+0glhZthwUKpEAVhDrXY95Tb1RB5lLqqef+QbVNaw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@types/ws": "^8.2.2",
@@ -10149,13 +9953,6 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/it-ws/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
       }
     },
     "node_modules/iterator.prototype": {
@@ -10883,49 +10680,12 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/jsc-android": {
-      "version": "250231.0.0",
-      "license": "BSD-2-Clause",
-      "peer": true
-    },
     "node_modules/jsc-safe-url": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/jsc-safe-url/-/jsc-safe-url-0.2.4.tgz",
       "integrity": "sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==",
+      "license": "0BSD",
       "peer": true
-    },
-    "node_modules/jscodeshift": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.14.0.tgz",
-      "integrity": "sha512-7eCC1knD7bLUPuSCwXsMZUH51O8jIcoVyKtI6P0XM0IVzlGjckPy3FIwQlorzbN0Sg79oK+RlohN32Mqf/lrYA==",
-      "peer": true,
-      "dependencies": {
-        "@babel/core": "^7.13.16",
-        "@babel/parser": "^7.13.16",
-        "@babel/plugin-proposal-class-properties": "^7.13.0",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.8",
-        "@babel/plugin-proposal-optional-chaining": "^7.13.12",
-        "@babel/plugin-transform-modules-commonjs": "^7.13.8",
-        "@babel/preset-flow": "^7.13.13",
-        "@babel/preset-typescript": "^7.13.0",
-        "@babel/register": "^7.13.16",
-        "babel-core": "^7.0.0-bridge.0",
-        "chalk": "^4.1.2",
-        "flow-parser": "0.*",
-        "graceful-fs": "^4.2.4",
-        "micromatch": "^4.0.4",
-        "neo-async": "^2.5.0",
-        "node-dir": "^0.1.17",
-        "recast": "^0.21.0",
-        "temp": "^0.8.4",
-        "write-file-atomic": "^2.3.0"
-      },
-      "bin": {
-        "jscodeshift": "bin/jscodeshift.js"
-      },
-      "peerDependencies": {
-        "@babel/preset-env": "^7.1.6"
-      }
     },
     "node_modules/jsesc": {
       "version": "3.0.2",
@@ -10947,6 +10707,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/json-parse-even-better-errors": {
@@ -10994,25 +10755,12 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/just-debounce-it": {
-      "version": "3.2.0",
-      "license": "MIT"
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/kleur": {
@@ -11063,80 +10811,6 @@
         "wherearewe": "^2.0.1"
       }
     },
-    "node_modules/kubo-rpc-client/node_modules/@libp2p/crypto": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-5.0.15.tgz",
-      "integrity": "sha512-28xYMOn3fs8flsNgCVVxp27gEmDTtZHbz+qEVv3v7cWfGRipaVhNXFV9tQJHWXHQ8mN8v/PQvgcfCcWu5jkrTg==",
-      "dependencies": {
-        "@libp2p/interface": "^2.7.0",
-        "@noble/curves": "^1.7.0",
-        "@noble/hashes": "^1.6.1",
-        "multiformats": "^13.3.1",
-        "protons-runtime": "^5.5.0",
-        "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.1.0"
-      }
-    },
-    "node_modules/kubo-rpc-client/node_modules/@libp2p/interface": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-2.7.0.tgz",
-      "integrity": "sha512-lWmfIGzbSaw//yoEWWJh8dXNDGSCwUyXwC7P1Q6jCFWNoEtCaB1pvwOGBtri7Db/aNFZryMzN5covoq5ulldnA==",
-      "dependencies": {
-        "@multiformats/multiaddr": "^12.3.3",
-        "it-pushable": "^3.2.3",
-        "it-stream-types": "^2.0.2",
-        "multiformats": "^13.3.1",
-        "progress-events": "^1.0.1",
-        "uint8arraylist": "^2.4.8"
-      }
-    },
-    "node_modules/kubo-rpc-client/node_modules/@libp2p/logger": {
-      "version": "5.1.13",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-5.1.13.tgz",
-      "integrity": "sha512-JKyMlySG8T+LpItsj9Vma57yap/A0HqJ8ZdaHvgdoThhSOfqcRs8oRWO/2EG0Q5hUXugw//EAT+Ptj8MyNdbjQ==",
-      "dependencies": {
-        "@libp2p/interface": "^2.7.0",
-        "@multiformats/multiaddr": "^12.3.3",
-        "interface-datastore": "^8.3.1",
-        "multiformats": "^13.3.1",
-        "weald": "^1.0.4"
-      }
-    },
-    "node_modules/kubo-rpc-client/node_modules/@libp2p/peer-id": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-5.1.0.tgz",
-      "integrity": "sha512-9Xob9DDg1uBboM2QvJ5nyPbsjxsNS9obmGAYeAtLSx5aHAIC4AweJQFHssUUCfW7mufkzX/s3zyR62XPR4SYyQ==",
-      "dependencies": {
-        "@libp2p/crypto": "^5.0.15",
-        "@libp2p/interface": "^2.7.0",
-        "multiformats": "^13.3.1",
-        "uint8arrays": "^5.1.0"
-      }
-    },
-    "node_modules/kubo-rpc-client/node_modules/@multiformats/multiaddr-to-uri": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-to-uri/-/multiaddr-to-uri-11.0.0.tgz",
-      "integrity": "sha512-9RNmlIGwZbBLsHekT50dbt4o4u8Iciw9kGjv+WHiGxQdsJ6xKKjU1+C0Vbas6RilMbaVOAOnEyfNcXbUmTkLxQ==",
-      "dependencies": {
-        "@multiformats/multiaddr": "^12.3.0"
-      }
-    },
-    "node_modules/kubo-rpc-client/node_modules/stream-to-it": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-1.0.1.tgz",
-      "integrity": "sha512-AqHYAYPHcmvMrcLNgncE/q0Aj/ajP6A4qGhxP6EVn7K3YTNs0bJpJyk57wc2Heb7MUL64jurvmnmui8D9kjZgA==",
-      "dependencies": {
-        "it-stream-types": "^2.0.1"
-      }
-    },
-    "node_modules/kubo-rpc-client/node_modules/uint8arrays": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
-      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
-      "dependencies": {
-        "multiformats": "^13.0.0"
-      }
-    },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
       "dev": true,
@@ -11173,43 +10847,46 @@
       }
     },
     "node_modules/libp2p": {
-      "version": "1.1.1",
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-2.8.5.tgz",
+      "integrity": "sha512-K2jqFmNp3LsTeuJ15t6jG0Z9WoydLs+AfSDvhSYQa7lRTu9IANt84SxNg+PsmGxMMiTOtIoMmo27DHzF3+ON8Q==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "@libp2p/crypto": "^3.0.4",
-        "@libp2p/interface": "^1.1.1",
-        "@libp2p/interface-internal": "^1.0.5",
-        "@libp2p/logger": "^4.0.4",
-        "@libp2p/multistream-select": "^5.1.1",
-        "@libp2p/peer-collections": "^5.1.3",
-        "@libp2p/peer-id": "^4.0.4",
-        "@libp2p/peer-id-factory": "^4.0.3",
-        "@libp2p/peer-store": "^10.0.5",
-        "@libp2p/utils": "^5.2.0",
-        "@multiformats/multiaddr": "^12.1.10",
+        "@chainsafe/is-ip": "^2.0.2",
+        "@chainsafe/netmask": "^2.0.0",
+        "@libp2p/crypto": "^5.1.1",
+        "@libp2p/interface": "^2.9.0",
+        "@libp2p/interface-internal": "^2.3.11",
+        "@libp2p/logger": "^5.1.15",
+        "@libp2p/multistream-select": "^6.0.22",
+        "@libp2p/peer-collections": "^6.0.27",
+        "@libp2p/peer-id": "^5.1.2",
+        "@libp2p/peer-store": "^11.1.4",
+        "@libp2p/utils": "^6.6.2",
+        "@multiformats/dns": "^1.0.6",
+        "@multiformats/multiaddr": "^12.3.5",
+        "@multiformats/multiaddr-matcher": "^1.7.0",
         "any-signal": "^4.1.1",
-        "datastore-core": "^9.0.1",
-        "interface-datastore": "^8.2.0",
-        "it-merge": "^3.0.0",
-        "it-parallel": "^3.0.6",
+        "datastore-core": "^10.0.2",
+        "interface-datastore": "^8.3.1",
+        "it-byte-stream": "^2.0.1",
+        "it-merge": "^3.0.5",
+        "it-parallel": "^3.0.8",
         "merge-options": "^3.0.4",
-        "multiformats": "^13.0.0",
-        "private-ip": "^3.0.1",
-        "rate-limiter-flexible": "^4.0.0",
-        "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/libp2p/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
+        "multiformats": "^13.3.1",
+        "p-defer": "^4.0.1",
+        "p-retry": "^6.2.1",
+        "progress-events": "^1.0.1",
+        "race-event": "^1.3.0",
+        "race-signal": "^1.1.2",
+        "uint8arrays": "^5.1.0"
       }
     },
     "node_modules/lighthouse-logger": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.4.2.tgz",
       "integrity": "sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==",
+      "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "debug": "^2.6.9",
@@ -11220,6 +10897,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ms": "2.0.0"
@@ -11229,6 +10907,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/lines-and-columns": {
@@ -11253,6 +10932,7 @@
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {
@@ -11300,11 +10980,8 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
       "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
+      "license": "MIT",
       "peer": true
-    },
-    "node_modules/long": {
-      "version": "5.2.3",
-      "license": "Apache-2.0"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -11321,28 +10998,6 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/make-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-      "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-      "peer": true,
-      "dependencies": {
-        "pify": "^4.0.1",
-        "semver": "^5.6.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/make-dir/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "peer": true,
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/make-error": {
@@ -11401,9 +11056,10 @@
       }
     },
     "node_modules/marky": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.5.tgz",
-      "integrity": "sha512-q9JtQJKjpsVxCRVgQ+WapguSbKC3SQ5HEzFGPAJMStgh3QjCawp00UKv3MTTAArTmGmmPUvllHZoNbZ3gs0I+Q==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.3.0.tgz",
+      "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
+      "license": "Apache-2.0",
       "peer": true
     },
     "node_modules/math-intrinsics": {
@@ -11426,6 +11082,8 @@
     },
     "node_modules/memoize-one": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
+      "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT",
       "peer": true
     },
@@ -11455,9 +11113,10 @@
       }
     },
     "node_modules/metro": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/metro/-/metro-0.81.0.tgz",
-      "integrity": "sha512-kzdzmpL0gKhEthZ9aOV7sTqvg6NuTxDV8SIm9pf9sO8VVEbKrQk5DNcwupOUjgPPFAuKUc2NkT0suyT62hm2xg==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro/-/metro-0.82.3.tgz",
+      "integrity": "sha512-EfSLtuUmfsGk3znJ+zoN8cRLniQo3W1wyA+nJMfpTLdENfbbPnGRTwmKhzRcJIUh9jgkrrF4oRQ5shLtQ2DsUw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
@@ -11471,34 +11130,32 @@
         "chalk": "^4.0.0",
         "ci-info": "^2.0.0",
         "connect": "^3.6.5",
-        "debug": "^2.2.0",
-        "denodeify": "^1.2.1",
+        "debug": "^4.4.0",
         "error-stack-parser": "^2.0.6",
         "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
-        "hermes-parser": "0.24.0",
+        "hermes-parser": "0.28.1",
         "image-size": "^1.0.2",
         "invariant": "^2.2.4",
-        "jest-worker": "^29.6.3",
+        "jest-worker": "^29.7.0",
         "jsc-safe-url": "^0.2.2",
         "lodash.throttle": "^4.1.1",
-        "metro-babel-transformer": "0.81.0",
-        "metro-cache": "0.81.0",
-        "metro-cache-key": "0.81.0",
-        "metro-config": "0.81.0",
-        "metro-core": "0.81.0",
-        "metro-file-map": "0.81.0",
-        "metro-resolver": "0.81.0",
-        "metro-runtime": "0.81.0",
-        "metro-source-map": "0.81.0",
-        "metro-symbolicate": "0.81.0",
-        "metro-transform-plugins": "0.81.0",
-        "metro-transform-worker": "0.81.0",
+        "metro-babel-transformer": "0.82.3",
+        "metro-cache": "0.82.3",
+        "metro-cache-key": "0.82.3",
+        "metro-config": "0.82.3",
+        "metro-core": "0.82.3",
+        "metro-file-map": "0.82.3",
+        "metro-resolver": "0.82.3",
+        "metro-runtime": "0.82.3",
+        "metro-source-map": "0.82.3",
+        "metro-symbolicate": "0.82.3",
+        "metro-transform-plugins": "0.82.3",
+        "metro-transform-worker": "0.82.3",
         "mime-types": "^2.1.27",
         "nullthrows": "^1.1.1",
         "serialize-error": "^2.1.0",
         "source-map": "^0.5.6",
-        "strip-ansi": "^6.0.0",
         "throat": "^5.0.0",
         "ws": "^7.5.10",
         "yargs": "^17.6.2"
@@ -11511,14 +11168,15 @@
       }
     },
     "node_modules/metro-babel-transformer": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.81.0.tgz",
-      "integrity": "sha512-Dc0QWK4wZIeHnyZ3sevWGTnnSkIDDn/SWyfrn99zbKbDOCoCYy71PAn9uCRrP/hduKLJQOy+tebd63Rr9D8tXg==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.82.3.tgz",
+      "integrity": "sha512-eC0f1MSA8rg7VoNDCYMIAIe5AEgYBskh5W8rIa4RGRdmEOsGlXbAV0AWMYoA7NlIALW/S9b10AcdIwD3n1e50w==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
-        "hermes-parser": "0.24.0",
+        "hermes-parser": "0.28.1",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -11526,38 +11184,43 @@
       }
     },
     "node_modules/metro-babel-transformer/node_modules/hermes-estree": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.24.0.tgz",
-      "integrity": "sha512-LyoXLB7IFzeZW0EvAbGZacbxBN7t6KKSDqFJPo3Ydow7wDlrDjXwsdiAHV6XOdvEN9MEuWXsSIFN4tzpyrXIHw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.28.1.tgz",
+      "integrity": "sha512-w3nxl/RGM7LBae0v8LH2o36+8VqwOZGv9rX1wyoWT6YaKZLqpJZ0YQ5P0LVr3tuRpf7vCx0iIG4i/VmBJejxTQ==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/metro-babel-transformer/node_modules/hermes-parser": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.24.0.tgz",
-      "integrity": "sha512-IJooSvvu2qNRe7oo9Rb04sUT4omtZqZqf9uq9WM25Tb6v3usmvA93UqfnnoWs5V0uYjEl9Al6MNU10MCGKLwpg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.28.1.tgz",
+      "integrity": "sha512-nf8o+hE8g7UJWParnccljHumE9Vlq8F7MqIdeahl+4x0tvCUJYRrT0L7h0MMg/X9YJmkNwsfbaNNrzPtFXOscg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "hermes-estree": "0.24.0"
+        "hermes-estree": "0.28.1"
       }
     },
     "node_modules/metro-cache": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.81.0.tgz",
-      "integrity": "sha512-DyuqySicHXkHUDZFVJmh0ygxBSx6pCKUrTcSgb884oiscV/ROt1Vhye+x+OIHcsodyA10gzZtrVtxIFV4l9I4g==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.82.3.tgz",
+      "integrity": "sha512-9zKhicA5GENROeP+iXku1NrI8FegtwEg3iPXHGixkm1Yppkbwsy/3lSHSiJZoT6GkZmxUDjN6sQ5QQ+/p72Msw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "exponential-backoff": "^3.1.1",
         "flow-enums-runtime": "^0.0.6",
-        "metro-core": "0.81.0"
+        "https-proxy-agent": "^7.0.5",
+        "metro-core": "0.82.3"
       },
       "engines": {
         "node": ">=18.18"
       }
     },
     "node_modules/metro-cache-key": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.81.0.tgz",
-      "integrity": "sha512-qX/IwtknP9bQZL78OK9xeSvLM/xlGfrs6SlUGgHvrxtmGTRSsxcyqxR+c+7ch1xr05n62Gin/O44QKg5V70rNQ==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.82.3.tgz",
+      "integrity": "sha512-dDLTUOJ7YYqGog9kR55InchwnkkHuxBXD765J3hQVWWPCy6xO9uZXZYGX1Y/tIMV8U7Ho1Sve0V13n5rFajrRQ==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -11566,83 +11229,116 @@
         "node": ">=18.18"
       }
     },
+    "node_modules/metro-cache/node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/metro-cache/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/metro-config": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.81.0.tgz",
-      "integrity": "sha512-6CinEaBe3WLpRlKlYXXu8r1UblJhbwD6Gtnoib5U8j6Pjp7XxMG9h/DGMeNp9aGLDu1OieUqiXpFo7O0/rR5Kg==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.82.3.tgz",
+      "integrity": "sha512-GRG9sBkPvrGXD/Wu3RdEDuWg5NDixF9t0c6Zz9kZ9Aa/aQY+m85JgaCI5HYEV+UzVC/IUFFSpJiMfzQRicppLw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "connect": "^3.6.5",
         "cosmiconfig": "^5.0.5",
         "flow-enums-runtime": "^0.0.6",
-        "jest-validate": "^29.6.3",
-        "metro": "0.81.0",
-        "metro-cache": "0.81.0",
-        "metro-core": "0.81.0",
-        "metro-runtime": "0.81.0"
+        "jest-validate": "^29.7.0",
+        "metro": "0.82.3",
+        "metro-cache": "0.82.3",
+        "metro-core": "0.82.3",
+        "metro-runtime": "0.82.3"
       },
       "engines": {
         "node": ">=18.18"
       }
     },
     "node_modules/metro-core": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.81.0.tgz",
-      "integrity": "sha512-CVkM5YCOAFkNMvJai6KzA0RpztzfEKRX62/PFMOJ9J7K0uq/UkOFLxcgpcncMIrfy0PbfEj811b69tjULUQe1Q==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.82.3.tgz",
+      "integrity": "sha512-JQZDdXo3hyLl1pqVT4IKEwcBK+3f11qFXeCjQ1hjVpjMwQLOqSM02J7NC/4DNSBt+qWBxWj6R5Jphcc7+9AEWw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "lodash.throttle": "^4.1.1",
-        "metro-resolver": "0.81.0"
+        "metro-resolver": "0.82.3"
       },
       "engines": {
         "node": ">=18.18"
       }
     },
     "node_modules/metro-file-map": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.81.0.tgz",
-      "integrity": "sha512-zMDI5uYhQCyxbye/AuFx/pAbsz9K+vKL7h1ShUXdN2fz4VUPiyQYRsRqOoVG1DsiCgzd5B6LW0YW77NFpjDQeg==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.82.3.tgz",
+      "integrity": "sha512-o4wtloAge85MZl85F87FT59R/4tn5GvCvLfYcnzzDB20o2YX9AMxZqswrGMaei/GbD/Win5FrLF/Iq8oetcByA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "anymatch": "^3.0.3",
-        "debug": "^2.2.0",
+        "debug": "^4.4.0",
         "fb-watchman": "^2.0.0",
         "flow-enums-runtime": "^0.0.6",
         "graceful-fs": "^4.2.4",
         "invariant": "^2.2.4",
-        "jest-worker": "^29.6.3",
+        "jest-worker": "^29.7.0",
         "micromatch": "^4.0.4",
-        "node-abort-controller": "^3.1.1",
         "nullthrows": "^1.1.1",
         "walker": "^1.0.7"
       },
       "engines": {
         "node": ">=18.18"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
       }
     },
     "node_modules/metro-file-map/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "ms": "2.0.0"
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/metro-file-map/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/metro-minify-terser": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.81.0.tgz",
-      "integrity": "sha512-U2ramh3W822ZR1nfXgIk+emxsf5eZSg10GbQrT0ZizImK8IZ5BmJY+BHRIkQgHzWFpExOVxC7kWbGL1bZALswA==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.82.3.tgz",
+      "integrity": "sha512-/3FasOULfHq1P0KPNFy5y28Th5oknPSwEbt9JELVBMAPhUnLqQkCLr4M+RQzKG3aEQN1/mEqenWApFCkk6Nm/Q==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
@@ -11653,9 +11349,10 @@
       }
     },
     "node_modules/metro-resolver": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.81.0.tgz",
-      "integrity": "sha512-Uu2Q+buHhm571cEwpPek8egMbdSTqmwT/5U7ZVNpK6Z2ElQBBCxd7HmFAslKXa7wgpTO2FAn6MqGeERbAtVDUA==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.82.3.tgz",
+      "integrity": "sha512-pdib7UrOM04j/RjWmaqmjjWRiuCbpA8BdUSuXzvBaK0QlNzHkRRDv6kiOGxgQ+UgG+KdbPcJktsW9olqiDhf9w==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -11665,9 +11362,10 @@
       }
     },
     "node_modules/metro-runtime": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.81.0.tgz",
-      "integrity": "sha512-6oYB5HOt37RuGz2eV4A6yhcl+PUTwJYLDlY9vhT+aVjbUWI6MdBCf69vc4f5K5Vpt+yOkjy+2LDwLS0ykWFwYw==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.82.3.tgz",
+      "integrity": "sha512-J4SrUUsBy9ire8I2sFuXN5MzPmuBHlx1bjvAjdoo1ecpH2mtS3ubRqVnMotBxuK5+GhrbW0mtg5/46PVXy26cw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.25.0",
@@ -11678,9 +11376,10 @@
       }
     },
     "node_modules/metro-source-map": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.81.0.tgz",
-      "integrity": "sha512-TzsVxhH83dyxg4A4+L1nzNO12I7ps5IHLjKGZH3Hrf549eiZivkdjYiq/S5lOB+p2HiQ+Ykcwtmcja95LIC62g==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.82.3.tgz",
+      "integrity": "sha512-gz7wfjz23rit6ePQ7NKE9x+VOWGKm54vli4wbphR9W+3y0bh6Ad7T0BGH9DUzRAnOnOorewrVEqFmT24mia5sg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/traverse": "^7.25.3",
@@ -11688,9 +11387,9 @@
         "@babel/types": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-symbolicate": "0.81.0",
+        "metro-symbolicate": "0.82.3",
         "nullthrows": "^1.1.1",
-        "ob1": "0.81.0",
+        "ob1": "0.82.3",
         "source-map": "^0.5.6",
         "vlq": "^1.0.0"
       },
@@ -11699,17 +11398,17 @@
       }
     },
     "node_modules/metro-symbolicate": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.81.0.tgz",
-      "integrity": "sha512-C/1rWbNTPYp6yzID8IPuQPpVGzJ2rbWYBATxlvQ9dfK5lVNoxcwz77hjcY8ISLsRRR15hyd/zbjCNKPKeNgE1Q==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.82.3.tgz",
+      "integrity": "sha512-WZKhR+QGbwkOLWP1z58Y7BFWUqLVDEEPsSQ5UI5+OWQDAwdtsPU9+sSNoJtD5qRU9qrB2XewQE3lJ2EQRRFJew==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6",
         "invariant": "^2.2.4",
-        "metro-source-map": "0.81.0",
+        "metro-source-map": "0.82.3",
         "nullthrows": "^1.1.1",
         "source-map": "^0.5.6",
-        "through2": "^2.0.1",
         "vlq": "^1.0.0"
       },
       "bin": {
@@ -11720,9 +11419,10 @@
       }
     },
     "node_modules/metro-transform-plugins": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.81.0.tgz",
-      "integrity": "sha512-uErLAPBvttGCrmGSCa0dNHlOTk3uJFVEVWa5WDg6tQ79PRmuYRwzUgLhVzn/9/kyr75eUX3QWXN79Jvu4txt6Q==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.82.3.tgz",
+      "integrity": "sha512-s1gVrkhczwMbxZLRSLCJ16K/4Sqx5IhO4sWlL6j0jlIEs1/Drn3JrkUUdQTtgmJS8SBpxmmB66cw7wnz751dVg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -11737,9 +11437,10 @@
       }
     },
     "node_modules/metro-transform-worker": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.81.0.tgz",
-      "integrity": "sha512-HrQ0twiruhKy0yA+9nK5bIe3WQXZcC66PXTvRIos61/EASLAP2DzEmW7IxN/MGsfZegN2UzqL2CG38+mOB45vg==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.82.3.tgz",
+      "integrity": "sha512-z5Y7nYlSlLAEhjFi73uEJh69G5IC6HFZmXFcrxnY+JNlsjT2r0GgsDF4WaQGtarAIt5NP88V8983/PedwNfEcw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -11747,13 +11448,13 @@
         "@babel/parser": "^7.25.3",
         "@babel/types": "^7.25.2",
         "flow-enums-runtime": "^0.0.6",
-        "metro": "0.81.0",
-        "metro-babel-transformer": "0.81.0",
-        "metro-cache": "0.81.0",
-        "metro-cache-key": "0.81.0",
-        "metro-minify-terser": "0.81.0",
-        "metro-source-map": "0.81.0",
-        "metro-transform-plugins": "0.81.0",
+        "metro": "0.82.3",
+        "metro-babel-transformer": "0.82.3",
+        "metro-cache": "0.82.3",
+        "metro-cache-key": "0.82.3",
+        "metro-minify-terser": "0.82.3",
+        "metro-source-map": "0.82.3",
+        "metro-transform-plugins": "0.82.3",
         "nullthrows": "^1.1.1"
       },
       "engines": {
@@ -11764,42 +11465,56 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/metro/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "ms": "2.0.0"
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/metro/node_modules/hermes-estree": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.24.0.tgz",
-      "integrity": "sha512-LyoXLB7IFzeZW0EvAbGZacbxBN7t6KKSDqFJPo3Ydow7wDlrDjXwsdiAHV6XOdvEN9MEuWXsSIFN4tzpyrXIHw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.28.1.tgz",
+      "integrity": "sha512-w3nxl/RGM7LBae0v8LH2o36+8VqwOZGv9rX1wyoWT6YaKZLqpJZ0YQ5P0LVr3tuRpf7vCx0iIG4i/VmBJejxTQ==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/metro/node_modules/hermes-parser": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.24.0.tgz",
-      "integrity": "sha512-IJooSvvu2qNRe7oo9Rb04sUT4omtZqZqf9uq9WM25Tb6v3usmvA93UqfnnoWs5V0uYjEl9Al6MNU10MCGKLwpg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.28.1.tgz",
+      "integrity": "sha512-nf8o+hE8g7UJWParnccljHumE9Vlq8F7MqIdeahl+4x0tvCUJYRrT0L7h0MMg/X9YJmkNwsfbaNNrzPtFXOscg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "hermes-estree": "0.24.0"
+        "hermes-estree": "0.28.1"
       }
     },
     "node_modules/metro/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/metro/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8.3.0"
@@ -11832,6 +11547,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
       "peer": true,
       "bin": {
         "mime": "cli.js"
@@ -11855,16 +11571,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/mimic-fn": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mimic-response": {
@@ -11992,15 +11698,15 @@
       "license": "ISC"
     },
     "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "peer": true,
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -12096,7 +11802,9 @@
       }
     },
     "node_modules/mortice": {
-      "version": "3.0.4",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/mortice/-/mortice-3.0.6.tgz",
+      "integrity": "sha512-xUjsTQreX8rO3pHuGYDZ3PY/sEiONIzqzjLeog5akdY4bz9TlDDuvYlU8fm+6qnm4rnpa6AFxLhsfSBThLijdA==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "observable-webworkers": "^2.0.1",
@@ -12104,37 +11812,14 @@
         "p-timeout": "^6.0.0"
       }
     },
-    "node_modules/mortice/node_modules/p-queue": {
-      "version": "8.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "eventemitter3": "^5.0.1",
-        "p-timeout": "^6.1.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "license": "MIT"
     },
-    "node_modules/multibase": {
-      "version": "4.0.6",
-      "license": "MIT",
-      "dependencies": {
-        "@multiformats/base-x": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
-    },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
       "license": "MIT",
       "dependencies": {
         "dns-packet": "^5.2.2",
@@ -12145,22 +11830,10 @@
       }
     },
     "node_modules/multiformats": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.1.tgz",
-      "integrity": "sha512-QxowxTNwJ3r5RMctoGA5p13w5RbRT2QDkoM+yFlqfLiioBp78nhDjnRLvmSBI9+KAqN4VdgOVWM9c0CHd86m3g=="
-    },
-    "node_modules/multihashes": {
-      "version": "4.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "multibase": "^4.0.1",
-        "uint8arrays": "^3.0.0",
-        "varint": "^5.0.2"
-      },
-      "engines": {
-        "node": ">=12.0.0",
-        "npm": ">=6.0.0"
-      }
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.3.tgz",
+      "integrity": "sha512-TlaFCzs3NHNzMpwiGwRYehnnhHlZcWfptygFekshlb9xCyO09GfN+9881+VBENCdRnKOeqmMxDCbupNecV8xRQ==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/murmurhash3js-revisited": {
       "version": "3.0.0",
@@ -12188,7 +11861,9 @@
       }
     },
     "node_modules/napi-build-utils": {
-      "version": "1.0.2",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
     "node_modules/native-fetch": {
@@ -12215,12 +11890,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "peer": true
     },
     "node_modules/netmask": {
       "version": "2.0.2",
@@ -12253,57 +11922,10 @@
         "node": ">=10"
       }
     },
-    "node_modules/node-abort-controller": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-3.1.1.tgz",
-      "integrity": "sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==",
-      "peer": true
-    },
     "node_modules/node-addon-api": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
-    },
-    "node_modules/node-datachannel": {
-      "version": "0.5.3",
-      "hasInstallScript": true,
-      "license": "MPL 2.0",
-      "dependencies": {
-        "node-domexception": "^2.0.1",
-        "prebuild-install": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/node-dir": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
-      "integrity": "sha512-tmPX422rYgofd4epzrNoOXiE8XFZYOcCq1vD7MAXCDO+O+zndlA2ztdKKMa+EeuBG5tHETpr4ml4RGgpqDCCAg==",
-      "peer": true,
-      "dependencies": {
-        "minimatch": "^3.0.2"
-      },
-      "engines": {
-        "node": ">= 0.10.5"
-      }
-    },
-    "node_modules/node-domexception": {
-      "version": "2.0.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -12326,6 +11948,8 @@
     },
     "node_modules/node-forge": {
       "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
@@ -12393,29 +12017,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/npm-run-path": {
-      "version": "5.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm-run-path/node_modules/path-key": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/npmlog": {
       "version": "6.0.2",
       "license": "ISC",
@@ -12434,12 +12035,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
       "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/ob1": {
-      "version": "0.81.0",
-      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.81.0.tgz",
-      "integrity": "sha512-6Cvrkxt1tqaRdWqTAMcVYEiO5i1xcF9y7t06nFdjFqkfPsEloCf8WwhXdwBpNUkVYSQlSGS7cDgVQR86miBfBQ==",
+      "version": "0.82.3",
+      "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.82.3.tgz",
+      "integrity": "sha512-8/SeymYlPMVODpCATHqm+X8eiuvD1GsKVa11n688V4GGgjrM3CRvrbtrYBs4t89LJDkv5CwGYPdqayuY0DmTTA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "flow-enums-runtime": "^0.0.6"
@@ -12569,6 +12172,8 @@
     },
     "node_modules/observable-webworkers": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/observable-webworkers/-/observable-webworkers-2.0.1.tgz",
+      "integrity": "sha512-JI1vB0u3pZjoQKOK1ROWzp0ygxSi7Yb0iR+7UNsw4/Zn4cQ0P3R7XL38zac/Dy2tEA7Lg88/wIJTjF8vYXZ0uw==",
       "license": "Apache-2.0 OR MIT",
       "engines": {
         "node": ">=16.0.0",
@@ -12579,6 +12184,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
@@ -12594,23 +12200,11 @@
         "wrappy": "1"
       }
     },
-    "node_modules/onetime": {
-      "version": "6.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/open": {
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
       "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "is-docker": "^2.0.0",
@@ -12664,7 +12258,9 @@
       }
     },
     "node_modules/p-event": {
-      "version": "6.0.0",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
+      "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
       "license": "MIT",
       "dependencies": {
         "p-timeout": "^6.1.2"
@@ -12731,31 +12327,25 @@
       }
     },
     "node_modules/p-queue": {
-      "version": "7.4.1",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-8.1.0.tgz",
+      "integrity": "sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.1",
-        "p-timeout": "^5.0.2"
+        "p-timeout": "^6.1.2"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-queue/node_modules/p-timeout": {
-      "version": "5.1.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-retry": {
-      "version": "6.2.0",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
+      "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
       "license": "MIT",
       "dependencies": {
         "@types/retry": "0.12.2",
@@ -12770,7 +12360,9 @@
       }
     },
     "node_modules/p-timeout": {
-      "version": "6.1.2",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
@@ -12784,6 +12376,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/p-wait-for": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-5.0.2.tgz",
+      "integrity": "sha512-lwx6u1CotQYPVju77R+D0vFomni/AqRfqLmqQ8hekklqZ6gAY9rONh7lBQ0uxWMkC2AuX9b2DVAl8To0NyP1JA==",
+      "license": "MIT",
+      "dependencies": {
+        "p-timeout": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/parent-module": {
@@ -12814,6 +12421,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "error-ex": "^1.3.1",
@@ -12827,6 +12435,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 0.8"
@@ -12848,6 +12457,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12855,6 +12465,7 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-type": {
@@ -12880,78 +12491,11 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/pirates": {
       "version": "4.0.6",
       "license": "MIT",
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/pkg-dir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-      "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-      "peer": true,
-      "dependencies": {
-        "find-up": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "peer": true,
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "peer": true,
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "peer": true,
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -12963,7 +12507,9 @@
       }
     },
     "node_modules/prebuild-install": {
-      "version": "7.1.1",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
       "license": "MIT",
       "dependencies": {
         "detect-libc": "^2.0.0",
@@ -12971,7 +12517,7 @@
         "github-from-package": "0.0.0",
         "minimist": "^1.2.3",
         "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
+        "napi-build-utils": "^2.0.0",
         "node-abi": "^3.3.0",
         "pump": "^3.0.0",
         "rc": "^1.2.7",
@@ -13018,25 +12564,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/private-ip": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "@chainsafe/is-ip": "^2.0.1",
-        "ip-regex": "^5.0.0",
-        "ipaddr.js": "^2.1.0",
-        "netmask": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "peer": true
-    },
     "node_modules/progress-events": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.0.1.tgz",
@@ -13044,6 +12571,8 @@
     },
     "node_modules/promise": {
       "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
+      "integrity": "sha512-rZPNPKTOYVNEEKFaq1HqTgOwZD+4/YHS5ukLzQCypkj+OkYx7iv0mA91lJlpPPZ8vMau3IIGj5Qlwrx+8iiSmg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -13116,28 +12645,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/protobufjs": {
-      "version": "7.2.5",
-      "hasInstallScript": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/protons-runtime": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-5.5.0.tgz",
@@ -13146,13 +12653,6 @@
         "uint8-varint": "^2.0.2",
         "uint8arraylist": "^2.4.3",
         "uint8arrays": "^5.0.1"
-      }
-    },
-    "node_modules/protons-runtime/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
       }
     },
     "node_modules/proxy-from-env": {
@@ -13189,10 +12689,29 @@
       ],
       "license": "MIT"
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/queue": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
       "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "inherits": "~2.0.3"
@@ -13256,14 +12775,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/rate-limiter-flexible": {
-      "version": "4.0.0",
-      "license": "ISC"
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -13279,21 +12795,20 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "license": "MIT",
       "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-devtools-core": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-5.3.2.tgz",
-      "integrity": "sha512-crr9HkVrDiJ0A4zot89oS0Cgv0Oa4OG1Em4jit3P3ZxZSKPMYyMjfwMqgcJna9o625g8oN87rBm8SWWrSTBZxg==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-6.1.2.tgz",
+      "integrity": "sha512-ldFwzufLletzCikNJVYaxlxMLu7swJ3T2VrGfzXlMsVhZhPDKXA38DEROidaYZVgMAmQnIjymrmqto5pyfrwPA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
@@ -13304,6 +12819,7 @@
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=8.3.0"
@@ -13327,24 +12843,25 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/react-native": {
-      "version": "0.76.2",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.76.2.tgz",
-      "integrity": "sha512-mkEBKGOmJxhfq8IOsvmk0QuTzlBt9vS+uo0gwbqfUmEDqoC359v80zhUf94WimYBrBkpRQWFbEu5iqMDHrYzlQ==",
+      "version": "0.79.2",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.79.2.tgz",
+      "integrity": "sha512-AnGzb56JvU5YCL7cAwg10+ewDquzvmgrMddiBM0GAWLwQM/6DJfGd2ZKrMuKKehHerpDDZgG+EY64gk3x3dEkw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@jest/create-cache-key-function": "^29.6.3",
-        "@react-native/assets-registry": "0.76.2",
-        "@react-native/codegen": "0.76.2",
-        "@react-native/community-cli-plugin": "0.76.2",
-        "@react-native/gradle-plugin": "0.76.2",
-        "@react-native/js-polyfills": "0.76.2",
-        "@react-native/normalize-colors": "0.76.2",
-        "@react-native/virtualized-lists": "0.76.2",
+        "@jest/create-cache-key-function": "^29.7.0",
+        "@react-native/assets-registry": "0.79.2",
+        "@react-native/codegen": "0.79.2",
+        "@react-native/community-cli-plugin": "0.79.2",
+        "@react-native/gradle-plugin": "0.79.2",
+        "@react-native/js-polyfills": "0.79.2",
+        "@react-native/normalize-colors": "0.79.2",
+        "@react-native/virtualized-lists": "0.79.2",
         "abort-controller": "^3.0.0",
         "anser": "^1.4.9",
         "ansi-regex": "^5.0.0",
         "babel-jest": "^29.7.0",
-        "babel-plugin-syntax-hermes-parser": "^0.23.1",
+        "babel-plugin-syntax-hermes-parser": "0.25.1",
         "base64-js": "^1.5.1",
         "chalk": "^4.0.0",
         "commander": "^12.0.0",
@@ -13352,19 +12869,17 @@
         "flow-enums-runtime": "^0.0.6",
         "glob": "^7.1.1",
         "invariant": "^2.2.4",
-        "jest-environment-node": "^29.6.3",
-        "jsc-android": "^250231.0.0",
+        "jest-environment-node": "^29.7.0",
         "memoize-one": "^5.0.0",
-        "metro-runtime": "^0.81.0",
-        "metro-source-map": "^0.81.0",
-        "mkdirp": "^0.5.1",
+        "metro-runtime": "^0.82.0",
+        "metro-source-map": "^0.82.0",
         "nullthrows": "^1.1.1",
         "pretty-format": "^29.7.0",
         "promise": "^8.3.0",
-        "react-devtools-core": "^5.3.1",
+        "react-devtools-core": "^6.1.1",
         "react-refresh": "^0.14.0",
         "regenerator-runtime": "^0.13.2",
-        "scheduler": "0.24.0-canary-efb381bbf-20230505",
+        "scheduler": "0.25.0",
         "semver": "^7.1.3",
         "stacktrace-parser": "^0.1.10",
         "whatwg-fetch": "^3.0.0",
@@ -13378,8 +12893,8 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@types/react": "^18.2.6",
-        "react": "^18.2.0"
+        "@types/react": "^19.0.0",
+        "react": "^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -13404,7 +12919,9 @@
       }
     },
     "node_modules/react-native-webrtc": {
-      "version": "118.0.0",
+      "version": "124.0.5",
+      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-124.0.5.tgz",
+      "integrity": "sha512-LIQJKst+t53bJOcQef9VXuz3pVheSBUA4olQGkxosbF4pHW1gsWoXYmf6wmI2zrqOA+aZsjjB6aT9AKLyr6a0Q==",
       "license": "MIT",
       "dependencies": {
         "base64-js": "1.5.1",
@@ -13417,6 +12934,8 @@
     },
     "node_modules/react-native-webrtc/node_modules/event-target-shim": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
       "license": "MIT",
       "engines": {
         "node": ">=10.13.0"
@@ -13429,6 +12948,7 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
       "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=18"
@@ -13436,6 +12956,8 @@
     },
     "node_modules/react-native/node_modules/ws": {
       "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
+      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -13446,6 +12968,7 @@
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -13461,36 +12984,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/readline": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/readline/-/readline-1.3.0.tgz",
-      "integrity": "sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg==",
-      "peer": true
-    },
-    "node_modules/recast": {
-      "version": "0.21.5",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.21.5.tgz",
-      "integrity": "sha512-hjMmLaUXAm1hIuTqOdeYObMslq/q+Xff6QE3Y2P+uoHAg2nmVlLBps2hzh1UJDdMtDTMXOFewK6ky51JQIeECg==",
-      "peer": true,
-      "dependencies": {
-        "ast-types": "0.15.2",
-        "esprima": "~4.0.0",
-        "source-map": "~0.6.1",
-        "tslib": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/recast/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/redis-errors": {
@@ -13511,6 +13004,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.6",
@@ -13535,12 +13034,14 @@
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
-      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A=="
+      "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+      "dev": true
     },
     "node_modules/regenerate-unicode-properties": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
       "integrity": "sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==",
+      "dev": true,
       "dependencies": {
         "regenerate": "^1.4.2"
       },
@@ -13550,11 +13051,14 @@
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.4"
@@ -13581,6 +13085,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.1.1.tgz",
       "integrity": "sha512-k67Nb9jvwJcJmVpw0jPttR1/zVfnKf8Km0IPatrU/zJ5XeG3+Slx0xLXs9HByJSzXzrlz5EDvN6yLNMDc2qdnw==",
+      "dev": true,
       "dependencies": {
         "regenerate": "^1.4.2",
         "regenerate-unicode-properties": "^10.2.0",
@@ -13596,12 +13101,14 @@
     "node_modules/regjsgen": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
-      "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q=="
+      "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
+      "dev": true
     },
     "node_modules/regjsparser": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.11.2.tgz",
       "integrity": "sha512-3OGZZ4HoLJkkAZx/48mTXJNlmqTGOzc0o9OWQPuWpkOlXXPbyN6OafCcoXUnBqE2D3f/T5L+pWc1kdEmnfnRsA==",
+      "dev": true,
       "dependencies": {
         "jsesc": "~3.0.2"
       },
@@ -13618,6 +13125,7 @@
     },
     "node_modules/resolve": {
       "version": "1.22.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.13.0",
@@ -13654,6 +13162,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
       "integrity": "sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=4"
@@ -13667,12 +13176,16 @@
         "node": ">=10"
       }
     },
-    "node_modules/retimer": {
-      "version": "3.0.0",
-      "license": "MIT"
+    "node_modules/retimeable-signal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/retimeable-signal/-/retimeable-signal-1.0.1.tgz",
+      "integrity": "sha512-Cy26CYfbWnYu8HMoJeDhaMpW/EYFIbne3vMf6G9RSrOyWYXbPehja/BEdzpqmM84uy2bfBD7NPZhoQ4GZEtgvg==",
+      "license": "Apache-2.0 OR MIT"
     },
     "node_modules/retry": {
       "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -13790,22 +13303,25 @@
     },
     "node_modules/sanitize-filename": {
       "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
       "license": "WTFPL OR ISC",
       "dependencies": {
         "truncate-utf8-bytes": "^1.0.0"
       }
     },
     "node_modules/sax": {
-      "version": "1.3.0",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
       "license": "ISC"
     },
     "node_modules/scheduler": {
-      "version": "0.24.0-canary-efb381bbf-20230505",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
       "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "peer": true
     },
     "node_modules/secp256k1": {
       "version": "4.0.4",
@@ -13819,19 +13335,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/selfsigned": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
-      "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
-      "peer": true,
-      "dependencies": {
-        "@types/node-forge": "^1.3.0",
-        "node-forge": "^1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/semver": {
@@ -13849,6 +13352,7 @@
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
       "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "debug": "2.6.9",
@@ -13873,6 +13377,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ms": "2.0.0"
@@ -13882,18 +13387,21 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/send/node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
@@ -13906,6 +13414,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 0.8"
@@ -13915,6 +13424,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
       "integrity": "sha512-ghgmKt5o4Tly5yEG/UJp8qTd0AN7Xalw4XBtDEKP655B699qMEtra1WlXeE6WIvdEG481JvRxULKsInq/iNysw==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -13924,6 +13434,7 @@
       "version": "1.16.2",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
       "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "encodeurl": "~2.0.0",
@@ -13939,6 +13450,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 0.8"
@@ -13983,6 +13495,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC",
       "peer": true
     },
     "node_modules/sha.js": {
@@ -13994,18 +13507,6 @@
       },
       "bin": {
         "sha.js": "bin.js"
-      }
-    },
-    "node_modules/shallow-clone": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-      "peer": true,
-      "dependencies": {
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/sharp": {
@@ -14048,6 +13549,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -14058,16 +13560,21 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
-      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
+      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
+      "license": "MIT",
       "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -14253,6 +13760,7 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "license": "BSD-3-Clause",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -14262,6 +13770,7 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -14272,6 +13781,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -14358,10 +13868,13 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/stacktrace-parser": {
-      "version": "0.1.10",
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/stacktrace-parser/-/stacktrace-parser-0.1.11.tgz",
+      "integrity": "sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14380,6 +13893,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 0.6"
@@ -14408,15 +13922,13 @@
       }
     },
     "node_modules/stream-to-it": {
-      "version": "0.2.4",
-      "license": "MIT",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-1.0.1.tgz",
+      "integrity": "sha512-AqHYAYPHcmvMrcLNgncE/q0Aj/ajP6A4qGhxP6EVn7K3YTNs0bJpJyk57wc2Heb7MUL64jurvmnmui8D9kjZgA==",
+      "license": "Apache-2.0 OR MIT",
       "dependencies": {
-        "get-iterator": "^1.0.2"
+        "it-stream-types": "^2.0.1"
       }
-    },
-    "node_modules/stream-to-it/node_modules/get-iterator": {
-      "version": "1.0.2",
-      "license": "MIT"
     },
     "node_modules/strict-event-emitter": {
       "version": "0.5.1",
@@ -14575,21 +14087,28 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-final-newline": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/super-regex": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-0.2.0.tgz",
+      "integrity": "sha512-WZzIx3rC1CvbMDloLsVw0lkZVKJWbrkJ0k1ghKFmcnPrW1+jWbgTkTEWVtD9lMdmI4jZEz40+naBxl1dCUhXXw==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-regexp": "^3.0.0",
+        "function-timeout": "^0.1.0",
+        "time-span": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/supports-color": {
@@ -14605,6 +14124,7 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -14730,49 +14250,15 @@
         "node": ">=8"
       }
     },
-    "node_modules/tar/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/tar/node_modules/yallist": {
       "version": "4.0.0",
       "license": "ISC"
     },
-    "node_modules/temp": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
-      "integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
-      "peer": true,
-      "dependencies": {
-        "rimraf": "~2.6.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/temp/node_modules/rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "peer": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      }
-    },
     "node_modules/terser": {
-      "version": "5.36.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.36.0.tgz",
-      "integrity": "sha512-IYV9eNMuFAV4THUspIRXkLakHnV6XO7FEdtKjf/mDyrnqUg9LnlOn6/RwRvM9SZjR4GUq8Nk8zj67FzVARr74w==",
+      "version": "5.39.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
+      "integrity": "sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==",
+      "license": "BSD-2-Clause",
       "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -14791,6 +14277,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/test-exclude": {
@@ -14814,65 +14301,56 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+      "license": "MIT",
       "peer": true
-    },
-    "node_modules/through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "peer": true,
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
-    },
-    "node_modules/through2/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "peer": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/through2/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "peer": true
-    },
-    "node_modules/through2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
     },
     "node_modules/thunky": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "license": "MIT"
     },
-    "node_modules/timeout-abort-controller": {
-      "version": "3.0.0",
+    "node_modules/time-span": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+      "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
       "license": "MIT",
       "dependencies": {
-        "retimer": "^3.0.0"
+        "convert-hrtime": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/timestamp-nano": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/timestamp-nano/-/timestamp-nano-1.0.1.tgz",
+      "integrity": "sha512-4oGOVZWTu5sl89PtCDnhQBSt7/vL1zVEwAfxH1p49JhTosxzVQWYBYFRFZ8nJmo0G6f824iyP/44BFAwIoKvIA==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.5.0"
       }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT"
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -14892,9 +14370,22 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -14904,6 +14395,8 @@
     },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
       "license": "WTFPL",
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
@@ -15011,6 +14504,24 @@
       "dev": true,
       "license": "0BSD"
     },
+    "node_modules/tsyringe": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+      "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/tsyringe/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
+    },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
       "license": "Apache-2.0",
@@ -15041,6 +14552,8 @@
     },
     "node_modules/type-fest": {
       "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
+      "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==",
       "license": "(MIT OR CC0-1.0)",
       "peer": true,
       "engines": {
@@ -15130,18 +14643,13 @@
       }
     },
     "node_modules/uint8-varint": {
-      "version": "2.0.3",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.4.tgz",
+      "integrity": "sha512-FwpTa7ZGA/f/EssWAb5/YV6pHgVF1fViKdW8cWaEarjB8t7NyofSWBdOTyFPaGuUG4gx3v1O3PQ8etsiOs3lcw==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "uint8arraylist": "^2.0.0",
         "uint8arrays": "^5.0.0"
-      }
-    },
-    "node_modules/uint8-varint/node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "license": "Apache-2.0 OR MIT",
-      "dependencies": {
-        "multiformats": "^13.0.0"
       }
     },
     "node_modules/uint8arraylist": {
@@ -15151,23 +14659,14 @@
         "uint8arrays": "^5.0.1"
       }
     },
-    "node_modules/uint8arraylist/node_modules/uint8arrays": {
-      "version": "5.0.1",
+    "node_modules/uint8arrays": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.0.tgz",
+      "integrity": "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "multiformats": "^13.0.0"
       }
-    },
-    "node_modules/uint8arrays": {
-      "version": "3.1.1",
-      "license": "MIT",
-      "dependencies": {
-        "multiformats": "^9.4.2"
-      }
-    },
-    "node_modules/uint8arrays/node_modules/multiformats": {
-      "version": "9.9.0",
-      "license": "(Apache-2.0 AND MIT)"
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
@@ -15184,12 +14683,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.5.0.tgz",
-      "integrity": "sha512-NFQG741e8mJ0fLQk90xKxFdaSM7z4+IQpAgsFI36bCDY9Z2+aXXZjVy2uUksMouWfMI9+w5ejOq5zYYTBCQJDQ==",
-      "peer": true,
+      "version": "6.21.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
+      "integrity": "sha512-uROZWze0R0itiAKVPsYhFov9LxrPMHLMEQFszeI2gCN6bnIIZ8twzBCJcN2LJrBBLfrP0t1FW0g+JmKVl8Vk1g==",
+      "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -15201,6 +14700,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
       "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -15209,6 +14709,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
       "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
+      "dev": true,
       "dependencies": {
         "unicode-canonical-property-names-ecmascript": "^2.0.0",
         "unicode-property-aliases-ecmascript": "^2.0.0"
@@ -15221,6 +14722,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
       "integrity": "sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -15229,6 +14731,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
       "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -15253,6 +14756,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 0.8"
@@ -15296,8 +14800,10 @@
       }
     },
     "node_modules/utf8-byte-length": {
-      "version": "1.0.4",
-      "license": "WTFPL"
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+      "license": "(WTFPL OR MIT)"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -15307,6 +14813,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">= 0.4.0"
@@ -15346,25 +14853,11 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/varint": {
-      "version": "5.0.2",
-      "license": "MIT"
-    },
-    "node_modules/varint-decoder": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "varint": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0",
-        "npm": ">=3.0.0"
-      }
-    },
     "node_modules/vlq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
       "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
+      "license": "MIT",
       "peer": true
     },
     "node_modules/walker": {
@@ -15402,6 +14895,19 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/webcrypto-core": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.1.tgz",
+      "integrity": "sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==",
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.7.0"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -15409,6 +14915,8 @@
     },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT",
       "peer": true
     },
@@ -15434,6 +14942,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -15552,19 +15061,10 @@
       "version": "1.0.2",
       "license": "ISC"
     },
-    "node_modules/write-file-atomic": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
-      }
-    },
     "node_modules/ws": {
-      "version": "8.18.0",
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -15584,6 +15084,8 @@
     },
     "node_modules/xml2js": {
       "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
       "license": "MIT",
       "dependencies": {
         "sax": ">=0.6.0",
@@ -15595,18 +15097,11 @@
     },
     "node_modules/xmlbuilder": {
       "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {
@@ -15745,14 +15240,14 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@helia/json": "^2.0.0",
+        "@helia/json": "^4.0.3",
         "@helia/unixfs": "^5.0.0",
         "axios": "^1.7.7",
         "blockstore-fs": "^2.0.2",
-        "helia": "^3.0.0",
+        "helia": "^5.3.0",
         "ip": "^2.0.1",
         "kubo-rpc-client": "^5.1.0",
-        "multiformats": "^13.0.0"
+        "multiformats": "^13.3.3"
       },
       "devDependencies": {
         "@types/ip": "^1.1.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "keychain",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "keychain",
-      "version": "0.1.0",
+      "version": "1.1.0",
       "license": "ISC",
       "workspaces": [
         "packages/*"
@@ -147,13 +147,14 @@
       "integrity": "sha512-HazVq9zwTVwGmqdwYzu7WyQ6FQVZ7SwET0KKQuKm55jD0IfUpZgN0OPIiZG3zV1iSrVYcN0bdwLRXI/VNCYsUA=="
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -494,17 +495,19 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-      "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -531,23 +534,25 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-      "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.1.tgz",
+      "integrity": "sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.25.9",
-        "@babel/types": "^7.26.0"
+        "@babel/template": "^7.27.1",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.2.tgz",
-      "integrity": "sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.2.tgz",
+      "integrity": "sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.26.0"
+        "@babel/types": "^7.27.1"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2072,28 +2077,23 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
+      "integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "license": "MIT"
-    },
     "node_modules/@babel/template": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-      "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.25.9",
-        "@babel/parser": "^7.25.9",
-        "@babel/types": "^7.25.9"
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2136,12 +2136,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.0.tgz",
-      "integrity": "sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.1.tgz",
+      "integrity": "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.25.9",
-        "@babel/helper-validator-identifier": "^7.25.9"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -4042,9 +4043,10 @@
       }
     },
     "node_modules/@mdip/browser-hdkey/node_modules/base-x": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
-      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
+      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
+      "license": "MIT"
     },
     "node_modules/@mdip/browser-hdkey/node_modules/bs58": {
       "version": "5.0.0",
@@ -5696,7 +5698,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.7",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -6007,7 +6011,9 @@
       "license": "MIT"
     },
     "node_modules/base-x": {
-      "version": "3.0.9",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -8977,9 +8983,10 @@
       }
     },
     "node_modules/image-size": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.1.1.tgz",
-      "integrity": "sha512-541xKlUw6jr/6gGuk92F+mYM5zaFAc5ahphvkqvNe2bQ6gVBkd6bfrmVJ2t4KDAfikAYZyIqTnktX3i6/aQDrQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "license": "MIT",
       "peer": true,
       "dependencies": {
         "queue": "6.0.2"
@@ -14684,7 +14691,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.1",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
+      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",
@@ -15686,7 +15695,7 @@
     },
     "packages/cipher": {
       "name": "@mdip/cipher",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@mdip/browser-hdkey": "^0.1.8",
@@ -15702,7 +15711,7 @@
     },
     "packages/common": {
       "name": "@mdip/common",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@mdip/ipfs": "*"
@@ -15716,7 +15725,7 @@
     },
     "packages/gatekeeper": {
       "name": "@mdip/gatekeeper",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@mdip/cipher": "*",
@@ -15733,7 +15742,7 @@
     },
     "packages/ipfs": {
       "name": "@mdip/ipfs",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@helia/json": "^2.0.0",
@@ -15751,7 +15760,7 @@
     },
     "packages/keymaster": {
       "name": "@mdip/keymaster",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@mdip/common": "*",
@@ -15764,9 +15773,10 @@
       }
     },
     "packages/keymaster/node_modules/image-size": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.1.tgz",
-      "integrity": "sha512-NI6NK/2zchlZopsQrcVIS7jxA0/rtIy74B+/rx5s7rKQyFebmQjZVhzxXgRZJROk+WhhOq+S6sUaODxp0L5hfg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
+      "license": "MIT",
       "bin": {
         "image-size": "bin/image-size.js"
       },

--- a/packages/cipher/src/cipher-node.ts
+++ b/packages/cipher/src/cipher-node.ts
@@ -7,16 +7,9 @@ import { managedNonce } from '@noble/ciphers/webcrypto/utils'
 import { bytesToUtf8, utf8ToBytes } from '@noble/ciphers/utils';
 import { base64url } from 'multiformats/bases/base64';
 import HDKeyNode from 'hdkey';
-import { webcrypto } from 'node:crypto';
 import { Cipher, HDKeyJSON, EcdsaJwkPublic, EcdsaJwkPrivate, EcdsaJwkPair } from './types.js';
 import canonicalizeModule from 'canonicalize';
 const canonicalize = canonicalizeModule as unknown as (input: unknown) => string;
-
-// node.js 18 and older, requires polyfilling globalThis.crypto
-if (!globalThis.crypto) {
-    // @ts-expect-error: globalThis may not be declared
-    globalThis.crypto = webcrypto
-}
 
 // Polyfill for synchronous signatures
 // Recommendation from https://github.com/paulmillr/noble-secp256k1/blob/main/README.md

--- a/packages/gatekeeper/package.json
+++ b/packages/gatekeeper/package.json
@@ -24,6 +24,10 @@
       "import": "./dist/db/json-cache.js",
       "types": "./dist/types/db/json-cache.d.ts"
     },
+    "./db/json-memory": {
+      "import": "./dist/db/json-memory.js",
+      "types": "./dist/types/db/json-memory.d.ts"
+    },
     "./db/sqlite": {
       "import": "./dist/db/sqlite.js",
       "types": "./dist/types/db/sqlite.d.ts"

--- a/packages/gatekeeper/src/db/json-memory.ts
+++ b/packages/gatekeeper/src/db/json-memory.ts
@@ -2,7 +2,7 @@ import { JsonDbFile } from '../types.js';
 import { AbstractJson } from "./abstract-json.js";
 
 export default class DbJsonMemory extends AbstractJson {
-    private dbCache: JsonDbFile | null = null;
+    private dbCache: string | null = null;
 
     constructor(name: string, folder: string = 'data') {
         super(name, folder);
@@ -11,13 +11,13 @@ export default class DbJsonMemory extends AbstractJson {
 
     protected loadDb(): JsonDbFile {
         if (!this.dbCache) {
-            this.dbCache = { dids: {} }; // Initialize an empty in-memory database
+            this.dbCache = JSON.stringify({ dids: {} });
         }
-        return JSON.parse(JSON.stringify(this.dbCache));
+        return JSON.parse(this.dbCache);
     }
 
     protected writeDb(db: JsonDbFile): void {
-        this.dbCache = JSON.parse(JSON.stringify(db));
+        this.dbCache = JSON.stringify(db);
     }
 
     async resetDb(): Promise<JsonDbFile> {

--- a/packages/gatekeeper/src/db/json-memory.ts
+++ b/packages/gatekeeper/src/db/json-memory.ts
@@ -1,0 +1,27 @@
+import { JsonDbFile } from '../types.js';
+import { AbstractJson } from "./abstract-json.js";
+
+export default class DbJsonMemory extends AbstractJson {
+    private dbCache: JsonDbFile | null = null;
+
+    constructor(name: string, folder: string = 'data') {
+        super(name, folder);
+        this.loadDb();
+    }
+
+    protected loadDb(): JsonDbFile {
+        if (!this.dbCache) {
+            this.dbCache = { dids: {} }; // Initialize an empty in-memory database
+        }
+        return JSON.parse(JSON.stringify(this.dbCache));
+    }
+
+    protected writeDb(db: JsonDbFile): void {
+        this.dbCache = JSON.parse(JSON.stringify(db));
+    }
+
+    async resetDb(): Promise<JsonDbFile> {
+        this.dbCache = null;
+        return this.loadDb();
+    }
+}

--- a/packages/gatekeeper/src/gatekeeper.ts
+++ b/packages/gatekeeper/src/gatekeeper.ts
@@ -753,10 +753,7 @@ export default class Gatekeeper implements GatekeeperInterface {
             return false;
         }
 
-        const registry = doc.mdip?.registry;
-        if (!registry) {
-            throw new InvalidOperationError('no registry in doc.mdip')
-        }
+        const registry = doc.mdip?.registry || 'missing registry';
 
         // Reject operations with unsupported registries
         if (!this.supportedRegistries.includes(registry)) {

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -34,14 +34,14 @@
   "author": "David McFadzean <davidmc@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@helia/json": "^2.0.0",
+    "@helia/json": "^4.0.3",
     "@helia/unixfs": "^5.0.0",
     "axios": "^1.7.7",
     "blockstore-fs": "^2.0.2",
-    "helia": "^3.0.0",
+    "helia": "^5.3.0",
     "ip": "^2.0.1",
     "kubo-rpc-client": "^5.1.0",
-    "multiformats": "^13.0.0"
+    "multiformats": "^13.3.3"
   },
   "repository": {
     "type": "git",

--- a/packages/keymaster/package.json
+++ b/packages/keymaster/package.json
@@ -24,6 +24,10 @@
       "import": "./dist/db/json-enc.js",
       "types": "./dist/types/db/json-enc.d.ts"
     },
+    "./wallet/json-memory": {
+      "import": "./dist/db/json-memory.js",
+      "types": "./dist/types/db/json-memory.d.ts"
+    },
     "./wallet/redis": {
       "import": "./dist/db/redis.js",
       "types": "./dist/types/db/redis.d.ts"

--- a/packages/keymaster/src/db/json-memory.ts
+++ b/packages/keymaster/src/db/json-memory.ts
@@ -1,0 +1,21 @@
+import { StoredWallet, WalletBase } from '../types.js';
+
+export default class WalletJsonMemory implements WalletBase {
+    walletCache: string | null = null;
+
+    async saveWallet(wallet: StoredWallet, overwrite: boolean = false): Promise<boolean> {
+        if (this.walletCache && !overwrite) {
+            return false;
+        }
+        this.walletCache = JSON.stringify(wallet);
+        return true;
+    }
+
+    async loadWallet(): Promise<StoredWallet> {
+        if (!this.walletCache) {
+            return null;
+        }
+
+        return JSON.parse(this.walletCache);
+    }
+}

--- a/tests/gatekeeper.test.ts
+++ b/tests/gatekeeper.test.ts
@@ -2772,22 +2772,6 @@ describe('checkDIDs', () => {
         expect(check.total).toBe(3);
         expect(check.byType.invalid).toBe(1);
     });
-
-    // it('should reset a corrupted db', async () => {
-    //     mockFs({});
-
-    //     const keypair = cipher.generateRandomJwk();
-    //     const agentOp = await createAgentOp(keypair);
-    //     const agentDID = await gatekeeper.createDID(agentOp);
-    //     const assetOp = await createAssetOp(agentDID, keypair);
-    //     await gatekeeper.createDID(assetOp);
-
-    //     fs.writeFileSync('data/test.json', "{ dids: {");
-
-    //     const { total } = await gatekeeper.checkDIDs();
-
-    //     expect(total).toBe(0);
-    // });
 });
 
 

--- a/tests/gatekeeper.test.ts
+++ b/tests/gatekeeper.test.ts
@@ -1122,17 +1122,27 @@ describe('updateDID', () => {
     });
 
     it('should throw exception on invalid update operation', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const agentOp = await createAgentOp(keypair);
+        const did = await gatekeeper.createDID(agentOp);
+        const doc = await gatekeeper.resolveDID(did);
+
         try {
-            const keypair = cipher.generateRandomJwk();
-            const agentOp = await createAgentOp(keypair);
-            const did = await gatekeeper.createDID(agentOp);
-            const doc = await gatekeeper.resolveDID(did);
             const updateOp = await createUpdateOp(keypair, did, doc);
             delete updateOp.signature;
             await gatekeeper.updateDID(updateOp);
             throw new ExpectedExceptionError();
         } catch (error: any) {
             expect(error.message).toBe('Invalid operation: signature');
+        }
+
+        try {
+            const updateOp = await createUpdateOp(keypair, did, doc);
+            delete updateOp.did;
+            await gatekeeper.updateDID(updateOp);
+            throw new ExpectedExceptionError();
+        } catch (error: any) {
+            expect(error.message).toBe('Invalid operation: missing operation.did');
         }
     });
 

--- a/tests/gatekeeper.test.ts
+++ b/tests/gatekeeper.test.ts
@@ -1,5 +1,3 @@
-import mockFs from 'mock-fs';
-import fs from 'fs';
 import CipherNode from '@mdip/cipher/node';
 import { Operation, MdipDocument, BlockInfo } from '@mdip/gatekeeper/types';
 import Gatekeeper from '@mdip/gatekeeper';
@@ -173,13 +171,8 @@ async function createAssetOp(
 
 describe('constructor', () => {
 
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should throw exception on invalid parameters', async () => {
-        mockFs({});
-
         try {
             // @ts-expect-error Testing invalid usage
             new Gatekeeper();
@@ -201,13 +194,8 @@ describe('constructor', () => {
 
 describe('generateDID', () => {
 
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should create DID from operation', async () => {
-        mockFs({});
-
         const mockTxn: Operation = {
             type: "create",
             created: new Date().toISOString(),
@@ -223,8 +211,6 @@ describe('generateDID', () => {
     });
 
     it('should create DID from operation with configured prefix', async () => {
-        mockFs({});
-
         const mockTxn: Operation = {
             type: "create",
             created: new Date().toISOString(),
@@ -242,8 +228,6 @@ describe('generateDID', () => {
     });
 
     it('should create DID from operation with custom prefix', async () => {
-        mockFs({});
-
         const mockTxn: Operation = {
             type: "create",
             created: new Date().toISOString(),
@@ -261,8 +245,6 @@ describe('generateDID', () => {
     });
 
     it('should create same DID from same operation with date included', async () => {
-        mockFs({});
-
         const mockTxn: Operation = {
             type: "create",
             created: new Date().toISOString(),
@@ -280,13 +262,8 @@ describe('generateDID', () => {
 });
 
 describe('generateDoc', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should generate an agent doc from a valid anchor', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.generateDID(agentOp);
@@ -323,8 +300,6 @@ describe('generateDoc', () => {
     });
 
     it('should generate an agent doc with a custom prefix', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { prefix: 'did:custom' });
         const did = await gatekeeper.generateDID(agentOp);
@@ -362,8 +337,6 @@ describe('generateDoc', () => {
     });
 
     it('should generate an asset doc from a valid anchor', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agent = await gatekeeper.createDID(agentOp);
@@ -392,8 +365,6 @@ describe('generateDoc', () => {
     });
 
     it('should return an empty doc if mdip missing from anchor', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         delete agentOp.mdip;
@@ -403,8 +374,6 @@ describe('generateDoc', () => {
     });
 
     it('should return an empty doc if mdip version invalid', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 0 });
         const doc = await gatekeeper.generateDoc(agentOp);
@@ -413,8 +382,6 @@ describe('generateDoc', () => {
     });
 
     it('should return an empty doc if mdip type invalid', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         // @ts-expect-error Testing invalid usage
@@ -425,8 +392,6 @@ describe('generateDoc', () => {
     });
 
     it('should return an empty doc if mdip registry invalid', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 1, registry: 'mock' });
         const doc = await gatekeeper.generateDoc(agentOp);
@@ -436,13 +401,8 @@ describe('generateDoc', () => {
 });
 
 describe('createDID', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should create DID from agent operation', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
 
@@ -452,8 +412,6 @@ describe('createDID', () => {
     });
 
     it('should create DID for local registry', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 1, registry: 'local' });
 
@@ -463,8 +421,6 @@ describe('createDID', () => {
     });
 
     it('should throw exception on invalid version', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 2 });
 
@@ -478,8 +434,6 @@ describe('createDID', () => {
 
     // eslint-disable-next-line
     it('should throw exception on invalid registry', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 1, registry: 'mockRegistry' });
 
@@ -492,8 +446,6 @@ describe('createDID', () => {
     });
 
     it('should throw exception on unsupported registry', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 1, registry: 'TFTC' });
 
@@ -508,8 +460,6 @@ describe('createDID', () => {
     });
 
     it('should throw exception on invalid type', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 1, registry: 'mockRegistry' });
         // @ts-expect-error Testing invalid usage
@@ -524,8 +474,6 @@ describe('createDID', () => {
     });
 
     it('should throw exception on invalid create agent operation', async () => {
-        mockFs({});
-
         try {
             // @ts-expect-error Testing invalid usage
             await gatekeeper.createDID();
@@ -594,8 +542,6 @@ describe('createDID', () => {
     });
 
     it('should throw exception on create op size exceeding limit', async () => {
-        mockFs({});
-
         const gk = new Gatekeeper({ db, ipfs, console: mockConsole, maxOpBytes: 100 });
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
@@ -609,8 +555,6 @@ describe('createDID', () => {
     });
 
     it('should create DID from asset operation', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agent = await gatekeeper.createDID(agentOp);
@@ -622,8 +566,6 @@ describe('createDID', () => {
     });
 
     it('should throw exception on invalid create asset operation', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agent = await gatekeeper.createDID(agentOp);
@@ -669,8 +611,6 @@ describe('createDID', () => {
     });
 
     it('should throw exception when registry queue exceeds limit', async () => {
-        mockFs({});
-
         const gk = new Gatekeeper({ db, ipfs, console: mockConsole, maxQueueSize: 5, registries: ['hyperswarm', 'TFTC'] });
 
         try {
@@ -688,13 +628,8 @@ describe('createDID', () => {
 
 describe('resolveDID', () => {
 
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should resolve a valid agent DID', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const opid = await gatekeeper.generateCID(agentOp);
@@ -735,8 +670,6 @@ describe('resolveDID', () => {
     });
 
     it('should resolve a valid agent DID after an update', async () => {
-
-        mockFs({});
 
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
@@ -783,8 +716,6 @@ describe('resolveDID', () => {
 
     it('should resolve confirmed version when specified', async () => {
 
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 1, registry: 'hyperswarm' }); // Specify hyperswarm registry for this agent
         const did = await gatekeeper.createDID(agentOp);
@@ -801,8 +732,6 @@ describe('resolveDID', () => {
     });
 
     it('should resolve verified version after an update', async () => {
-
-        mockFs({});
 
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
@@ -851,8 +780,6 @@ describe('resolveDID', () => {
 
     it('should resolve unconfirmed version when specified', async () => {
 
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 1, registry: 'hyperswarm' }); // Specify hyperswarm registry for this agent
         const did = await gatekeeper.createDID(agentOp);
@@ -898,8 +825,6 @@ describe('resolveDID', () => {
 
     it('should resolve version at specified time', async () => {
 
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -924,8 +849,6 @@ describe('resolveDID', () => {
     });
 
     it('should resolve specified version', async () => {
-
-        mockFs({});
 
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
@@ -952,8 +875,6 @@ describe('resolveDID', () => {
 
     it('should resolve all specified versions', async () => {
 
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -973,8 +894,6 @@ describe('resolveDID', () => {
     });
 
     it('should resolve a valid asset DID', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agent = await gatekeeper.createDID(agentOp);
@@ -1006,8 +925,6 @@ describe('resolveDID', () => {
     });
 
     it('should not resolve an invalid DID', async () => {
-        mockFs({});
-
         const BadFormat = 'bad format';
 
         try {
@@ -1088,8 +1005,6 @@ describe('resolveDID', () => {
     });
 
     it('should throw an exception on invalid signature in create op', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1108,8 +1023,6 @@ describe('resolveDID', () => {
     });
 
     it('should throw an exception on invalid signature in update op', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1132,8 +1045,6 @@ describe('resolveDID', () => {
     });
 
     it('should throw an exception on invalid operation previd in update op', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1162,13 +1073,8 @@ describe('resolveDID', () => {
 
 describe('updateDID', () => {
 
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should update a valid DID', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1187,8 +1093,6 @@ describe('updateDID', () => {
     });
 
     it('should increment version with each update', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1206,8 +1110,6 @@ describe('updateDID', () => {
     });
 
     it('should return false if update operation is invalid', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1220,8 +1122,6 @@ describe('updateDID', () => {
     });
 
     it('should throw exception on invalid update operation', async () => {
-        mockFs({});
-
         try {
             const keypair = cipher.generateRandomJwk();
             const agentOp = await createAgentOp(keypair);
@@ -1237,8 +1137,6 @@ describe('updateDID', () => {
     });
 
     it('should throw exception on update op size exceeding limit', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1255,8 +1153,6 @@ describe('updateDID', () => {
     });
 
     it('should verify DID that has been updated multiple times', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1273,8 +1169,6 @@ describe('updateDID', () => {
     });
 
     it('should throw exception when registry queue exceeds limit', async () => {
-        mockFs({});
-
         const gk = new Gatekeeper({ db, ipfs, console: mockConsole, maxQueueSize: 5, registries: ['hyperswarm', 'TFTC'] });
 
         const keypair = cipher.generateRandomJwk();
@@ -1298,13 +1192,8 @@ describe('updateDID', () => {
 
 describe('exportDID', () => {
 
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should export a valid DID', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1316,8 +1205,6 @@ describe('exportDID', () => {
     });
 
     it('should export a valid updated DID', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1334,8 +1221,6 @@ describe('exportDID', () => {
 
     // eslint-disable-next-line
     it('should return empty array on an invalid DID', async () => {
-        mockFs({});
-
         const ops = await gatekeeper.exportDID('mockDID');
         expect(ops).toStrictEqual([]);
     });
@@ -1343,13 +1228,8 @@ describe('exportDID', () => {
 
 describe('exportDIDs', () => {
 
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should export valid DIDs', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1362,8 +1242,6 @@ describe('exportDIDs', () => {
     });
 
     it('should export all DIDs', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -1379,8 +1257,6 @@ describe('exportDIDs', () => {
     });
 
     it('should export a DIDs in order requested', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         delete agentOp.mdip!.validUntil;
@@ -1398,8 +1274,6 @@ describe('exportDIDs', () => {
     });
 
     it('should export valid updated DIDs', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1417,8 +1291,6 @@ describe('exportDIDs', () => {
 
     // eslint-disable-next-line
     it('should return empty array on an invalid DID', async () => {
-        mockFs({});
-
         const exports = await gatekeeper.exportDIDs(['mockDID']);
         const ops = exports[0];
         expect(ops).toStrictEqual([]);
@@ -1427,13 +1299,8 @@ describe('exportDIDs', () => {
 
 describe('importDIDs', () => {
 
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should import a valid agent DID export', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1448,13 +1315,8 @@ describe('importDIDs', () => {
 
 describe('removeDIDs', () => {
 
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should remove a valid DID', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1473,8 +1335,6 @@ describe('removeDIDs', () => {
     });
 
     it('should throw an exception if no array specified', async () => {
-        mockFs({});
-
         try {
             // @ts-expect-error Testing invalid usage
             await gatekeeper.removeDIDs();
@@ -1485,15 +1345,11 @@ describe('removeDIDs', () => {
     });
 
     it('should return true if no DID specified remove', async () => {
-        mockFs({});
-
         const ok = await gatekeeper.removeDIDs([]);
         expect(ok).toBe(true);
     });
 
     it('should return true if unknown DIDs specified', async () => {
-        mockFs({});
-
         const ok = await gatekeeper.removeDIDs(['did:test:mock']);
         expect(ok).toBe(true);
     });
@@ -1502,13 +1358,8 @@ describe('removeDIDs', () => {
 describe('exportBatch', () => {
     // local DIDs are excluded from exportBatch so we'll create on hyperswarm
 
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should export a valid batch', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 1, registry: 'hyperswarm' });
         const did = await gatekeeper.createDID(agentOp);
@@ -1520,8 +1371,6 @@ describe('exportBatch', () => {
     });
 
     it('should export batch with all DIDs', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 1, registry: 'hyperswarm' });
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -1537,8 +1386,6 @@ describe('exportBatch', () => {
     });
 
     it('should export a valid updated batch', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 1, registry: 'hyperswarm' });
         const did = await gatekeeper.createDID(agentOp);
@@ -1555,8 +1402,6 @@ describe('exportBatch', () => {
 
     // eslint-disable-next-line
     it('should return empty array on an invalid DID', async () => {
-        mockFs({});
-
         const exports = await gatekeeper.exportBatch(['mockDID']);
         expect(exports).toStrictEqual([]);
     });
@@ -1564,13 +1409,8 @@ describe('exportBatch', () => {
 
 describe('importBatch', () => {
 
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should queue a valid agent DID export', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1582,8 +1422,6 @@ describe('importBatch', () => {
     });
 
     it('should report when event already processed', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1598,8 +1436,6 @@ describe('importBatch', () => {
     });
 
     it('should throw an exception on undefined', async () => {
-        mockFs({});
-
         try {
             // @ts-expect-error Testing invalid usage
             await gatekeeper.importBatch();
@@ -1611,8 +1447,6 @@ describe('importBatch', () => {
     });
 
     it('should throw an exception on non-array parameter', async () => {
-        mockFs({});
-
         try {
             // @ts-expect-error Testing invalid usage
             await gatekeeper.importBatch('mock');
@@ -1623,8 +1457,6 @@ describe('importBatch', () => {
     });
 
     it('should throw an exception on an empty array', async () => {
-        mockFs({});
-
         try {
             await gatekeeper.importBatch([]);
             throw new ExpectedExceptionError();
@@ -1634,8 +1466,6 @@ describe('importBatch', () => {
     });
 
     it('should report an error on non-transactions', async () => {
-        mockFs({});
-
         // @ts-expect-error Testing invalid usage
         const response = await gatekeeper.importBatch([1, 2, 3]);
 
@@ -1643,8 +1473,6 @@ describe('importBatch', () => {
     });
 
     it('should report an error on invalid event time', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1658,8 +1486,6 @@ describe('importBatch', () => {
     });
 
     it('should report an error on invalid operation', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1674,8 +1500,6 @@ describe('importBatch', () => {
     });
 
     it('should report an error on invalid operation type', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1689,8 +1513,6 @@ describe('importBatch', () => {
     });
 
     it('should report an error on missing created time', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1704,8 +1526,6 @@ describe('importBatch', () => {
     });
 
     it('should report an error on missing mdip metadata', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1719,8 +1539,6 @@ describe('importBatch', () => {
     });
 
     it('should report an error on invalid mdip version', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1734,8 +1552,6 @@ describe('importBatch', () => {
     });
 
     it('should report an error on invalid mdip type', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1750,8 +1566,6 @@ describe('importBatch', () => {
     });
 
     it('should report an error on invalid mdip registry', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1765,8 +1579,6 @@ describe('importBatch', () => {
     });
 
     it('should report an error on missing operation signature', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1780,8 +1592,6 @@ describe('importBatch', () => {
     });
 
     it('should report an error on invalid operation signature date', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1795,8 +1605,6 @@ describe('importBatch', () => {
     });
 
     it('should report an error on invalid operation signature hash', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1810,8 +1618,6 @@ describe('importBatch', () => {
     });
 
     it('should report an error on invalid operation signature signer', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1825,8 +1631,6 @@ describe('importBatch', () => {
     });
 
     it('should report an error on missing operation key', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1840,8 +1644,6 @@ describe('importBatch', () => {
     });
 
     it('should report an error on incorrect controller', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -1857,8 +1659,6 @@ describe('importBatch', () => {
     });
 
     it('should report an error on invalid update operation missing doc', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1876,8 +1676,6 @@ describe('importBatch', () => {
     });
 
     it('should report an error on invalid update operation missing did', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1895,8 +1693,6 @@ describe('importBatch', () => {
     });
 
     it('should report an error on invalid delete operation', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1917,13 +1713,8 @@ describe('importBatch', () => {
 
 describe('processEvents', () => {
 
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should import a valid agent DID export', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -1936,8 +1727,6 @@ describe('processEvents', () => {
     });
 
     it('should import a valid asset DID export', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -1952,8 +1741,6 @@ describe('processEvents', () => {
     });
 
     it('should import a valid batch export', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         // create on hyperswarm because exportBatch will not export local DIDs
         const agentOp = await createAgentOp(keypair, { version: 1, registry: 'hyperswarm' });
@@ -1971,8 +1758,6 @@ describe('processEvents', () => {
     it('should import a batch export with missing event dids', async () => {
         // This simulates an import from hyperswarm-mediator which receives only operations and creates events without DIDs
         // (TBD revisit whether events should be created with DIDs in advance of import)
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         // create on hyperswarm because exportBatch will not export local DIDs
         const agentOp = await createAgentOp(keypair, { version: 1, registry: 'hyperswarm' });
@@ -1997,8 +1782,6 @@ describe('processEvents', () => {
     });
 
     it('should report 0 ops added when DID exists', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -2015,8 +1798,6 @@ describe('processEvents', () => {
     });
 
     it('should update events when DID is imported from its native registry', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 1, registry: 'TFTC' });
         const did = await gatekeeper.createDID(agentOp);
@@ -2051,8 +1832,6 @@ describe('processEvents', () => {
     });
 
     it('should resolve as confirmed when DID is imported from its native registry', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 1, registry: 'TFTC' });
         const did = await gatekeeper.createDID(agentOp);
@@ -2073,8 +1852,6 @@ describe('processEvents', () => {
     });
 
     it('should resolve with timestamp when available', async () => {
-        mockFs({});
-
         const mockBlock1 = { hash: 'mockBlockid1', height: 100, time: 100 };
         const mockBlock2 = { hash: 'mockBlockid2', height: 101, time: 101 };
         await gatekeeper.addBlock('TFTC', mockBlock1);
@@ -2126,8 +1903,6 @@ describe('processEvents', () => {
     });
 
     it('should not overwrite events when verified DID is later synced from another registry', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 1, registry: 'TFTC' });
         const did = await gatekeeper.createDID(agentOp);
@@ -2149,8 +1924,6 @@ describe('processEvents', () => {
     });
 
     it('should report 2 ops imported when DID deleted first', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -2169,8 +1942,6 @@ describe('processEvents', () => {
     });
 
     it('should report N+1 ops imported for N updates', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -2199,8 +1970,6 @@ describe('processEvents', () => {
     });
 
     it('should resolve an imported DID', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -2216,8 +1985,6 @@ describe('processEvents', () => {
     });
 
     it('should handle processing events in any order', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -2242,8 +2009,6 @@ describe('processEvents', () => {
     });
 
     it('should handle processing pre-v0.5 event without previd property', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -2267,8 +2032,6 @@ describe('processEvents', () => {
     });
 
     it('should handle processing events with unknown previd property', async () => {
-        mockFs({});
-
         const mockPrevid = 'mockPrevid';
 
         const keypair = cipher.generateRandomJwk();
@@ -2295,8 +2058,6 @@ describe('processEvents', () => {
     });
 
     it('should reject events with duplicate previd property', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -2340,8 +2101,6 @@ describe('processEvents', () => {
     });
 
     it('should handle a reorg event', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { registry: 'TFTC' });
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -2406,8 +2165,6 @@ describe('processEvents', () => {
     });
 
     it('should handle deferred operation validation when asset ownership changes', async () => {
-        mockFs({});
-
         const keypair1 = cipher.generateRandomJwk();
         const agentOp1 = await createAgentOp(keypair1, { version: 1, registry: 'TFTC' });
         const agentDID1 = await gatekeeper.createDID(agentOp1);
@@ -2457,8 +2214,6 @@ describe('processEvents', () => {
     });
 
     it('should reject events with bad signatures', async () => {
-        mockFs({});
-
         const keypair1 = cipher.generateRandomJwk();
         const agentOp1 = await createAgentOp(keypair1);
         const agentDID1 = await gatekeeper.createDID(agentOp1);
@@ -2491,8 +2246,6 @@ describe('processEvents', () => {
     });
 
     it('should return busy when already proccessing events', async () => {
-        mockFs({});
-
         const gk = new Gatekeeper({ db, ipfs, console: mockConsole });
         // @ts-expect-error Testing private state
         gk.isProcessingEvents = true;
@@ -2502,8 +2255,6 @@ describe('processEvents', () => {
     });
 
     it('should gracefully handle expections', async () => {
-        mockFs({});
-
         const gk = new Gatekeeper({ db, ipfs, console: mockConsole });
         // @ts-expect-error Testing private state
         gk.eventsQueue = null;
@@ -2517,13 +2268,8 @@ describe('processEvents', () => {
 });
 
 describe('getQueue', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should return empty list when no events in queue', async () => {
-        mockFs({});
-
         const registry = 'TFTC';
 
         const queue = await gatekeeper.getQueue(registry);
@@ -2532,8 +2278,6 @@ describe('getQueue', () => {
     });
 
     it('should return single event in queue', async () => {
-        mockFs({});
-
         const registry = 'TFTC';
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 1, registry });
@@ -2549,8 +2293,6 @@ describe('getQueue', () => {
     });
 
     it('should throw an exception if invalid registry', async () => {
-        mockFs({});
-
         try {
             await gatekeeper.getQueue('mock');
             throw new ExpectedExceptionError();
@@ -2562,13 +2304,8 @@ describe('getQueue', () => {
 });
 
 describe('clearQueue', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should clear non-empty queue', async () => {
-        mockFs({});
-
         const registry = 'TFTC';
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 1, registry });
@@ -2586,8 +2323,6 @@ describe('clearQueue', () => {
     });
 
     it('should clear only specified events', async () => {
-        mockFs({});
-
         const registry = 'TFTC';
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 1, registry });
@@ -2620,15 +2355,11 @@ describe('clearQueue', () => {
     });
 
     it('should return true if queue already empty', async () => {
-        mockFs({});
-
         const ok = await gatekeeper.clearQueue('TFTC', []);
         expect(ok).toBe(true);
     });
 
     it('should return true if invalid queue specified', async () => {
-        mockFs({});
-
         const registry = 'TFTC';
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 1, registry });
@@ -2648,8 +2379,6 @@ describe('clearQueue', () => {
     });
 
     it('should throw an exception if invalid registry', async () => {
-        mockFs({});
-
         try {
             await gatekeeper.clearQueue('mock', []);
             throw new ExpectedExceptionError();
@@ -2660,13 +2389,8 @@ describe('clearQueue', () => {
 });
 
 describe('getDids', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should return all DIDs', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -2681,8 +2405,6 @@ describe('getDids', () => {
     });
 
     it('should return all DIDs resolved', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -2700,8 +2422,6 @@ describe('getDids', () => {
     });
 
     it('should return all DIDs confirmed and resolved', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 1, registry: 'TFTC' });
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -2724,8 +2444,6 @@ describe('getDids', () => {
     });
 
     it('should return all DIDs unconfirmed and resolved', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 1, registry: 'TFTC' });
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -2749,8 +2467,6 @@ describe('getDids', () => {
     });
 
     it('should return all DIDs after specified time', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -2774,8 +2490,6 @@ describe('getDids', () => {
     });
 
     it('should return all DIDs before specified time', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -2800,8 +2514,6 @@ describe('getDids', () => {
     });
 
     it('should return all DIDs between specified times', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -2828,8 +2540,6 @@ describe('getDids', () => {
     });
 
     it('should resolve all specified DIDs', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -2857,13 +2567,8 @@ describe('getDids', () => {
 });
 
 describe('listRegistries', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should return list of default valid registries', async () => {
-        mockFs({});
-
         const gatekeeper = new Gatekeeper({ db, ipfs, console: mockConsole });
         const registries = await gatekeeper.listRegistries();
 
@@ -2873,8 +2578,6 @@ describe('listRegistries', () => {
     });
 
     it('should return list of configured registries', async () => {
-        mockFs({});
-
         const gatekeeper = new Gatekeeper({ db, ipfs, console: mockConsole, registries: ['hyperswarm', 'TFTC'] });
         const registries = await gatekeeper.listRegistries();
 
@@ -2884,8 +2587,6 @@ describe('listRegistries', () => {
     });
 
     it('should return list of inferred registries', async () => {
-        mockFs({});
-
         const gatekeeper = new Gatekeeper({ db, ipfs, console: mockConsole });
         await gatekeeper.getQueue('hyperswarm');
         await gatekeeper.getQueue('TFTC');
@@ -2900,8 +2601,6 @@ describe('listRegistries', () => {
     });
 
     it('should return non-redundant list of inferred registries', async () => {
-        mockFs({});
-
         const gatekeeper = new Gatekeeper({ db, ipfs, console: mockConsole });
         await gatekeeper.getQueue('hyperswarm');
         await gatekeeper.getQueue('hyperswarm');
@@ -2921,13 +2620,8 @@ describe('listRegistries', () => {
 });
 
 describe('verifyDb', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should verify all DIDs in db', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -2943,8 +2637,6 @@ describe('verifyDb', () => {
     });
 
     it('should get same results with cached verifications', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -2958,8 +2650,6 @@ describe('verifyDb', () => {
     });
 
     it('should get same results with chatty turned off', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -2973,8 +2663,6 @@ describe('verifyDb', () => {
     });
 
     it('should remove invalid DIDs', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -2998,8 +2686,6 @@ describe('verifyDb', () => {
     });
 
     it('should remove expired DIDs', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -3025,13 +2711,8 @@ describe('verifyDb', () => {
 });
 
 describe('checkDIDs', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should check all DIDs', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -3050,8 +2731,6 @@ describe('checkDIDs', () => {
     });
 
     it('should report unconfirmed DIDs', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair, { version: 1, registry: 'hyperswarm' });
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -3078,8 +2757,6 @@ describe('checkDIDs', () => {
     });
 
     it('should report invalid DIDs', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -3282,21 +2959,14 @@ describe('isValidDID', () => {
 });
 
 describe('Test operation validation errors', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should return false if operation is invalid', async () => {
-        mockFs({});
-
         // @ts-expect-error Testing invalid value
         const result = await gatekeeper.verifyOperation({ type: 'dummy' });
         expect(result).toBe(false);
     });
 
     it('update error with missing didDocument', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -3315,8 +2985,6 @@ describe('Test operation validation errors', () => {
     });
 
     it('update error with missing didDocument', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -3335,8 +3003,6 @@ describe('Test operation validation errors', () => {
     });
 
     it('update error with deactivated didDocumentMetadata', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -3355,8 +3021,6 @@ describe('Test operation validation errors', () => {
     });
 
     it('update error without verificationMethod', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -3375,8 +3039,6 @@ describe('Test operation validation errors', () => {
     });
 
     it('update error with empty verificationMethod', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const did = await gatekeeper.createDID(agentOp);
@@ -3396,8 +3058,6 @@ describe('Test operation validation errors', () => {
     });
 
     it('create error with invalid type', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         const agentOp = await createAgentOp(keypair);
         const agent = await gatekeeper.createDID(agentOp);
@@ -3416,8 +3076,6 @@ describe('Test operation validation errors', () => {
     });
 
     it('create error with invalid signature', async () => {
-        mockFs({});
-
         const keypair = cipher.generateRandomJwk();
         let agentOp = await createAgentOp(keypair);
         agentOp.mdip!.prefix = "dummy";
@@ -3433,13 +3091,8 @@ describe('Test operation validation errors', () => {
 });
 
 describe('addJSON', () => {
-    beforeEach(() => {
-        mockFs({});
-    });
+    beforeEach(() => {    });
 
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     const data = { key: 'mock' };
     const hash = 'z3v8AuaXiw9ZVBhPuQdTJySePBjwpBtvsSCRLXuPLzwqokHV8cS';
@@ -3452,13 +3105,8 @@ describe('addJSON', () => {
 });
 
 describe('getJSON', () => {
-    beforeEach(() => {
-        mockFs({});
-    });
+    beforeEach(() => {    });
 
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     const mockData = { key: 'mock' };
 
@@ -3471,13 +3119,8 @@ describe('getJSON', () => {
 });
 
 describe('addText', () => {
-    beforeEach(() => {
-        mockFs({});
-    });
+    beforeEach(() => {    });
 
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     const mockData = 'mock text data';
     const hash = 'zb2rhgNGdyFtViUWRk4oYLGrwdkgbt4GnF2s15k3ZujX6w3QW';
@@ -3490,13 +3133,8 @@ describe('addText', () => {
 });
 
 describe('getText', () => {
-    beforeEach(() => {
-        mockFs({});
-    });
+    beforeEach(() => {    });
 
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     const mockData = 'mock text data';
 
@@ -3509,13 +3147,8 @@ describe('getText', () => {
 });
 
 describe('addData', () => {
-    beforeEach(() => {
-        mockFs({});
-    });
+    beforeEach(() => {    });
 
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     const mockData = Buffer.from('mock data');
     const hash = 'zb2rhYuMKCR7pY51Tzv52NmTW9zYU2P53XFUJitvDwtSpCDhd';
@@ -3528,13 +3161,8 @@ describe('addData', () => {
 });
 
 describe('getData', () => {
-    beforeEach(() => {
-        mockFs({});
-    });
+    beforeEach(() => {    });
 
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     const mockData = Buffer.from('mock data');
 
@@ -3559,13 +3187,8 @@ const mockBlock2: BlockInfo = {
 };
 
 describe('addBlock', () => {
-    beforeEach(() => {
-        mockFs({});
-    });
+    beforeEach(() => {    });
 
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should add a new block', async () => {
         const ok = await gatekeeper.addBlock('local', mockBlock);
@@ -3585,13 +3208,8 @@ describe('addBlock', () => {
 });
 
 describe('getBlock', () => {
-    beforeEach(() => {
-        mockFs({});
-    });
+    beforeEach(() => {    });
 
-    afterEach(() => {
-        mockFs.restore();
-    });
 
     it('should get a block by height', async () => {
         await gatekeeper.addBlock('local', mockBlock);

--- a/tests/gatekeeper.test.ts
+++ b/tests/gatekeeper.test.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import CipherNode from '@mdip/cipher/node';
 import { Operation, MdipDocument, BlockInfo } from '@mdip/gatekeeper/types';
 import Gatekeeper from '@mdip/gatekeeper';
-import DbJson from '@mdip/gatekeeper/db/json';
+import DbJsonMemory from '@mdip/gatekeeper/db/json-memory.ts';
 import { copyJSON, compareOrdinals } from '@mdip/common/utils';
 import { InvalidDIDError, ExpectedExceptionError } from '@mdip/common/errors';
 import type { EcdsaJwkPair } from '@mdip/cipher/types';
@@ -18,7 +18,7 @@ const mockConsole = {
 } as unknown as typeof console;
 
 const cipher = new CipherNode();
-const db = new DbJson('test');
+const db = new DbJsonMemory('test');
 const ipfs = new HeliaClient();
 const gatekeeper = new Gatekeeper({ db, ipfs, console: mockConsole, registries: ['local', 'hyperswarm', 'TFTC'] });
 
@@ -3096,21 +3096,21 @@ describe('checkDIDs', () => {
         expect(check.byType.invalid).toBe(1);
     });
 
-    it('should reset a corrupted db', async () => {
-        mockFs({});
+    // it('should reset a corrupted db', async () => {
+    //     mockFs({});
 
-        const keypair = cipher.generateRandomJwk();
-        const agentOp = await createAgentOp(keypair);
-        const agentDID = await gatekeeper.createDID(agentOp);
-        const assetOp = await createAssetOp(agentDID, keypair);
-        await gatekeeper.createDID(assetOp);
+    //     const keypair = cipher.generateRandomJwk();
+    //     const agentOp = await createAgentOp(keypair);
+    //     const agentDID = await gatekeeper.createDID(agentOp);
+    //     const assetOp = await createAssetOp(agentDID, keypair);
+    //     await gatekeeper.createDID(assetOp);
 
-        fs.writeFileSync('data/test.json', "{ dids: {");
+    //     fs.writeFileSync('data/test.json', "{ dids: {");
 
-        const { total } = await gatekeeper.checkDIDs();
+    //     const { total } = await gatekeeper.checkDIDs();
 
-        expect(total).toBe(0);
-    });
+    //     expect(total).toBe(0);
+    // });
 });
 
 

--- a/tests/keymaster.test.ts
+++ b/tests/keymaster.test.ts
@@ -1,7 +1,4 @@
-import mockFs from 'mock-fs';
-import fs from 'fs';
 import sharp from 'sharp';
-
 import Gatekeeper from '@mdip/gatekeeper';
 import Keymaster, {
     EncryptedMessage
@@ -29,16 +26,14 @@ import canonicalizeModule from 'canonicalize';
 import { MdipDocument } from "@mdip/gatekeeper/types";
 const canonicalize = canonicalizeModule as unknown as (input: unknown) => string;
 
-let db = new DbJsonMemory('test');
-let ipfs = new HeliaClient();
-let gatekeeper = new Gatekeeper({ db, ipfs, registries: ['local', 'hyperswarm', 'TFTC'] });
-let wallet = new WalletJsonMemory();
-let cipher = new CipherNode();
-let keymaster = new Keymaster({ gatekeeper, wallet, cipher });
+let gatekeeper: Gatekeeper;
+let wallet: WalletJsonMemory;
+let cipher: CipherNode;
+let keymaster: Keymaster;
 
 beforeEach(() => {
-    db = new DbJsonMemory('test');
-    ipfs = new HeliaClient();
+    const db = new DbJsonMemory('test');
+    const ipfs = new HeliaClient();
     gatekeeper = new Gatekeeper({ db, ipfs, registries: ['local', 'hyperswarm', 'TFTC'] });
     wallet = new WalletJsonMemory();
     cipher = new CipherNode();
@@ -46,14 +41,7 @@ beforeEach(() => {
 });
 
 describe('constructor', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should throw exception on invalid parameters', async () => {
-        mockFs({});
-
         try {
             // @ts-expect-error Testing invalid usage, missing args
             new Keymaster();
@@ -130,14 +118,7 @@ describe('constructor', () => {
 });
 
 describe('loadWallet', () => {
-
-    afterEach(async () => {
-        mockFs.restore();
-    });
-
     it('should create a wallet on first load', async () => {
-        mockFs({});
-
         const wallet = await keymaster.loadWallet();
 
         expect(wallet.seed!.mnemonic.length > 0).toBe(true);
@@ -148,8 +129,6 @@ describe('loadWallet', () => {
     });
 
     it('should return the same wallet on second load', async () => {
-        mockFs({});
-
         const wallet1 = await keymaster.loadWallet();
         const wallet2 = await keymaster.loadWallet();
 
@@ -157,16 +136,12 @@ describe('loadWallet', () => {
     });
 
     it('should return null when loading non-existing encrypted wallet', async () => {
-        mockFs({});
-
         const wallet_enc = new WalletEncrypted(wallet, 'passphrase');
         const check_wallet = await wallet_enc.loadWallet();
         expect(check_wallet).toBe(null);
     });
 
     it('should throw exception when passphrase not set', async () => {
-        mockFs({});
-
         // @ts-expect-error Testing invalid usage, no passphrase
         const wallet_enc = new WalletEncrypted(wallet);
         const keymaster = new Keymaster({ gatekeeper, wallet: wallet_enc, cipher });
@@ -180,7 +155,6 @@ describe('loadWallet', () => {
     });
 
     it('should throw exception on load with incorrect passphrase', async () => {
-        mockFs({});
         const mockWallet: WalletFile = { seed: {} as Seed, counter: 0, ids: {} };
         const wallet_enc1 = new WalletEncrypted(wallet, 'passphrase');
         const keymaster1 = new Keymaster({ gatekeeper, wallet: wallet_enc1, cipher });
@@ -198,8 +172,6 @@ describe('loadWallet', () => {
     });
 
     it('should throw exception on encrypted wallet', async () => {
-        mockFs({});
-
         const mockWallet: EncryptedWallet = { salt: "", iv: "", data: "" };
         await keymaster.saveWallet(mockWallet);
 
@@ -212,8 +184,6 @@ describe('loadWallet', () => {
     });
 
     it('should throw exception on corrupted wallet', async () => {
-        mockFs({});
-
         // @ts-expect-error Testing invalid usage, missing salt
         const mockWallet: WalletFile = { counter: 0, ids: {} };
         await keymaster.saveWallet(mockWallet);
@@ -228,13 +198,7 @@ describe('loadWallet', () => {
 });
 
 describe('saveWallet', () => {
-
-    afterEach(async () => {
-        mockFs.restore();
-    });
-
     it('test saving directly on the unencrypted wallet', async () => {
-        mockFs({});
         const mockWallet: WalletFile = { seed: {} as Seed, counter: 0, ids: {} };
 
         const ok = await wallet.saveWallet(mockWallet);
@@ -242,7 +206,6 @@ describe('saveWallet', () => {
     });
 
     it('test saving directly on the encrypted wallet', async () => {
-        mockFs({});
         const mockWallet: WalletFile = { seed: {} as Seed, counter: 0, ids: {} };
         const wallet_enc = new WalletEncrypted(wallet, 'passphrase');
         const ok = await wallet_enc.saveWallet(mockWallet);
@@ -251,7 +214,6 @@ describe('saveWallet', () => {
     });
 
     it('should save a wallet', async () => {
-        mockFs({});
         const mockWallet: WalletFile = { seed: {} as Seed, counter: 0, ids: {} };
 
         const ok = await keymaster.saveWallet(mockWallet);
@@ -262,7 +224,6 @@ describe('saveWallet', () => {
     });
 
     it('should ignore overwrite flag if unnecessary', async () => {
-        mockFs({});
         const mockWallet: WalletFile = { seed: {} as Seed, counter: 0, ids: {} };
 
         const ok = await keymaster.saveWallet(mockWallet, false);
@@ -272,21 +233,7 @@ describe('saveWallet', () => {
         expect(wallet).toStrictEqual(mockWallet);
     });
 
-    it('should handle data folder existing already', async () => {
-        mockFs({
-            data: {}
-        });
-        const mockWallet: WalletFile = { seed: {} as Seed, counter: 0, ids: {} };
-
-        const ok = await keymaster.saveWallet(mockWallet);
-        const wallet = await keymaster.loadWallet();
-
-        expect(ok).toBe(true);
-        expect(wallet).toStrictEqual(mockWallet);
-    });
-
     it('should overwrite an existing wallet', async () => {
-        mockFs({});
         const mockWallet1: WalletFile = { seed: {} as Seed, counter: 1, ids: {} };
         const mockWallet2: WalletFile = { seed: {} as Seed, counter: 2, ids: {} };
 
@@ -299,7 +246,6 @@ describe('saveWallet', () => {
     });
 
     it('should not overwrite an existing wallet if specified', async () => {
-        mockFs({});
         const mockWallet1: WalletFile = { seed: {} as Seed, counter: 1, ids: {} };
         const mockWallet2: WalletFile = { seed: {} as Seed, counter: 2, ids: {} };
 
@@ -312,8 +258,6 @@ describe('saveWallet', () => {
     });
 
     it('should overwrite an existing wallet in a loop', async () => {
-        mockFs({});
-
         for (let i = 0; i < 10; i++) {
             const mockWallet: WalletFile = { seed: {} as Seed, counter: i + 1, ids: {} };
 
@@ -326,8 +270,6 @@ describe('saveWallet', () => {
     });
 
     it('should not overwrite an existing wallet if specified', async () => {
-        mockFs({});
-
         const wallet_enc = new WalletEncrypted(wallet, 'passphrase');
         const keymaster = new Keymaster({ gatekeeper, wallet: wallet_enc, cipher });
 
@@ -343,7 +285,6 @@ describe('saveWallet', () => {
     });
 
     it('wallet should throw when passphrase not set', async () => {
-        mockFs({});
         const mockWallet: WalletFile = { seed: {} as Seed, counter: 0, ids: {} };
         // @ts-expect-error Testing invalid usage, no passphrase
         const wallet_enc = new WalletEncrypted(wallet);
@@ -368,14 +309,7 @@ describe('saveWallet', () => {
 });
 
 describe('decryptMnemonic', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return 12 words', async () => {
-        mockFs({});
-
         const wallet = await keymaster.loadWallet();
         const mnemonic = await keymaster.decryptMnemonic();
 
@@ -388,14 +322,7 @@ describe('decryptMnemonic', () => {
 });
 
 describe('updateSeedBank', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should throw error on missing DID', async () => {
-        mockFs({});
-
         const doc: MdipDocument = {};
 
         try {
@@ -409,14 +336,7 @@ describe('updateSeedBank', () => {
 });
 
 describe('newWallet', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should overwrite an existing wallet when allowed', async () => {
-        mockFs({});
-
         const wallet1 = await keymaster.loadWallet();
         await keymaster.newWallet(undefined, true);
         const wallet2 = await keymaster.loadWallet();
@@ -425,8 +345,6 @@ describe('newWallet', () => {
     });
 
     it('should not overwrite an existing wallet by default', async () => {
-        mockFs({});
-
         await keymaster.loadWallet();
 
         try {
@@ -439,8 +357,6 @@ describe('newWallet', () => {
     });
 
     it('should create a wallet from a mnemonic', async () => {
-        mockFs({});
-
         const mnemonic1 = cipher.generateMnemonic();
         await keymaster.newWallet(mnemonic1);
         const mnemonic2 = await keymaster.decryptMnemonic();
@@ -449,8 +365,6 @@ describe('newWallet', () => {
     });
 
     it('should throw exception on invalid mnemonic', async () => {
-        mockFs({});
-
         try {
             // @ts-expect-error Testing invalid usage, incorrect argument
             await keymaster.newWallet([]);
@@ -463,13 +377,7 @@ describe('newWallet', () => {
 });
 
 describe('resolveSeedBank', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should create a deterministic seed bank ID', async () => {
-        mockFs({});
-
         const bank1 = await keymaster.resolveSeedBank();
         const bank2 = await keymaster.resolveSeedBank();
 
@@ -478,14 +386,7 @@ describe('resolveSeedBank', () => {
 });
 
 describe('backupWallet', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return a valid DID', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const did = await keymaster.backupWallet();
         const doc = await keymaster.resolveDID(did);
@@ -494,8 +395,6 @@ describe('backupWallet', () => {
     });
 
     it('should store backup in seed bank', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const did = await keymaster.backupWallet();
         const bank = await keymaster.resolveSeedBank();
@@ -505,14 +404,7 @@ describe('backupWallet', () => {
 });
 
 describe('recoverWallet', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should recover wallet from seed bank', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const wallet = await keymaster.loadWallet();
         const mnemonic = await keymaster.decryptMnemonic();
@@ -526,8 +418,6 @@ describe('recoverWallet', () => {
     });
 
     it('should recover wallet from backup DID', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const wallet = await keymaster.loadWallet();
         const mnemonic = await keymaster.decryptMnemonic();
@@ -541,8 +431,6 @@ describe('recoverWallet', () => {
     });
 
     it('should do nothing if wallet was not backed up', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const mnemonic = await keymaster.decryptMnemonic();
 
@@ -554,8 +442,6 @@ describe('recoverWallet', () => {
     });
 
     it('should do nothing if backup DID is invalid', async () => {
-        mockFs({});
-
         const agentDID = await keymaster.createId('Bob');
         const mnemonic = await keymaster.decryptMnemonic();
 
@@ -568,14 +454,7 @@ describe('recoverWallet', () => {
 });
 
 describe('createId', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should create a new ID', async () => {
-        mockFs({});
-
         const name = 'Bob';
         const did = await keymaster.createId(name);
         const wallet = await keymaster.loadWallet();
@@ -585,8 +464,6 @@ describe('createId', () => {
     });
 
     it('should create a new ID with a Unicode name', async () => {
-        mockFs({});
-
         const name = 'ҽ× ʍɑϲհíղɑ';
         const did = await keymaster.createId(name);
         const wallet = await keymaster.loadWallet();
@@ -596,8 +473,6 @@ describe('createId', () => {
     });
 
     it('should create a new ID on default registry', async () => {
-        mockFs({});
-
         const name = 'Bob';
         const did = await keymaster.createId(name);
         const doc = await keymaster.resolveDID(did);
@@ -606,8 +481,6 @@ describe('createId', () => {
     });
 
     it('should create a new ID on customized default registry', async () => {
-        mockFs({});
-
         const defaultRegistry = 'TFTC';
         const keymaster = new Keymaster({ gatekeeper, wallet, cipher, defaultRegistry });
 
@@ -619,23 +492,18 @@ describe('createId', () => {
     });
 
     it('should throw to create a second ID with the same name', async () => {
-        mockFs({});
-
         const name = 'Bob';
         await keymaster.createId(name);
 
         try {
             await keymaster.createId(name);
             throw new ExpectedExceptionError();
-        } catch (error: any) {
-            // eslint-disable-next-line
+        } catch (error: any) {            // eslint-disable-next-line
             expect(error.message).toBe('Invalid parameter: name already used');
         }
     });
 
     it('should create a second ID with a different name', async () => {
-        mockFs({});
-
         const name1 = 'Bob';
         const did1 = await keymaster.createId(name1);
 
@@ -650,8 +518,6 @@ describe('createId', () => {
     });
 
     it('should not create an ID with an empty name', async () => {
-        mockFs({});
-
         const expectedError = 'Invalid parameter: name must be a non-empty string';
 
         try {
@@ -699,8 +565,6 @@ describe('createId', () => {
     });
 
     it('should not create an ID with a name that is too long', async () => {
-        mockFs({});
-
         try {
             await keymaster.createId('1234567890123456789012345678901234567890');
             throw new ExpectedExceptionError();
@@ -711,8 +575,6 @@ describe('createId', () => {
     });
 
     it('should not create an ID with a name that contains unprintable characters', async () => {
-        mockFs({});
-
         try {
             await keymaster.createId('hello\nworld!');
             throw new ExpectedExceptionError();
@@ -724,14 +586,7 @@ describe('createId', () => {
 });
 
 describe('removeId', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should remove an existing ID', async () => {
-        mockFs({});
-
         const name = 'Bob';
         await keymaster.createId(name);
 
@@ -744,8 +599,6 @@ describe('removeId', () => {
     });
 
     it('should throw to remove an non-existent ID', async () => {
-        mockFs({});
-
         const name1 = 'Bob';
         const name2 = 'Alice';
 
@@ -761,14 +614,7 @@ describe('removeId', () => {
 });
 
 describe('renameId', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should rename an existing ID', async () => {
-        mockFs({});
-
         const name1 = 'Bob';
         const name2 = 'Alice';
         const did = await keymaster.createId(name1);
@@ -782,8 +628,6 @@ describe('renameId', () => {
     });
 
     it('should not rename from an non-existent ID', async () => {
-        mockFs({});
-
         const name1 = 'Bob';
         const name2 = 'Alice';
 
@@ -796,8 +640,6 @@ describe('renameId', () => {
     });
 
     it('should not rename to an already existing ID', async () => {
-        mockFs({});
-
         const name1 = 'Bob';
         await keymaster.createId(name1);
 
@@ -811,14 +653,7 @@ describe('renameId', () => {
 });
 
 describe('setCurrentId', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should switch to another ID', async () => {
-        mockFs({});
-
         const name1 = 'Bob';
         await keymaster.createId(name1);
 
@@ -832,8 +667,6 @@ describe('setCurrentId', () => {
     });
 
     it('should not switch to an invalid ID', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
 
         try {
@@ -847,14 +680,7 @@ describe('setCurrentId', () => {
 });
 
 describe('backupId', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should backup a new ID', async () => {
-        mockFs({});
-
         const name = 'Bob';
         await keymaster.createId(name);
 
@@ -868,8 +694,6 @@ describe('backupId', () => {
     });
 
     it('should backup a non-current ID', async () => {
-        mockFs({});
-
         const aliceDid = await keymaster.createId('Alice');
         await keymaster.createId('Bob'); // Bob will be current ID
         const ok = await keymaster.backupId('Alice');
@@ -883,14 +707,7 @@ describe('backupId', () => {
 });
 
 describe('recoverId', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should recover an id from backup', async () => {
-        mockFs({});
-
         const name = 'Bob';
         const did = await keymaster.createId(name);
         let wallet = await keymaster.loadWallet();
@@ -912,8 +729,6 @@ describe('recoverId', () => {
     });
 
     it('should not overwrite an id with the same name', async () => {
-        mockFs({});
-
         const did = await keymaster.createId('Bob');
         await keymaster.backupId();
 
@@ -927,8 +742,6 @@ describe('recoverId', () => {
     });
 
     it('should not recover an id to a different wallet', async () => {
-        mockFs({});
-
         const did = await keymaster.createId('Bob');
         await keymaster.backupId();
 
@@ -946,14 +759,7 @@ describe('recoverId', () => {
 });
 
 describe('testAgent', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return true for agent DID', async () => {
-        mockFs({});
-
         const did = await keymaster.createId('Bob');
         const isAgent = await keymaster.testAgent(did);
 
@@ -961,8 +767,6 @@ describe('testAgent', () => {
     });
 
     it('should return false for non-agent DID', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const dataDid = await keymaster.createAsset({ name: 'mockAnchor' });
         const isAgent = await keymaster.testAgent(dataDid);
@@ -971,8 +775,6 @@ describe('testAgent', () => {
     });
 
     it('should raise an exception if no DID specified', async () => {
-        mockFs({});
-
         try {
             // @ts-expect-error Testing invalid usage, missing arg
             await keymaster.testAgent();
@@ -984,8 +786,6 @@ describe('testAgent', () => {
     });
 
     it('should raise an exception if invalid DID specified', async () => {
-        mockFs({});
-
         try {
             await keymaster.testAgent('mock');
             throw new ExpectedExceptionError();
@@ -997,14 +797,7 @@ describe('testAgent', () => {
 });
 
 describe('resolveDID', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should resolve a new ID', async () => {
-        mockFs({});
-
         const name = 'Bob';
         const did = await keymaster.createId(name);
         const doc = await keymaster.resolveDID(did);
@@ -1014,14 +807,7 @@ describe('resolveDID', () => {
 });
 
 describe('resolveAsset', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should resolve a new asset', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const mockAsset = { name: 'mockAnchor' };
         const did = await keymaster.createAsset(mockAsset);
@@ -1031,8 +817,6 @@ describe('resolveAsset', () => {
     });
 
     it('should return empty asset on invalid DID', async () => {
-        mockFs({});
-
         const agentDID = await keymaster.createId('Bob');
         const asset = await keymaster.resolveAsset(agentDID);
 
@@ -1040,8 +824,6 @@ describe('resolveAsset', () => {
     });
 
     it('should return empty asset when revoked', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const mockAsset = { name: 'mockAnchor' };
         const did = await keymaster.createAsset(mockAsset);
@@ -1054,13 +836,7 @@ describe('resolveAsset', () => {
 });
 
 describe('updateAsset', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should update an asset', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const mockAsset1 = { name: 'original' };
         const mockAsset2 = { name: 'updated' };
@@ -1073,8 +849,6 @@ describe('updateAsset', () => {
     });
 
     it('should update an asset with merged data', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const mockAsset1 = { key1: 'val1' };
         const mockAsset2 = { key2: 'val2' };
@@ -1087,8 +861,6 @@ describe('updateAsset', () => {
     });
 
     it('should remove a property when updated to be undefined ', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const mockAsset1 = { key1: 'val1', key2: 'val2' };
         const mockAsset2 = { key2: undefined };
@@ -1102,14 +874,7 @@ describe('updateAsset', () => {
 });
 
 describe('rotateKeys', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should update DID doc with new keys', async () => {
-        mockFs({});
-
         const alice = await keymaster.createId('Alice', { registry: 'local' });
         let doc = await keymaster.resolveDID(alice);
         let vm = doc.didDocument!.verificationMethod![0];
@@ -1129,8 +894,6 @@ describe('rotateKeys', () => {
     });
 
     it('should decrypt messages encrypted with rotating keys', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice', { registry: 'local' });
         const bob = await keymaster.createId('Bob', { registry: 'local' });
         const secrets = [];
@@ -1162,8 +925,6 @@ describe('rotateKeys', () => {
     });
 
     it('should raise an exception if latest version is not confirmed', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice', { registry: 'TFTC' });
         await keymaster.rotateKeys();
 
@@ -1178,14 +939,7 @@ describe('rotateKeys', () => {
 });
 
 describe('addName', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should create a new name', async () => {
-        mockFs({});
-
         const bob = await keymaster.createId('Bob');
         const ok = await keymaster.addName('Jack', bob);
         const wallet = await keymaster.loadWallet();
@@ -1195,8 +949,6 @@ describe('addName', () => {
     });
 
     it('should create a Unicode name', async () => {
-        mockFs({});
-
         const name = 'ҽ× ʍɑϲհíղɑ';
 
         const bob = await keymaster.createId('Bob');
@@ -1208,8 +960,6 @@ describe('addName', () => {
     });
 
     it('should not add duplicate name', async () => {
-        mockFs({});
-
         const alice = await keymaster.createId('Alice');
         const bob = await keymaster.createId('Bob');
 
@@ -1224,8 +974,6 @@ describe('addName', () => {
     });
 
     it('should not add a name that is same as an ID', async () => {
-        mockFs({});
-
         const alice = await keymaster.createId('Alice');
 
         try {
@@ -1238,8 +986,6 @@ describe('addName', () => {
     });
 
     it('should not add an empty name', async () => {
-        mockFs({});
-
         const alice = await keymaster.createId('Alice');
         const expectedError = 'Invalid parameter: name must be a non-empty string';
 
@@ -1288,8 +1034,6 @@ describe('addName', () => {
     });
 
     it('should not add a name that is too long', async () => {
-        mockFs({});
-
         const alice = await keymaster.createId('Alice');
 
         try {
@@ -1302,8 +1046,6 @@ describe('addName', () => {
     });
 
     it('should not add a name that contains unprintable characters', async () => {
-        mockFs({});
-
         const alice = await keymaster.createId('Alice');
 
         try {
@@ -1317,14 +1059,7 @@ describe('addName', () => {
 });
 
 describe('getName', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return DID for a new name', async () => {
-        mockFs({});
-
         const bob = await keymaster.createId('Bob');
         const ok = await keymaster.addName('Jack', bob);
         const did = await keymaster.getName('Jack');
@@ -1334,8 +1069,6 @@ describe('getName', () => {
     });
 
     it('should return null for unknown name', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const did = await keymaster.getName('Jack');
 
@@ -1343,8 +1076,6 @@ describe('getName', () => {
     });
 
     it('should return null for non-string names', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
 
         // @ts-expect-error Testing invalid usage, missing arg
@@ -1366,14 +1097,7 @@ describe('getName', () => {
 });
 
 describe('removeName', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should remove a valid name', async () => {
-        mockFs({});
-
         const bob = await keymaster.createId('Bob');
 
         await keymaster.addName('Jack', bob);
@@ -1385,8 +1109,6 @@ describe('removeName', () => {
     });
 
     it('should return true if name is missing', async () => {
-        mockFs({});
-
         const ok = await keymaster.removeName('Jack');
 
         expect(ok).toBe(true);
@@ -1394,14 +1116,7 @@ describe('removeName', () => {
 });
 
 describe('listNames', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return current list of wallet names', async () => {
-        mockFs({});
-
         const bob = await keymaster.createId('Bob');
 
         for (let i = 0; i < 10; i++) {
@@ -1418,8 +1133,6 @@ describe('listNames', () => {
     });
 
     it('should return empty list if no names added', async () => {
-        mockFs({});
-
         const names = await keymaster.listNames();
 
         expect(Object.keys(names).length).toBe(0);
@@ -1427,14 +1140,7 @@ describe('listNames', () => {
 });
 
 describe('resolveDID', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should resolve a valid id name', async () => {
-        mockFs({});
-
         const did = await keymaster.createId('Bob');
         const doc = await keymaster.resolveDID('Bob');
 
@@ -1442,8 +1148,6 @@ describe('resolveDID', () => {
     });
 
     it('should resolve a valid asset name', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
 
         const mockAnchor = { name: 'mockAnchor' };
@@ -1458,8 +1162,6 @@ describe('resolveDID', () => {
     });
 
     it('should throw an exception for invalid name', async () => {
-        mockFs({});
-
         try {
             await keymaster.resolveDID('mock');
             throw new ExpectedExceptionError();
@@ -1470,14 +1172,7 @@ describe('resolveDID', () => {
 });
 
 describe('createAsset', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should create DID from an object anchor', async () => {
-        mockFs({});
-
         const ownerDid = await keymaster.createId('Bob');
         const mockAnchor = { name: 'mockAnchor' };
         const dataDid = await keymaster.createAsset(mockAnchor);
@@ -1489,8 +1184,6 @@ describe('createAsset', () => {
     });
 
     it('should create DID from a string anchor', async () => {
-        mockFs({});
-
         const ownerDid = await keymaster.createId('Bob');
         const mockAnchor = "mockAnchor";
         const dataDid = await keymaster.createAsset(mockAnchor);
@@ -1502,8 +1195,6 @@ describe('createAsset', () => {
     });
 
     it('should create DID from a list anchor', async () => {
-        mockFs({});
-
         const ownerDid = await keymaster.createId('Bob');
         const mockAnchor = [1, 2, 3];
         const dataDid = await keymaster.createAsset(mockAnchor);
@@ -1515,8 +1206,6 @@ describe('createAsset', () => {
     });
 
     it('should create DID for a different valid ID', async () => {
-        mockFs({});
-
         const ownerDid = await keymaster.createId('Bob');
         const mockAnchor = "mockAnchor";
 
@@ -1531,8 +1220,6 @@ describe('createAsset', () => {
     });
 
     it('should create asset with specified name', async () => {
-        mockFs({});
-
         const ownerDid = await keymaster.createId('Bob');
         const mockAnchor = { name: 'mockAnchor' };
         const mockName = 'mockName'
@@ -1545,21 +1232,16 @@ describe('createAsset', () => {
     });
 
     it('should throw an exception if no ID selected', async () => {
-        mockFs({});
-
         try {
             const mockAnchor = { name: 'mockAnchor' };
             await keymaster.createAsset(mockAnchor);
             throw new ExpectedExceptionError();
-        } catch (error: any) {
-            // eslint-disable-next-line
+        } catch (error: any) {            // eslint-disable-next-line
             expect(error.message).toBe('Keymaster: No current ID');
         }
     });
 
     it('should throw an exception for an empty string anchor', async () => {
-        mockFs({});
-
         try {
             await keymaster.createId('Bob');
             await keymaster.createAsset({}, { name: 'Bob' });
@@ -1570,8 +1252,6 @@ describe('createAsset', () => {
     });
 
     it('should throw an exception for an invalid name', async () => {
-        mockFs({});
-
         try {
             await keymaster.createId('Bob');
             await keymaster.createAsset("");
@@ -1583,14 +1263,7 @@ describe('createAsset', () => {
 });
 
 describe('cloneAsset', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should clone an asset DID', async () => {
-        mockFs({});
-
         const ownerDid = await keymaster.createId('Bob');
         const mockData = { name: 'mockData' };
         const assetDid = await keymaster.createAsset(mockData);
@@ -1609,8 +1282,6 @@ describe('cloneAsset', () => {
     });
 
     it('should clone an asset name', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const mockData = { name: 'mockData' };
         const assetDid = await keymaster.createAsset(mockData);
@@ -1627,8 +1298,6 @@ describe('cloneAsset', () => {
     });
 
     it('should clone an empty asset', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const assetDid = await keymaster.createAsset({});
         await keymaster.addName('asset', assetDid);
@@ -1643,8 +1312,6 @@ describe('cloneAsset', () => {
     });
 
     it('should clone a clone', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const mockData = { name: 'mockData' };
         const assetDid = await keymaster.createAsset(mockData);
@@ -1661,28 +1328,18 @@ describe('cloneAsset', () => {
     });
 
     it('should throw an exception if invalid asset provided', async () => {
-        mockFs({});
-
         try {
             const bob = await keymaster.createId('Bob');
             await keymaster.cloneAsset(bob);
             throw new ExpectedExceptionError();
-        } catch (error: any) {
-            // eslint-disable-next-line
+        } catch (error: any) {            // eslint-disable-next-line
             expect(error.message).toBe('Invalid parameter: id');
         }
     });
 });
 
 describe('transferAsset', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should transfer an asset DID to an agent DID', async () => {
-        mockFs({});
-
         const alice = await keymaster.createId('Alice');
         await keymaster.createId('Bob');
         const mockAnchor = { name: 'mockAnchor' };
@@ -1702,8 +1359,6 @@ describe('transferAsset', () => {
     });
 
     it('should transfer an asset name to an agent name', async () => {
-        mockFs({});
-
         const alice = await keymaster.createId('Alice');
         await keymaster.createId('Bob');
         const mockAnchor = { name: 'mockAnchor' };
@@ -1724,8 +1379,6 @@ describe('transferAsset', () => {
     });
 
     it('should not update if controller does not change', async () => {
-        mockFs({});
-
         const bob = await keymaster.createId('Bob');
         const mockAnchor = { name: 'mockAnchor' };
         const dataDid = await keymaster.createAsset(mockAnchor);
@@ -1739,8 +1392,6 @@ describe('transferAsset', () => {
     });
 
     it('should throw an exception on invalid did', async () => {
-        mockFs({});
-
         const bob = await keymaster.createId('Bob');
 
         try {
@@ -1752,8 +1403,6 @@ describe('transferAsset', () => {
     });
 
     it('should throw if did is an agent', async () => {
-        mockFs({});
-
         const bob = await keymaster.createId('Bob');
 
         try {
@@ -1765,8 +1414,6 @@ describe('transferAsset', () => {
     });
 
     it('should throw an exception on invalid controller', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const mockAnchor = { name: 'mockAnchor' };
         const dataDid = await keymaster.createAsset(mockAnchor);
@@ -1780,8 +1427,6 @@ describe('transferAsset', () => {
     });
 
     it('should throw an exception if asset not owned by this wallet', async () => {
-        mockFs({});
-
         const alice = await keymaster.createId('Alice');
         const bob = await keymaster.createId('Bob');
         const mockAnchor = { name: 'mockAnchor' };
@@ -1798,14 +1443,7 @@ describe('transferAsset', () => {
 });
 
 describe('listAssets', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return empty list when no assets', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const assets = await keymaster.listAssets();
 
@@ -1813,8 +1451,6 @@ describe('listAssets', () => {
     });
 
     it('should return assets owned by current ID', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const mockAnchor = { name: 'mockAnchor' };
         const dataDid = await keymaster.createAsset(mockAnchor);
@@ -1824,8 +1460,6 @@ describe('listAssets', () => {
     });
 
     it('should return assets owned by specified ID', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
         const mockAnchor = { name: 'mockAnchor' };
         const dataDid = await keymaster.createAsset(mockAnchor);
@@ -1839,8 +1473,6 @@ describe('listAssets', () => {
     });
 
     it('should not include ephemeral assets', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const mockAnchor = { name: 'mockAnchor' };
         const validUntil = new Date();
@@ -1853,13 +1485,7 @@ describe('listAssets', () => {
 });
 
 describe('updateDID', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should throw if doc missing id', async () => {
-        mockFs({});
         const doc: MdipDocument = {};
 
         try {
@@ -1871,8 +1497,6 @@ describe('updateDID', () => {
     });
 
     it('should update an asset DID', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const mockAnchor = { name: 'mockAnchor' };
         const dataDid = await keymaster.createAsset(mockAnchor);
@@ -1890,8 +1514,6 @@ describe('updateDID', () => {
     });
 
     it('should not update an asset DID if no changes', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const mockAnchor = { name: 'mockAnchor', val: 1234 };
         const dataDid = await keymaster.createAsset(mockAnchor);
@@ -1908,8 +1530,6 @@ describe('updateDID', () => {
     });
 
     it('should update an asset DID when current ID is not owner ID', async () => {
-        mockFs({});
-
         const bob = await keymaster.createId('Bob');
         await keymaster.createId('Alice');
 
@@ -1935,14 +1555,7 @@ describe('updateDID', () => {
 });
 
 describe('revokeDID', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should revoke an asset DID', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const mockAnchor = { name: 'mockAnchor' };
         const dataDid = await keymaster.createAsset(mockAnchor);
@@ -1957,8 +1570,6 @@ describe('revokeDID', () => {
     });
 
     it('should revoke an asset DID when current ID is not owner ID', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         await keymaster.createId('Alice');
 
@@ -1980,14 +1591,7 @@ describe('revokeDID', () => {
 });
 
 describe('removeFromOwned', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return false if nothing owned', async () => {
-        mockFs({});
-
         const owner = await keymaster.createId('Alice');
         const ok = await keymaster.removeFromOwned("did:mock", owner);
 
@@ -2006,14 +1610,7 @@ function generateRandomString(length: number) {
 }
 
 describe('encryptMessage', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should encrypt a short message', async () => {
-        mockFs({});
-
         const name = 'Bob';
         const did = await keymaster.createId(name);
 
@@ -2027,8 +1624,6 @@ describe('encryptMessage', () => {
     });
 
     it('should encrypt a long message', async () => {
-        mockFs({});
-
 
         const name = 'Bob';
         const did = await keymaster.createId(name);
@@ -2044,14 +1639,7 @@ describe('encryptMessage', () => {
 });
 
 describe('decryptMessage', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should decrypt a short message encrypted by same ID', async () => {
-        mockFs({});
-
         const name = 'Bob';
         const did = await keymaster.createId(name);
 
@@ -2063,8 +1651,6 @@ describe('decryptMessage', () => {
     });
 
     it('should decrypt a short message after rotating keys (confirmed)', async () => {
-        mockFs({});
-
         const did = await keymaster.createId('Bob', { registry: 'local' });
         const msg = 'Hi Bob!';
         await keymaster.rotateKeys();
@@ -2076,8 +1662,6 @@ describe('decryptMessage', () => {
     });
 
     it('should decrypt a short message after rotating keys (unconfirmed)', async () => {
-        mockFs({});
-
         const did = await keymaster.createId('Bob', { registry: 'hyperswarm' });
         const msg = 'Hi Bob!';
         await keymaster.rotateKeys();
@@ -2088,8 +1672,6 @@ describe('decryptMessage', () => {
     });
 
     it('should decrypt a short message encrypted by another ID', async () => {
-        mockFs({});
-
         const name1 = 'Alice';
         await keymaster.createId(name1);
 
@@ -2108,8 +1690,6 @@ describe('decryptMessage', () => {
     });
 
     it('should decrypt a long message encrypted by another ID', async () => {
-        mockFs({});
-
         const name1 = 'Alice';
         await keymaster.createId(name1);
 
@@ -2128,8 +1708,6 @@ describe('decryptMessage', () => {
     });
 
     it('should throw an exception on invalid DID', async () => {
-        mockFs({});
-
         const name = await keymaster.createId("Alice");
 
         try {
@@ -2148,14 +1726,7 @@ const mockJson = {
 };
 
 describe('encryptJSON', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should encrypt valid JSON', async () => {
-        mockFs({});
-
         const bob = await keymaster.createId('Bob');
         await keymaster.resolveDID(bob);
 
@@ -2166,14 +1737,7 @@ describe('encryptJSON', () => {
 });
 
 describe('decryptJSON', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should decrypt valid JSON', async () => {
-        mockFs({});
-
         const bob = await keymaster.createId('Bob');
         const did = await keymaster.encryptJSON(mockJson, bob);
         const decipher = await keymaster.decryptJSON(did);
@@ -2183,14 +1747,7 @@ describe('decryptJSON', () => {
 });
 
 describe('addSignature', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should add a signature to the object', async () => {
-        mockFs({});
-
         const name = 'Bob';
         const did = await keymaster.createId(name);
         const hash = cipher.hashMessage(canonicalize(mockJson));
@@ -2201,8 +1758,6 @@ describe('addSignature', () => {
     });
 
     it('should throw an exception if no ID selected', async () => {
-        mockFs({});
-
         try {
             await keymaster.addSignature(mockJson);
             throw new ExpectedExceptionError();
@@ -2212,8 +1767,6 @@ describe('addSignature', () => {
     });
 
     it('should throw an exception if null parameter', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
 
         try {
@@ -2227,14 +1780,7 @@ describe('addSignature', () => {
 });
 
 describe('verifySignature', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return true for valid signature', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
 
         const signed = await keymaster.addSignature(mockJson);
@@ -2244,8 +1790,6 @@ describe('verifySignature', () => {
     });
 
     it('should return false for missing signature', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
 
         // @ts-expect-error Testing invalid usage, invalid arg
@@ -2255,8 +1799,6 @@ describe('verifySignature', () => {
     });
 
     it('should return false for invalid signature', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
 
         const signed = await keymaster.addSignature(mockJson);
@@ -2267,8 +1809,6 @@ describe('verifySignature', () => {
     });
 
     it('should return false for missing signer', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
 
         const signed = await keymaster.addSignature(mockJson);
@@ -2279,8 +1819,6 @@ describe('verifySignature', () => {
     });
 
     it('should return false for invalid hash', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
 
         const signed = await keymaster.addSignature(mockJson);
@@ -2291,8 +1829,6 @@ describe('verifySignature', () => {
     });
 
     it('should return false for null parameter', async () => {
-        mockFs({});
-
         // @ts-expect-error Testing invalid usage, missing arg
         const isValid = await keymaster.verifySignature();
 
@@ -2300,8 +1836,6 @@ describe('verifySignature', () => {
     });
 
     it('should return false for invalid JSON', async () => {
-        mockFs({});
-
         // @ts-expect-error Testing invalid usage, invalid arg
         const isValid = await keymaster.verifySignature("not JSON");
 
@@ -2309,8 +1843,7 @@ describe('verifySignature', () => {
     });
 });
 
-const mockSchema = {
-    // eslint-disable-next-line
+const mockSchema = {    // eslint-disable-next-line
     "$schema": "http://json-schema.org/draft-07/schema#",
     "properties": {
         "email": {
@@ -2325,14 +1858,7 @@ const mockSchema = {
 };
 
 describe('isVerifiableCredential', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return false for non-object or null', async () => {
-        mockFs({});
-
         // @ts-expect-error Testing invalid usage, calling private func
         const res1 = keymaster.isVerifiableCredential(null);
 
@@ -2345,14 +1871,7 @@ describe('isVerifiableCredential', () => {
 })
 
 describe('bindCredential', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should create a bound credential', async () => {
-        mockFs({});
-
         const userDid = await keymaster.createId('Bob');
         const credentialDid = await keymaster.createSchema(mockSchema);
 
@@ -2364,8 +1883,6 @@ describe('bindCredential', () => {
     });
 
     it('should create a bound credential with provided default', async () => {
-        mockFs({});
-
         const userDid = await keymaster.createId('Bob');
         const credentialDid = await keymaster.createSchema(mockSchema);
 
@@ -2378,8 +1895,6 @@ describe('bindCredential', () => {
     });
 
     it('should create a bound credential for a different user', async () => {
-        mockFs({});
-
         const alice = await keymaster.createId('Alice');
         const bob = await keymaster.createId('Bob');
         const credentialDid = await keymaster.createSchema(mockSchema);
@@ -2394,14 +1909,7 @@ describe('bindCredential', () => {
 });
 
 describe('issueCredential', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should issue a bound credential when user is issuer', async () => {
-        mockFs({});
-
         const subject = await keymaster.createId('Bob');
         const schema = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(schema, subject);
@@ -2421,8 +1929,6 @@ describe('issueCredential', () => {
     });
 
     it('should bind and issue a credential', async () => {
-        mockFs({});
-
         const subject = await keymaster.createId('Bob');
         const schema = await keymaster.createSchema(mockSchema);
         const unboundCredential = await keymaster.createTemplate(schema);
@@ -2446,8 +1952,6 @@ describe('issueCredential', () => {
     });
 
     it('should throw an exception if user is not issuer', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
         const bob = await keymaster.createId('Bob');
 
@@ -2468,8 +1972,6 @@ describe('issueCredential', () => {
     });
 
     it('should throw an exception on unbound credential without binding options', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
 
         const schema = await keymaster.createSchema(mockSchema);
@@ -2486,14 +1988,7 @@ describe('issueCredential', () => {
 });
 
 describe('listIssued', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return empty list for new ID', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const issued = await keymaster.listIssued();
 
@@ -2501,8 +1996,6 @@ describe('listIssued', () => {
     });
 
     it('should return list containing one issued credential', async () => {
-        mockFs({});
-
         const userDid = await keymaster.createId('Bob');
         const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, userDid);
@@ -2515,14 +2008,7 @@ describe('listIssued', () => {
 });
 
 describe('updateCredential', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should update a valid verifiable credential', async () => {
-        mockFs({});
-
         const userDid = await keymaster.createId('Bob');
         const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, userDid);
@@ -2543,8 +2029,6 @@ describe('updateCredential', () => {
     });
 
     it('should throw exception on invalid parameters', async () => {
-        mockFs({});
-
         const bob = await keymaster.createId('Bob');
         const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, bob);
@@ -2565,8 +2049,7 @@ describe('updateCredential', () => {
             await keymaster.updateCredential(bob, vc);
             throw new ExpectedExceptionError();
         }
-        catch (error: any) {
-            // eslint-disable-next-line
+        catch (error: any) {            // eslint-disable-next-line
             expect(error.message).toBe('Invalid parameter: did not encrypted');
         }
 
@@ -2580,8 +2063,7 @@ describe('updateCredential', () => {
             expect(error.message).toBe('Invalid parameter: did not encrypted JSON');
         }
 
-        try {
-            // Pass cipher DID instead of credential DID
+        try {            // Pass cipher DID instead of credential DID
             const cipherDID = await keymaster.encryptJSON({ bob }, bob);
             await keymaster.updateCredential(cipherDID, vc);
             throw new ExpectedExceptionError();
@@ -2595,8 +2077,7 @@ describe('updateCredential', () => {
             await keymaster.updateCredential(did);
             throw new ExpectedExceptionError();
         }
-        catch (error: any) {
-            // eslint-disable-next-line
+        catch (error: any) {            // eslint-disable-next-line
             expect(error.message).toBe('Invalid parameter: credential');
         }
 
@@ -2632,14 +2113,7 @@ describe('updateCredential', () => {
 });
 
 describe('revokeCredential', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should revoke a valid verifiable credential', async () => {
-        mockFs({});
-
         const userDid = await keymaster.createId('Bob');
         const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, userDid);
@@ -2654,8 +2128,6 @@ describe('revokeCredential', () => {
     });
 
     it('should throw exception if verifiable credential is already revoked', async () => {
-        mockFs({});
-
         const userDid = await keymaster.createId('Bob');
         const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, userDid);
@@ -2678,8 +2150,6 @@ describe('revokeCredential', () => {
     });
 
     it('should throw exception if user does not control verifiable credential', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
         const bob = await keymaster.createId('Bob');
 
@@ -2704,14 +2174,7 @@ describe('revokeCredential', () => {
 });
 
 describe('acceptCredential', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should add a valid verifiable credential to user wallet', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
         const bob = await keymaster.createId('Bob');
 
@@ -2732,8 +2195,6 @@ describe('acceptCredential', () => {
     });
 
     it('should return false if user cannot decrypt credential', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
         const bob = await keymaster.createId('Bob');
         await keymaster.createId('Carol');
@@ -2751,8 +2212,6 @@ describe('acceptCredential', () => {
     });
 
     it('should return false if user is not the credential subject', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
         const bob = await keymaster.createId('Bob');
         await keymaster.createId('Carol');
@@ -2772,8 +2231,6 @@ describe('acceptCredential', () => {
     });
 
     it('should return false if the verifiable credential is invalid', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
         await keymaster.createId('Bob');
 
@@ -2789,14 +2246,7 @@ describe('acceptCredential', () => {
 });
 
 describe('createChallenge', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should create a valid empty challenge', async () => {
-        mockFs({});
-
         const alice = await keymaster.createId('Alice');
         const did = await keymaster.createChallenge();
         const doc = await keymaster.resolveDID(did);
@@ -2813,8 +2263,6 @@ describe('createChallenge', () => {
     });
 
     it('should create an empty challenge with specified expiry', async () => {
-        mockFs({});
-
         const alice = await keymaster.createId('Alice');
         const validUntil = '2025-01-01';
         const did = await keymaster.createChallenge({}, { validUntil });
@@ -2827,8 +2275,6 @@ describe('createChallenge', () => {
     });
 
     it('should create a valid challenge', async () => {
-        mockFs({});
-
         const alice = await keymaster.createId('Alice');
         const bob = await keymaster.createId('Bob');
 
@@ -2853,8 +2299,6 @@ describe('createChallenge', () => {
     });
 
     it('should throw an exception if challenge spec is invalid', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
 
         try {
@@ -2888,8 +2332,6 @@ describe('createChallenge', () => {
     });
 
     it('should throw an exception if validUntil is not a valid date', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
 
         try {
@@ -2904,14 +2346,7 @@ describe('createChallenge', () => {
 });
 
 describe('createResponse', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should create a valid response to a simple challenge', async () => {
-        mockFs({});
-
         const alice = await keymaster.createId('Alice');
         const bob = await keymaster.createId('Bob');
         await keymaster.createId('Victor');
@@ -2953,8 +2388,6 @@ describe('createResponse', () => {
     });
 
     it('should throw an exception on invalid challenge', async () => {
-        mockFs({});
-
         const alice = await keymaster.createId('Alice');
 
         try {
@@ -3001,14 +2434,7 @@ describe('createResponse', () => {
 });
 
 describe('verifyResponse', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should verify valid response to empty challenge', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
         const bob = await keymaster.createId('Bob');
 
@@ -3035,8 +2461,6 @@ describe('verifyResponse', () => {
     });
 
     it('should verify a valid response to a single credential challenge', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
         const carol = await keymaster.createId('Carol');
         await keymaster.createId('Victor');
@@ -3077,8 +2501,6 @@ describe('verifyResponse', () => {
     });
 
     it('should not verify a invalid response to a single credential challenge', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
         await keymaster.createId('Carol');
         await keymaster.createId('Victor');
@@ -3113,8 +2535,6 @@ describe('verifyResponse', () => {
     });
 
     it('should verify a response if credential is updated', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
         const carol = await keymaster.createId('Carol');
         await keymaster.createId('Victor');
@@ -3160,8 +2580,6 @@ describe('verifyResponse', () => {
     });
 
     it('should demonstrate full workflow with credential revocations', async () => {
-        mockFs({});
-
         const alice = await keymaster.createId('Alice', { registry: 'local' });
         const bob = await keymaster.createId('Bob', { registry: 'local' });
         const carol = await keymaster.createId('Carol', { registry: 'local' });
@@ -3268,8 +2686,6 @@ describe('verifyResponse', () => {
     });
 
     it('should raise exception on invalid parameter', async () => {
-        mockFs({});
-
         const alice = await keymaster.createId('Alice');
 
         try {
@@ -3316,14 +2732,7 @@ describe('verifyResponse', () => {
 });
 
 describe('publishCredential', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should reveal a valid credential', async () => {
-        mockFs({});
-
         const bob = await keymaster.createId('Bob');
         const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, bob);
@@ -3339,8 +2748,6 @@ describe('publishCredential', () => {
     });
 
     it('should publish a valid credential without revealing', async () => {
-        mockFs({});
-
         const bob = await keymaster.createId('Bob');
         const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, bob);
@@ -3358,8 +2765,6 @@ describe('publishCredential', () => {
     });
 
     it('should throw when did is not a verifiable credential', async () => {
-        mockFs({});
-
         const bob = await keymaster.createId('Bob');
         const did = await keymaster.encryptJSON(mockJson, bob);
 
@@ -3374,14 +2779,7 @@ describe('publishCredential', () => {
 });
 
 describe('unpublishCredential', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should unpublish a published credential', async () => {
-        mockFs({});
-
         const bob = await keymaster.createId('Bob');
         const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, bob);
@@ -3397,8 +2795,6 @@ describe('unpublishCredential', () => {
     });
 
     it('should throw an exception when no current ID', async () => {
-        mockFs({});
-
         try {
             await keymaster.unpublishCredential('mock');
             throw new ExpectedExceptionError();
@@ -3409,8 +2805,6 @@ describe('unpublishCredential', () => {
     });
 
     it('should throw an exception when credential invalid', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
 
         try {
@@ -3423,8 +2817,6 @@ describe('unpublishCredential', () => {
     });
 
     it('should throw an exception when credential not found', async () => {
-        mockFs({});
-
         const bob = await keymaster.createId('Bob');
         const credentialDid = await keymaster.createSchema(mockSchema);
         const boundCredential = await keymaster.bindCredential(credentialDid, bob);
@@ -3441,14 +2833,7 @@ describe('unpublishCredential', () => {
 });
 
 describe('createGroup', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should create a new named group', async () => {
-        mockFs({});
-
         const ownerDid = await keymaster.createId('Bob');
         const groupName = 'mockGroup';
         const groupDid = await keymaster.createGroup(groupName);
@@ -3468,8 +2853,6 @@ describe('createGroup', () => {
     });
 
     it('should create a new named group with a different DID name', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const groupName = 'mockGroup';
         const didName = 'mockName';
@@ -3488,14 +2871,7 @@ describe('createGroup', () => {
 });
 
 describe('addGroupMember', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should add a DID member to the group', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const groupName = 'mockGroup';
         const groupDid = await keymaster.createGroup(groupName);
@@ -3515,8 +2891,6 @@ describe('addGroupMember', () => {
     });
 
     it('should add a DID alias to the group', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const groupName = 'mockGroup';
         const groupDid = await keymaster.createGroup(groupName);
@@ -3538,8 +2912,6 @@ describe('addGroupMember', () => {
     });
 
     it('should not add an unknown DID alias to the group', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const groupName = 'mockGroup';
         const groupDid = await keymaster.createGroup(groupName);
@@ -3554,8 +2926,6 @@ describe('addGroupMember', () => {
     });
 
     it('should add a DID to a group alias', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const groupName = 'mockGroup';
         const groupDid = await keymaster.createGroup(groupName);
@@ -3577,8 +2947,6 @@ describe('addGroupMember', () => {
     });
 
     it('should not add a DID member to an unknown group alias', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const mockAnchor = { name: 'mockData' };
         const dataDid = await keymaster.createAsset(mockAnchor);
@@ -3593,8 +2961,6 @@ describe('addGroupMember', () => {
     });
 
     it('should add a member to the group only once', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const groupName = 'mockGroup';
         const groupDid = await keymaster.createGroup(groupName);
@@ -3619,8 +2985,6 @@ describe('addGroupMember', () => {
     });
 
     it('should not increment version when adding a member a 2nd time', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const groupName = 'mockGroup';
         const groupDid = await keymaster.createGroup(groupName);
@@ -3639,8 +3003,6 @@ describe('addGroupMember', () => {
     });
 
     it('should add multiple members to the group', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const groupName = 'mockGroup';
         const groupDid = await keymaster.createGroup(groupName);
@@ -3658,8 +3020,6 @@ describe('addGroupMember', () => {
     });
 
     it('should not add a non-DID to the group', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const groupName = 'mockGroup';
         const groupDid = await keymaster.createGroup(groupName);
@@ -3710,8 +3070,6 @@ describe('addGroupMember', () => {
     });
 
     it('should not add a member to a non-group', async () => {
-        mockFs({});
-
         const agentDid = await keymaster.createId('Bob');
         const mockAnchor = { name: 'mockData' };
         const dataDid = await keymaster.createAsset(mockAnchor);
@@ -3756,8 +3114,7 @@ describe('addGroupMember', () => {
             await keymaster.addGroupMember(agentDid, dataDid);
             throw new ExpectedExceptionError();
         }
-        catch (error: any) {
-            // eslint-disable-next-line
+        catch (error: any) {            // eslint-disable-next-line
             expect(error.message).toBe('Invalid parameter: groupId');
         }
 
@@ -3771,8 +3128,6 @@ describe('addGroupMember', () => {
     });
 
     it('should not add a group to itself', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const groupDid = await keymaster.createGroup('group');
 
@@ -3786,8 +3141,6 @@ describe('addGroupMember', () => {
     });
 
     it('should not add a member that contains group', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const group1Did = await keymaster.createGroup('group-1');
         const group2Did = await keymaster.createGroup('group-2');
@@ -3807,14 +3160,7 @@ describe('addGroupMember', () => {
 });
 
 describe('removeGroupMember', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should remove a DID member from a group', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const groupName = 'mockGroup';
         const groupDid = await keymaster.createGroup(groupName);
@@ -3836,8 +3182,6 @@ describe('removeGroupMember', () => {
     });
 
     it('should remove a DID alias from a group', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const groupName = 'mockGroup';
         const groupDid = await keymaster.createGroup(groupName);
@@ -3862,8 +3206,6 @@ describe('removeGroupMember', () => {
     });
 
     it('should be OK to remove a DID that is not in the group', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const groupName = 'mockGroup';
         const groupDid = await keymaster.createGroup(groupName);
@@ -3884,8 +3226,6 @@ describe('removeGroupMember', () => {
     });
 
     it('should not increment version when removing a non-existent member', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const groupName = 'mockGroup';
         const groupDid = await keymaster.createGroup(groupName);
@@ -3902,8 +3242,6 @@ describe('removeGroupMember', () => {
     });
 
     it('should not remove a non-DID from the group', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const groupName = 'mockGroup';
         const groupDid = await keymaster.createGroup(groupName);
@@ -3954,8 +3292,6 @@ describe('removeGroupMember', () => {
     });
 
     it('should not remove a member from a non-group', async () => {
-        mockFs({});
-
         const agentDid = await keymaster.createId('Bob');
         const mockAnchor = { name: 'mockData' };
         const dataDid = await keymaster.createAsset(mockAnchor);
@@ -4024,14 +3360,7 @@ describe('removeGroupMember', () => {
 });
 
 describe('testGroup', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return true when member in group', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const groupName = 'mockGroup';
         const groupDid = await keymaster.createGroup(groupName);
@@ -4045,8 +3374,6 @@ describe('testGroup', () => {
     });
 
     it('should return false when member not in group', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const groupName = 'mockGroup';
         const groupDid = await keymaster.createGroup(groupName);
@@ -4059,8 +3386,6 @@ describe('testGroup', () => {
     });
 
     it('should return true when testing group only', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const groupName = 'mockGroup';
         const groupDid = await keymaster.createGroup(groupName);
@@ -4071,8 +3396,6 @@ describe('testGroup', () => {
     });
 
     it('should return false when testing non-group only', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const mockAnchor = { name: 'mockData' };
         const dataDid = await keymaster.createAsset(mockAnchor);
@@ -4083,8 +3406,6 @@ describe('testGroup', () => {
     });
 
     it('should return true when testing recursive groups', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const group1Did = await keymaster.createGroup('level-1');
         const group2Did = await keymaster.createGroup('level-2');
@@ -4112,14 +3433,7 @@ describe('testGroup', () => {
 });
 
 describe('getGroup', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return the specified group', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const groupName = 'mock';
         const groupDid = await keymaster.createGroup(groupName);
@@ -4131,8 +3445,6 @@ describe('getGroup', () => {
     });
 
     it('should return null on invalid DID', async () => {
-        mockFs({});
-
         const did = await keymaster.createId('Bob');
         const group = (await keymaster.getGroup(did));
 
@@ -4140,8 +3452,6 @@ describe('getGroup', () => {
     });
 
     it('should return old style group (TEMP during did:test)', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const oldGroup = {
             name: 'mock',
@@ -4155,8 +3465,6 @@ describe('getGroup', () => {
     });
 
     it('should return null if non-group DID specified', async () => {
-        mockFs({});
-
         const agentDID = await keymaster.createId('Bob');
         const group = await keymaster.getGroup(agentDID);
 
@@ -4164,8 +3472,6 @@ describe('getGroup', () => {
     });
 
     it('should raise an exception if no DID specified', async () => {
-        mockFs({});
-
         try {
             // @ts-expect-error Testing invalid usage, missing arg
             await keymaster.getGroup();
@@ -4178,14 +3484,7 @@ describe('getGroup', () => {
 });
 
 describe('listGroups', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return list of groups', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
 
         const group1 = await keymaster.createGroup('mock-1');
@@ -4205,14 +3504,7 @@ describe('listGroups', () => {
 });
 
 describe('pollTemplate', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return a poll template', async () => {
-        mockFs({});
-
         const template = await keymaster.pollTemplate();
 
         const expectedTemplate = {
@@ -4229,14 +3521,7 @@ describe('pollTemplate', () => {
 });
 
 describe('createPoll', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should create a poll from a valid template', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
         const template = await keymaster.pollTemplate();
@@ -4250,8 +3535,6 @@ describe('createPoll', () => {
     });
 
     it('should not create a poll from an invalid template', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
         const template = await keymaster.pollTemplate();
@@ -4304,8 +3587,7 @@ describe('createPoll', () => {
             await keymaster.createPoll(poll);
             throw new ExpectedExceptionError();
         }
-        catch (error: any) {
-            // eslint-disable-next-line
+        catch (error: any) {            // eslint-disable-next-line
             expect(error.message).toBe('Invalid parameter: poll.options');
         }
 
@@ -4345,8 +3627,7 @@ describe('createPoll', () => {
             await keymaster.createPoll(poll);
             throw new ExpectedExceptionError();
         }
-        catch (error: any) {
-            // eslint-disable-next-line
+        catch (error: any) {            // eslint-disable-next-line
             expect(error.message).toBe('Invalid parameter: poll.deadline');
         }
 
@@ -4378,14 +3659,7 @@ describe('createPoll', () => {
 });
 
 describe('testPoll', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return true only for a poll DID', async () => {
-        mockFs({});
-
         const agentDid = await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
         const template = await keymaster.pollTemplate();
@@ -4416,14 +3690,7 @@ describe('testPoll', () => {
 });
 
 describe('listPolls', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return list of polls', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
         const template = await keymaster.pollTemplate();
@@ -4447,14 +3714,7 @@ describe('listPolls', () => {
 });
 
 describe('getPoll', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return the specified poll', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
         const template = await keymaster.pollTemplate();
@@ -4468,8 +3728,6 @@ describe('getPoll', () => {
     });
 
     it('should return null on invalid id', async () => {
-        mockFs({});
-
         const did = await keymaster.createId('Bob');
         const poll = await keymaster.getPoll(did);
 
@@ -4477,8 +3735,6 @@ describe('getPoll', () => {
     });
 
     it('should return old style poll (TEMP during did:test)', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
         const template = await keymaster.pollTemplate();
@@ -4492,8 +3748,6 @@ describe('getPoll', () => {
     });
 
     it('should return null if non-poll DID specified', async () => {
-        mockFs({});
-
         const agentDID = await keymaster.createId('Bob');
         const group = await keymaster.getPoll(agentDID);
 
@@ -4501,8 +3755,6 @@ describe('getPoll', () => {
     });
 
     it('should raise an exception if no poll DID specified', async () => {
-        mockFs({});
-
         try {
             // @ts-expect-error Testing invalid usage, missing arg
             await keymaster.getPoll();
@@ -4515,14 +3767,7 @@ describe('getPoll', () => {
 });
 
 describe('viewPoll', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return a valid view from a new poll', async () => {
-        mockFs({});
-
         const bobDid = await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
         await keymaster.addGroupMember(rosterDid, bobDid);
@@ -4549,8 +3794,6 @@ describe('viewPoll', () => {
     });
 
     it('should throw on invalid poll id', async () => {
-        mockFs({});
-
         const did = await keymaster.createId('Bob');
 
         try {
@@ -4564,14 +3807,7 @@ describe('viewPoll', () => {
 });
 
 describe('votePoll', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return a valid ballot', async () => {
-        mockFs({});
-
         const bobDid = await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
         await keymaster.addGroupMember(rosterDid, bobDid);
@@ -4592,8 +3828,6 @@ describe('votePoll', () => {
     });
 
     it('should allow a spoiled ballot', async () => {
-        mockFs({});
-
         const bobDid = await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
         await keymaster.addGroupMember(rosterDid, bobDid);
@@ -4614,8 +3848,6 @@ describe('votePoll', () => {
     });
 
     it('should not return a ballot for an invalid vote', async () => {
-        mockFs({});
-
         const bobDid = await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
         await keymaster.addGroupMember(rosterDid, bobDid);
@@ -4635,8 +3867,6 @@ describe('votePoll', () => {
     });
 
     it('should not return a ballot for an ineligible voter', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
         const template = await keymaster.pollTemplate();
@@ -4655,8 +3885,6 @@ describe('votePoll', () => {
     });
 
     it('should throw on an invalid poll id', async () => {
-        mockFs({});
-
         const did = await keymaster.createId('Bob');
 
         try {
@@ -4670,14 +3898,7 @@ describe('votePoll', () => {
 });
 
 describe('updatePoll', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should update poll with valid ballot', async () => {
-        mockFs({});
-
         const bobDid = await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
         await keymaster.addGroupMember(rosterDid, bobDid);
@@ -4694,8 +3915,6 @@ describe('updatePoll', () => {
     });
 
     it('should reject non-ballots', async () => {
-        mockFs({});
-
         const bobDid = await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
         await keymaster.addGroupMember(rosterDid, bobDid);
@@ -4713,8 +3932,6 @@ describe('updatePoll', () => {
     });
 
     it('should throw on invalid ballot id', async () => {
-        mockFs({});
-
         const bob = await keymaster.createId('Bob');
         const did = await keymaster.encryptJSON(mockJson, bob);
 
@@ -4728,8 +3945,6 @@ describe('updatePoll', () => {
     });
 
     it('should throw on invalid poll id', async () => {
-        mockFs({});
-
         const bob = await keymaster.createId('Bob');
 
         const ballot = {
@@ -4750,14 +3965,7 @@ describe('updatePoll', () => {
 });
 
 describe('publishPoll', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should publish results to poll', async () => {
-        mockFs({});
-
         const bobDid = await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
         await keymaster.addGroupMember(rosterDid, bobDid);
@@ -4799,8 +4007,6 @@ describe('publishPoll', () => {
     });
 
     it('should reveal results to poll', async () => {
-        mockFs({});
-
         const bobDid = await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
         await keymaster.addGroupMember(rosterDid, bobDid);
@@ -4825,14 +4031,7 @@ describe('publishPoll', () => {
 });
 
 describe('unpublishPoll', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should remove results from poll', async () => {
-        mockFs({});
-
         const bobDid = await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
         await keymaster.addGroupMember(rosterDid, bobDid);
@@ -4851,8 +4050,6 @@ describe('unpublishPoll', () => {
     });
 
     it('should throw when non-owner tries to update pill', async () => {
-        mockFs({});
-
         const bobDid = await keymaster.createId('Bob');
         const rosterDid = await keymaster.createGroup('mockRoster');
         await keymaster.addGroupMember(rosterDid, bobDid);
@@ -4874,14 +4071,7 @@ describe('unpublishPoll', () => {
 });
 
 describe('createSchema', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should create a credential from a schema', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
 
         const did = await keymaster.createSchema(mockSchema);
@@ -4892,8 +4082,6 @@ describe('createSchema', () => {
     });
 
     it('should create a default schema', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const did = await keymaster.createSchema();
         const doc = await keymaster.resolveDID(did);
@@ -4915,8 +4103,6 @@ describe('createSchema', () => {
     });
 
     it('should create a simple schema', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const did = await keymaster.createSchema(mockSchema);
         const doc = await keymaster.resolveDID(did);
@@ -4925,22 +4111,17 @@ describe('createSchema', () => {
     });
 
     it('should throw an exception on create invalid schema', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
 
         try {
             await keymaster.createSchema({ mock: 'not a schema' });
             throw new ExpectedExceptionError();
-        } catch (error: any) {
-            // eslint-disable-next-line
+        } catch (error: any) {            // eslint-disable-next-line
             expect(error.message).toBe('Invalid parameter: schema');
         }
     });
 
     it('should throw an exception on schema missing properties', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
 
         try {
@@ -4953,14 +4134,7 @@ describe('createSchema', () => {
 });
 
 describe('listSchemas', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return list of schemas', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
 
         const schema1 = await keymaster.createSchema();
@@ -4978,14 +4152,7 @@ describe('listSchemas', () => {
 });
 
 describe('getSchema', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return the schema', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const did = await keymaster.createSchema(mockSchema);
         const schema = await keymaster.getSchema(did);
@@ -4994,8 +4161,6 @@ describe('getSchema', () => {
     });
 
     it('should return null on invalid id', async () => {
-        mockFs({});
-
         const did = await keymaster.createId('Bob');
         const schema = await keymaster.getSchema(did);
 
@@ -5003,8 +4168,6 @@ describe('getSchema', () => {
     });
 
     it('should return the old style schema (TEMP during did:test)', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const did = await keymaster.createAsset(mockSchema);
         const schema = await keymaster.getSchema(did);
@@ -5013,8 +4176,6 @@ describe('getSchema', () => {
     });
 
     it('should throw an exception on get invalid schema', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
 
         try {
@@ -5027,14 +4188,7 @@ describe('getSchema', () => {
 });
 
 describe('setSchema', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should update the schema', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const did = await keymaster.createSchema();
         const ok = await keymaster.setSchema(did, mockSchema);
@@ -5045,8 +4199,6 @@ describe('setSchema', () => {
     });
 
     it('should throw an exception on set invalid schema', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const did = await keymaster.createSchema();
 
@@ -5060,14 +4212,7 @@ describe('setSchema', () => {
 });
 
 describe('testSchema', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return true for a valid schema', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const did = await keymaster.createSchema();
         await keymaster.setSchema(did, mockSchema);
@@ -5078,8 +4223,6 @@ describe('testSchema', () => {
     });
 
     it('should return false for a non-schema DID', async () => {
-        mockFs({});
-
         const agentDID = await keymaster.createId('Bob');
         const isSchema = await keymaster.testSchema(agentDID);
 
@@ -5087,8 +4230,6 @@ describe('testSchema', () => {
     });
 
     it('should return false for non-schemas', async () => {
-        mockFs({});
-
         // @ts-expect-error Testing invalid usage, missing arg
         let isSchema = await keymaster.testSchema();
         expect(isSchema).toBe(false);
@@ -5115,14 +4256,7 @@ describe('testSchema', () => {
 });
 
 describe('createTemplate', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should create template from a valid schema', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const did = await keymaster.createSchema();
         await keymaster.setSchema(did, mockSchema);
@@ -5137,8 +4271,6 @@ describe('createTemplate', () => {
     });
 
     it('should raise an exception when no DID provided', async () => {
-        mockFs({});
-
         try {
             // @ts-expect-error Testing invalid usage, missing arg
             await keymaster.createTemplate();
@@ -5150,13 +4282,7 @@ describe('createTemplate', () => {
 });
 
 describe('listRegistries', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return list of valid registries', async () => {
-        mockFs({});
-
         const registries = await keymaster.listRegistries();
 
         expect(registries.includes('local')).toBe(true);
@@ -5204,13 +4330,7 @@ async function setupCredentials() {
 }
 
 describe('checkWallet', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should report no problems with empty wallet', async () => {
-        mockFs({});
-
         const { checked, invalid, deleted } = await keymaster.checkWallet();
 
         expect(checked).toBe(0);
@@ -5219,8 +4339,6 @@ describe('checkWallet', () => {
     });
 
     it('should report no problems with wallet with only one ID', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
 
         const { checked, invalid, deleted } = await keymaster.checkWallet();
@@ -5231,8 +4349,6 @@ describe('checkWallet', () => {
     });
 
     it('should detect revoked ID', async () => {
-        mockFs({});
-
         const agentDID = await keymaster.createId('Alice');
         await keymaster.revokeDID(agentDID);
 
@@ -5244,8 +4360,6 @@ describe('checkWallet', () => {
     });
 
     it('should detect removed DIDs', async () => {
-        mockFs({});
-
         const agentDID = await keymaster.createId('Alice');
         const schemaDID = await keymaster.createSchema();
         await keymaster.addName('schema', schemaDID);
@@ -5259,8 +4373,6 @@ describe('checkWallet', () => {
     });
 
     it('should detect invalid DIDs', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
         await keymaster.addToOwned('did:test:mock1');
         await keymaster.addToHeld('did:test:mock2');
@@ -5273,8 +4385,6 @@ describe('checkWallet', () => {
     });
 
     it('should detect revoked credentials in wallet', async () => {
-        mockFs({});
-
         const credentials = await setupCredentials();
         await keymaster.addName('credential-0', credentials[0]);
         await keymaster.addName('credential-2', credentials[2]);
@@ -5290,13 +4400,7 @@ describe('checkWallet', () => {
 });
 
 describe('fixWallet', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should report no problems with empty wallet', async () => {
-        mockFs({});
-
         const { idsRemoved, ownedRemoved, heldRemoved, namesRemoved } = await keymaster.fixWallet();
 
         expect(idsRemoved).toBe(0);
@@ -5306,8 +4410,6 @@ describe('fixWallet', () => {
     });
 
     it('should report no problems with wallet with only one ID', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
         const { idsRemoved, ownedRemoved, heldRemoved, namesRemoved } = await keymaster.fixWallet();
 
@@ -5318,8 +4420,6 @@ describe('fixWallet', () => {
     });
 
     it('should remove revoked ID', async () => {
-        mockFs({});
-
         const agentDID = await keymaster.createId('Alice');
         await keymaster.revokeDID(agentDID);
 
@@ -5332,8 +4432,6 @@ describe('fixWallet', () => {
     });
 
     it('should remove deleted DIDs', async () => {
-        mockFs({});
-
         const agentDID = await keymaster.createId('Alice');
         const schemaDID = await keymaster.createSchema();
         await keymaster.addName('schema', schemaDID);
@@ -5348,8 +4446,6 @@ describe('fixWallet', () => {
     });
 
     it('should remove invalid DIDs', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
         await keymaster.addToOwned('did:test:mock1');
         await keymaster.addToHeld('did:test:mock2');
@@ -5363,8 +4459,6 @@ describe('fixWallet', () => {
     });
 
     it('should remove revoked credentials', async () => {
-        mockFs({});
-
         const credentials = await setupCredentials();
         await keymaster.addName('credential-0', credentials[0]);
         await keymaster.addName('credential-2', credentials[2]);
@@ -5381,13 +4475,7 @@ describe('fixWallet', () => {
 });
 
 describe('listCredentials', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('return list of held credentials', async () => {
-        mockFs({});
-
         const expectedCredentials = await setupCredentials();
         const credentials = await keymaster.listCredentials('Carol');
 
@@ -5395,8 +4483,6 @@ describe('listCredentials', () => {
     });
 
     it('return empty list if specified ID holds no credentials', async () => {
-        mockFs({});
-
         await setupCredentials();
         const credentials = await keymaster.listCredentials('Bob');
 
@@ -5404,8 +4490,6 @@ describe('listCredentials', () => {
     });
 
     it('raises an exception if invalid ID specified', async () => {
-        mockFs({});
-
         try {
             await keymaster.listCredentials('mock');
             throw new ExpectedExceptionError();
@@ -5416,13 +4500,7 @@ describe('listCredentials', () => {
 });
 
 describe('getCredential', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('returns decrypted credential for valid DID', async () => {
-        mockFs({});
-
         const credentials = await setupCredentials();
 
         for (const did of credentials) {
@@ -5432,8 +4510,6 @@ describe('getCredential', () => {
     });
 
     it('raises an exception if invalid DID specified', async () => {
-        mockFs({});
-
         try {
             await keymaster.getCredential('mock');
             throw new ExpectedExceptionError();
@@ -5443,8 +4519,6 @@ describe('getCredential', () => {
     });
 
     it('raises an exception if DID specified that is not a credential', async () => {
-        mockFs({});
-
         try {
             const agentDID = await keymaster.createId('Rando');
             await keymaster.getCredential(agentDID);
@@ -5455,8 +4529,6 @@ describe('getCredential', () => {
     });
 
     it('return null if not a verifiable credential', async () => {
-        mockFs({});
-
         const bob = await keymaster.createId('Bob');
         const did = await keymaster.encryptJSON(mockJson, bob);
         const res = await keymaster.getCredential(did);
@@ -5466,13 +4538,7 @@ describe('getCredential', () => {
 });
 
 describe('removeCredential', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('removes specified credential from held credentials list', async () => {
-        mockFs({});
-
         const credentials = await setupCredentials();
 
         const ok1 = await keymaster.removeCredential(credentials[1]);
@@ -5487,8 +4553,6 @@ describe('removeCredential', () => {
     });
 
     it('returns false if DID not previously held', async () => {
-        mockFs({});
-
         const agentDID = await keymaster.createId('Rando');
         const ok = await keymaster.removeCredential(agentDID);
 
@@ -5496,8 +4560,6 @@ describe('removeCredential', () => {
     });
 
     it('raises an exception if no DID specified', async () => {
-        mockFs({});
-
         try {
             // @ts-expect-error Testing invalid usage, missing arg
             await keymaster.removeCredential();
@@ -5508,8 +4570,6 @@ describe('removeCredential', () => {
     });
 
     it('raises an exception if invalid DID specified', async () => {
-        mockFs({});
-
         try {
             await keymaster.removeCredential('mock');
             throw new ExpectedExceptionError();
@@ -5520,13 +4580,7 @@ describe('removeCredential', () => {
 });
 
 describe('listIds', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should list all IDs wallet', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
         await keymaster.createId('Bob');
         await keymaster.createId('Carol');
@@ -5543,13 +4597,7 @@ describe('listIds', () => {
 });
 
 describe('getCurrentId', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should list all IDs wallet', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
         await keymaster.createId('Bob');
         await keymaster.createId('Carol');
@@ -5562,13 +4610,7 @@ describe('getCurrentId', () => {
 });
 
 describe('setCurrentId', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should set current ID', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
         await keymaster.createId('Bob');
         await keymaster.createId('Carol');
@@ -5581,8 +4623,6 @@ describe('setCurrentId', () => {
     });
 
     it('should throw an exception on invalid ID', async () => {
-        mockFs({});
-
         await keymaster.createId('Alice');
         await keymaster.createId('Bob');
         await keymaster.createId('Carol');
@@ -5598,14 +4638,7 @@ describe('setCurrentId', () => {
 });
 
 describe('createImage', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should create DID from image data', async () => {
-        mockFs({});
-
         const mockImage = await sharp({
             create: {
                 width: 100,
@@ -5636,8 +4669,6 @@ describe('createImage', () => {
     });
 
     it('should throw an exception on invalid image buffer', async () => {
-        mockFs({});
-
         try {
             await keymaster.createImage(Buffer.from('mock'));
             throw new ExpectedExceptionError();
@@ -5648,14 +4679,7 @@ describe('createImage', () => {
 });
 
 describe('updateImage', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should update image DID from image data', async () => {
-        mockFs({});
-
         const mockImage = await sharp({
             create: {
                 width: 100,
@@ -5697,8 +4721,6 @@ describe('updateImage', () => {
     });
 
     it('should add image to an empty asset', async () => {
-        mockFs({});
-
         const ownerDid = await keymaster.createId('Bob');
         const dataDid = await keymaster.createAsset({});
 
@@ -5732,8 +4754,6 @@ describe('updateImage', () => {
     });
 
     it('should throw an exception on invalid update image buffer', async () => {
-        mockFs({});
-
         const mockImage = await sharp({
             create: {
                 width: 100,
@@ -5756,14 +4776,7 @@ describe('updateImage', () => {
 });
 
 describe('getImage', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return the image', async () => {
-        mockFs({});
-
         // Create a small image buffer using sharp
         const mockImage = await sharp({
             create: {
@@ -5786,8 +4799,6 @@ describe('getImage', () => {
     });
 
     it('should return null on invalid did', async () => {
-        mockFs({});
-
         const did = await keymaster.createId('Bob');
         const image = await keymaster.getImage(did);
 
@@ -5795,8 +4806,6 @@ describe('getImage', () => {
     });
 
     it('should throw an exception on get invalid image', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
 
         try {
@@ -5809,13 +4818,7 @@ describe('getImage', () => {
 });
 
 describe('testImage', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return true for image DID', async () => {
-        mockFs({});
-
         // Create a small image buffer using sharp
         const mockImage = await sharp({
             create: {
@@ -5834,8 +4837,6 @@ describe('testImage', () => {
     });
 
     it('should return true for image name', async () => {
-        mockFs({});
-
         // Create a small image buffer using sharp
         const mockImage = await sharp({
             create: {
@@ -5855,8 +4856,6 @@ describe('testImage', () => {
     });
 
     it('should return false for non-image DID', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const did = await keymaster.createAsset({ name: 'mockAnchor' });
         const isImage = await keymaster.testImage(did);
@@ -5865,30 +4864,19 @@ describe('testImage', () => {
     });
 
     it('should return false if no DID specified', async () => {
-        mockFs({});
-
         // @ts-expect-error Testing invalid usage, missing arg
         const isImage = await keymaster.testImage();
         expect(isImage).toBe(false);
     });
 
     it('should return false if invalid DID specified', async () => {
-        mockFs({});
-
         const isImage = await keymaster.testImage('mock');
         expect(isImage).toBe(false);
     });
 });
 
 describe('createDocument', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should create DID from document data', async () => {
-        mockFs({});
-
         const mockDocument = Buffer.from('This is a mock binary document.', 'utf-8');
         const cid = await generateCID(mockDocument);
         const filename = 'mockDocument.txt';
@@ -5913,8 +4901,6 @@ describe('createDocument', () => {
     });
 
     it('should handle case where no filename is provided', async () => {
-        mockFs({});
-
         const mockDocument = Buffer.from('This is another mock binary document.', 'utf-8');
         const cid = await generateCID(mockDocument);
 
@@ -5938,8 +4924,6 @@ describe('createDocument', () => {
     });
 
     it('should handle case where filename has no extension', async () => {
-        mockFs({});
-
         const mockDocument = Buffer.from('This is another mock document.', 'utf-8');
         const cid = await generateCID(mockDocument);
         const filename = 'mockDocument';
@@ -5965,14 +4949,7 @@ describe('createDocument', () => {
 });
 
 describe('updateDocument', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should update named DID from document data', async () => {
-        mockFs({});
-
         const mockdoc_v1 = Buffer.from('This is the first version.', 'utf-8');
         const mockdoc_v2 = Buffer.from('This is the second version.', 'utf-8');
         const cid = await generateCID(mockdoc_v2);
@@ -5999,8 +4976,6 @@ describe('updateDocument', () => {
     });
 
     it('should handle case where no filename is provided', async () => {
-        mockFs({});
-
         const mockdoc_v1 = Buffer.from('This is another first version.', 'utf-8');
         const mockdoc_v2 = Buffer.from('This is another second version.', 'utf-8');
         const cid = await generateCID(mockdoc_v2);
@@ -6026,8 +5001,6 @@ describe('updateDocument', () => {
     });
 
     it('should handle case where filename has no extension', async () => {
-        mockFs({});
-
         const mockdoc_v1 = Buffer.from('This is yet another first version.', 'utf-8');
         const mockdoc_v2 = Buffer.from('This is yet another second version.', 'utf-8');
         const cid = await generateCID(mockdoc_v2);
@@ -6055,14 +5028,7 @@ describe('updateDocument', () => {
 });
 
 describe('getDocument', () => {
-
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return the document asset', async () => {
-        mockFs({});
-
         const mockDocument = Buffer.from('This is a mock binary document.', 'utf-8');
         const cid = await generateCID(mockDocument);
         const filename = 'mockDocument.txt';
@@ -6083,13 +5049,7 @@ describe('getDocument', () => {
 });
 
 describe('testDocument', () => {
-    afterEach(() => {
-        mockFs.restore();
-    });
-
     it('should return true for document DID', async () => {
-        mockFs({});
-
         const mockDocument = Buffer.from('This is a test document.', 'utf-8');
 
         await keymaster.createId('Bob');
@@ -6100,8 +5060,6 @@ describe('testDocument', () => {
     });
 
     it('should return true for document name', async () => {
-        mockFs({});
-
         const mockDocument = Buffer.from('This is another test document.', 'utf-8');
 
         await keymaster.createId('Bob');
@@ -6113,8 +5071,6 @@ describe('testDocument', () => {
     });
 
     it('should return false for non-document DID', async () => {
-        mockFs({});
-
         await keymaster.createId('Bob');
         const did = await keymaster.createAsset({ name: 'mockAnchor' });
         const isDocument = await keymaster.testDocument(did);
@@ -6123,16 +5079,12 @@ describe('testDocument', () => {
     });
 
     it('should return false if no DID specified', async () => {
-        mockFs({});
-
         // @ts-expect-error Testing invalid usage, missing arg
         const isDocument = await keymaster.testDocument();
         expect(isDocument).toBe(false);
     });
 
     it('should return false if invalid DID specified', async () => {
-        mockFs({});
-
         const isDocument = await keymaster.testDocument('mock');
         expect(isDocument).toBe(false);
     });


### PR DESCRIPTION
This PR upgrades the Node.js version to v22.15.0 LTS and updates related dependency versions and configurations.

-    Added a new in-memory JSON storage implementation for keymaster and gatekeeper (replacing mockFs in the unit tests)
-    Upgraded dependencies and updated Node.js versions in Dockerfiles, GitHub workflows, and documentation.