### PR TITLE
fix: Track bad IPFS peers

### DIFF
--- a/services/mediators/hyperswarm/src/hyperswarm-mediator.ts
+++ b/services/mediators/hyperswarm/src/hyperswarm-mediator.ts
@@ -388,15 +388,21 @@ async function addPeer(did: string): Promise<void> {
     };
 }
 
+const badPeers: Record<string, number> = {};
+
 async function syncPeers(peers: string[]): Promise<void> {
     for (const did of peers) {
         if (!(did in knownNodes)) {
             try {
                 await addPeer(did);
-                console.log(`added peer: ${did} ${JSON.stringify(knownNodes[did], null, 4)}`);
+                console.log(`Added IPFS peer: ${did} ${JSON.stringify(knownNodes[did], null, 4)}`);
             }
             catch (error) {
-                console.error(`Error adding peer: ${did}`, error);
+                if (!(did in badPeers)) {
+                    // Store time of first error so we can later implement a retry mechanism
+                    badPeers[did] = Date.now();
+                    console.error(`Error adding IPFS peer: ${did}`, error);
+                }
                 continue;
             }
         }


### PR DESCRIPTION
This PR aims to fix issues related to tracking bad IPFS peers by recording the first failure timestamp. Key changes include:

-    Introducing a new badPeers record to track IPFS peer errors.
-    Updating log messages for added and error cases to indicate "IPFS peer".
-    Adding error handling logic to prevent duplicate logging when a peer fails repeatedly.
