### PR TITLE
ci: update workflow to trigger on PRs

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -10,7 +10,7 @@
 name: Build & Test Docker images
 
 on:
-  workflow_dispatch:
+  pull_request:
 
 jobs:
   build_test_images:


### PR DESCRIPTION
Activates the testing pipeline for CLI tests. After this is merged we can add a rule to enforce it must pass before merging. 