### PR TITLE
feat: Validate GroupVault item names

### DIFF
--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -2780,6 +2780,8 @@ export default class Keymaster implements KeymasterInterface {
         const groupVault = await this.getGroupVault(vaultId);
         const { privateJwk, items } = await this.decryptGroupVault(groupVault);
 
+        name = this.validateName(name);
+
         const encryptedData = this.cipher.encryptBytes(groupVault.publicJwk, privateJwk, buffer);
         const cid = await this.gatekeeper.addText(encryptedData);
         const sha256 = this.cipher.hashMessage(buffer);

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -2779,13 +2779,12 @@ export default class Keymaster implements KeymasterInterface {
     async addGroupVaultItem(vaultId: string, name: string, buffer: Buffer): Promise<boolean> {
         const groupVault = await this.getGroupVault(vaultId);
         const { privateJwk, items } = await this.decryptGroupVault(groupVault);
-
-        name = this.validateName(name);
-
+        const validName = this.validateName(name);
         const encryptedData = this.cipher.encryptBytes(groupVault.publicJwk, privateJwk, buffer);
         const cid = await this.gatekeeper.addText(encryptedData);
         const sha256 = this.cipher.hashMessage(buffer);
-        items[name] = {
+        
+        items[validName] = {
             cid,
             sha256,
             bytes: buffer.length,

--- a/tests/keymaster.test.ts
+++ b/tests/keymaster.test.ts
@@ -528,6 +528,7 @@ describe('createId', () => {
     });
 
     it('should not create an ID with an empty name', async () => {
+        // eslint-disable-next-line
         const expectedError = 'Invalid parameter: name must be a non-empty string';
 
         try {
@@ -5320,9 +5321,19 @@ describe('listGroupVaultMembers', () => {
 });
 
 describe('addGroupVaultItem', () => {
+    const mockDocument = Buffer.from('This is a mock binary document 1.', 'utf-8');
+
     it('should add a document to the groupVault', async () => {
         const mockName = 'mockDocument1.txt';
-        const mockDocument = Buffer.from('This is a mock binary document 1.', 'utf-8');
+        await keymaster.createId('Bob');
+        const did = await keymaster.createGroupVault();
+
+        const ok = await keymaster.addGroupVaultItem(did, mockName, mockDocument);
+        expect(ok).toBe(true);
+    });
+
+    it('should add a document to the groupVault with a unicode name', async () => {
+        const mockName = 'm̾o̾c̾k̾N̾a̾m̾e̾.txt';
         await keymaster.createId('Bob');
         const did = await keymaster.createGroupVault();
 
@@ -5345,6 +5356,36 @@ describe('addGroupVaultItem', () => {
 
         const ok = await keymaster.addGroupVaultItem(did, mockName, mockImage);
         expect(ok).toBe(true);
+    });
+
+    it('should not add an item with an empty name', async () => {
+        await keymaster.createId('Bob');
+        const did = await keymaster.createGroupVault();
+        const expectedError = 'Invalid parameter: name must be a non-empty string';
+
+        try {
+            await keymaster.addGroupVaultItem(did, '', mockDocument);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(expectedError);
+        }
+
+        try {
+            await keymaster.addGroupVaultItem(did, '    ', mockDocument);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(expectedError);
+        }
+
+        try {
+            await keymaster.addGroupVaultItem(did, "\t\r\n", mockDocument);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(expectedError);
+        }
     });
 });
 


### PR DESCRIPTION
This PR adds validation for GroupVault item names to reject empty or whitespace-only names and expands tests accordingly.

-    Integrated validateName call in addGroupVaultItem to enforce non-empty item names.
-    Enhanced test suite with cases for unicode names and various invalid name inputs.
