### PR TITLE
feat: Adds GroupVault option for secret members

### DIFF
--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -2652,11 +2652,11 @@ export default class Keymaster implements KeymasterInterface {
         const memberKey = this.cipher.encryptMessage(idKeypair!.publicJwk, vaultKeypair.privateJwk, JSON.stringify(vaultKeypair.privateJwk));
         const memberID = this.cipher.hashMessage(salt + id.did);
         const keys = { [memberID]: memberKey };
-        const sha256 = this.cipher.hashJSON({});
         const config = this.cipher.encryptMessage(idKeypair!.publicJwk, vaultKeypair.privateJwk, JSON.stringify(options));
-        const publicJwk = options.secretMembers ? idKeypair!.publicJwk : vaultKeypair.publicJwk;
+        const publicJwk = options.secretMembers ? idKeypair!.publicJwk : vaultKeypair.publicJwk; // If secret, encrypt for the owner only
         const members = this.cipher.encryptMessage(publicJwk, vaultKeypair.privateJwk, JSON.stringify({}));
         const items = this.cipher.encryptMessage(vaultKeypair.publicJwk, vaultKeypair.privateJwk, JSON.stringify({}));
+        const sha256 = this.cipher.hashJSON({});
         const groupVault = {
             publicJwk: vaultKeypair.publicJwk,
             salt,

--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -186,10 +186,15 @@ export interface FileAsset extends BinaryAsset {
 export interface GroupVault {
     publicJwk: EcdsaJwkPublic,
     salt: string;
+    config: string;
     members: string;
     keys: Record<string, string>;
     items: string,
     sha256: string,
+}
+
+export interface GroupVaultConfig {
+    secretMembers?: boolean;
 }
 
 export type StoredWallet = EncryptedWallet | WalletFile | null;

--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -193,7 +193,7 @@ export interface GroupVault {
     sha256: string,
 }
 
-export interface GroupVaultConfig {
+export interface GroupVaultOptions extends CreateAssetOptions {
     secretMembers?: boolean;
 }
 

--- a/scripts/keychain-cli.js
+++ b/scripts/keychain-cli.js
@@ -1168,6 +1168,7 @@ program
     .description('Create a group vault')
     .option('-n, --name <name>', 'DID name')
     .option('-r, --registry <registry>', 'registry to use')
+    .option('-s, --secretMembers', 'keep member list secret from each other')
     .action(async (options) => {
         try {
             const did = await keymaster.createGroupVault(options);

--- a/tests/keymaster.test.ts
+++ b/tests/keymaster.test.ts
@@ -1409,6 +1409,7 @@ describe('transferAsset', () => {
             await keymaster.transferAsset('mockDID', bob);
             throw new ExpectedExceptionError();
         } catch (error: any) {
+            // eslint-disable-next-line
             expect(error.message).toBe('Unknown ID');
         }
     });

--- a/tests/keymaster.test.ts
+++ b/tests/keymaster.test.ts
@@ -5241,6 +5241,20 @@ describe('addGroupVaultMember', () => {
         expect(charlieId in groupVault!.keys).toBe(true);
     });
 
+    it('should throw an exception if not owner', async () => {
+        await keymaster.createId('Bob');
+        const did = await keymaster.createGroupVault();
+
+        await keymaster.createId('Alice');
+
+        try {
+            await keymaster.addGroupVaultMember(did, 'Bob');
+            throw new ExpectedExceptionError();
+        } catch (error: any) {
+            expect(error.message).toBe('Keymaster: Only vault owner can modify the vault');
+        }
+    });
+
     it('should throw an exception on invalid member', async () => {
         await keymaster.createId('Bob');
         const did = await keymaster.createGroupVault();
@@ -5295,6 +5309,20 @@ describe('removeGroupVaultMember', () => {
 
         const ok = await keymaster.removeGroupVaultMember(did, alice);
         expect(ok).toBe(true);
+    });
+
+    it('should throw an exception if not owner', async () => {
+        await keymaster.createId('Bob');
+        const did = await keymaster.createGroupVault();
+
+        await keymaster.createId('Alice');
+
+        try {
+            await keymaster.removeGroupVaultMember(did, 'Bob');
+            throw new ExpectedExceptionError();
+        } catch (error: any) {
+            expect(error.message).toBe('Keymaster: Only vault owner can modify the vault');
+        }
     });
 
     it('should throw an exception on invalid member', async () => {
@@ -5427,6 +5455,20 @@ describe('addGroupVaultItem', () => {
         expect(items!['item1'].sha256).toBe(items!['item2'].sha256);
     });
 
+    it('should throw an exception if not owner', async () => {
+        await keymaster.createId('Bob');
+        const did = await keymaster.createGroupVault();
+
+        await keymaster.createId('Alice');
+
+        try {
+            await keymaster.addGroupVaultItem(did, 'item1', mockDocument);
+            throw new ExpectedExceptionError();
+        } catch (error: any) {
+            expect(error.message).toBe('Keymaster: Only vault owner can modify the vault');
+        }
+    });
+
     it('should not add an item with an empty name', async () => {
         await keymaster.createId('Bob');
         const did = await keymaster.createGroupVault();
@@ -5481,6 +5523,20 @@ describe('removeGroupVaultItem', () => {
 
         const ok = await keymaster.removeGroupVaultItem(did, 'bogus');
         expect(ok).toBe(true);
+    });
+
+    it('should throw an exception if not owner', async () => {
+        await keymaster.createId('Bob');
+        const did = await keymaster.createGroupVault();
+
+        await keymaster.createId('Alice');
+
+        try {
+            await keymaster.removeGroupVaultItem(did, 'item1');
+            throw new ExpectedExceptionError();
+        } catch (error: any) {
+            expect(error.message).toBe('Keymaster: Only vault owner can modify the vault');
+        }
     });
 });
 

--- a/tests/keymaster.test.ts
+++ b/tests/keymaster.test.ts
@@ -5198,49 +5198,6 @@ describe('testGroupVault', () => {
     });
 });
 
-describe('getGroupVaultConfig', () => {
-    it('should return config for owner', async () => {
-        await keymaster.createId('Bob');
-        const did = await keymaster.createGroupVault();
-        const config = await keymaster.getGroupVaultConfig(did);
-
-        expect(config).toStrictEqual({ secretMembers: false });
-    });
-
-    it('should return empty config for non-owner', async () => {
-        const alice = await keymaster.createId('Alice');
-        await keymaster.createId('Bob');
-        const did = await keymaster.createGroupVault();
-        await keymaster.addGroupVaultMember(did, alice);
-
-        await keymaster.setCurrentId('Alice');
-        const config = await keymaster.getGroupVaultConfig(did);
-
-        expect(config).toStrictEqual({});
-    });
-});
-
-describe('setGroupVaultConfig', () => {
-    it('should return true when set', async () => {
-        await keymaster.createId('Bob');
-        const did = await keymaster.createGroupVault();
-        const ok = await keymaster.setGroupVaultConfig(did, { secretMembers: true });
-        const config = await keymaster.getGroupVaultConfig(did);
-
-        expect(ok).toBe(true);
-        expect(config).toStrictEqual({ secretMembers: true });
-    });
-
-    it('should return false when no change', async () => {
-        await keymaster.createId('Bob');
-        const did = await keymaster.createGroupVault();
-        const config = await keymaster.getGroupVaultConfig(did);
-        const ok = await keymaster.setGroupVaultConfig(did, config);
-
-        expect(ok).toBe(false);
-    });
-});
-
 describe('addGroupVaultMember', () => {
     it('should add a new member to the groupVault', async () => {
         const alice = await keymaster.createId('Alice');
@@ -5408,8 +5365,7 @@ describe('listGroupVaultMembers', () => {
     it('should not return member list to members when secret', async () => {
         await keymaster.createId('Alice');
         await keymaster.createId('Bob');
-        const did = await keymaster.createGroupVault();
-        await keymaster.setGroupVaultConfig(did, { secretMembers: true });
+        const did = await keymaster.createGroupVault({ secretMembers: true });
         await keymaster.addGroupVaultMember(did, 'Alice');
         await keymaster.setCurrentId('Alice');
 

--- a/tests/keymaster.test.ts
+++ b/tests/keymaster.test.ts
@@ -5241,6 +5241,7 @@ describe('addGroupVaultMember', () => {
         expect(charlieId in groupVault!.keys).toBe(true);
     });
 
+    // eslint-disable-next-line
     it('should throw an exception if not owner', async () => {
         await keymaster.createId('Bob');
         const did = await keymaster.createGroupVault();
@@ -5251,6 +5252,7 @@ describe('addGroupVaultMember', () => {
             await keymaster.addGroupVaultMember(did, 'Bob');
             throw new ExpectedExceptionError();
         } catch (error: any) {
+            // eslint-disable-next-line
             expect(error.message).toBe('Keymaster: Only vault owner can modify the vault');
         }
     });


### PR DESCRIPTION
This PR introduces a new GroupVault option for secret members (meaning vault members cannot view other members), adds corresponding tests and updates to CLI and internal types and logic in Keymaster.

-    Added new tests for GroupVault member operations and error cases
-    Updated CLI options for creating a group vault with secret members
-    Modified GroupVault creation, decryption, and owner checking logic in the Keymaster implementation
