### PR TITLE
feat: Add shared logins to group vaults

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,8 +86,6 @@ services:
       - KC_NODE_NAME=${KC_NODE_NAME}
       - KC_MDIP_PROTOCOL=${KC_MDIP_PROTOCOL}
       - KC_HYPR_EXPORT_INTERVAL=${KC_HYPR_EXPORT_INTERVAL}
-    volumes:
-      - ./data:/app/hyperswarm/data
     user: "${KC_UID}:${KC_GID}"
     depends_on:
       - gatekeeper

--- a/package-lock.json
+++ b/package-lock.json
@@ -5102,6 +5102,53 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
+      "integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "fflate": "^0.8.2",
+        "token-types": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/inflate/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tokenizer/inflate/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "license": "MIT",
@@ -8505,6 +8552,12 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "dev": true,
@@ -8514,6 +8567,24 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.0.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.0.0.tgz",
+      "integrity": "sha512-ek5xNX2YBYlXhiUXui3D/BXa3LdqPmoLJ7rqEx2bKJ7EAUEfmXgW0Das7Dc6Nr9MvqaOnIqiPV0mZk/r/UpNAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.2.7",
+        "strtok3": "^10.2.2",
+        "token-types": "^6.0.0",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -12950,6 +13021,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/peek-readable": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-7.0.0.tgz",
+      "integrity": "sha512-nri2TO5JE3/mRryik9LlHFT53cgHfRK0Lt0BAZQXku/AW3E6XLt2GaY8siWi7dvW/m1z0ecn+J+bpDa9ZN3IsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -14608,6 +14692,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strtok3": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.2.2.tgz",
+      "integrity": "sha512-Xt18+h4s7Z8xyZ0tmBoRmzxcop97R4BAh+dXouUDCYn+Em+1P3qpkUfI5ueWLT8ynC5hZ+q4iPEmGG1urvQGBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/super-regex": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-0.2.0.tgz",
@@ -14890,6 +14991,23 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/token-types": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.0.tgz",
+      "integrity": "sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -15164,6 +15282,18 @@
       "dependencies": {
         "uint8arraylist": "^2.0.0",
         "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.4.0.tgz",
+      "integrity": "sha512-ZPtzy0hu4cZjv3z5NW9gfKnNLjoz4y6uv4HlelAjDK7sY/xOkKZv9xK/WQpcsBB3jEybChz9DPC2U/+cusjJVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/uint8arraylist": {
@@ -15782,6 +15912,7 @@
       "dependencies": {
         "@mdip/common": "*",
         "axios": "^1.7.7",
+        "file-type": "^21.0.0",
         "image-size": "^2.0.1",
         "ioredis": "^5.4.1",
         "mongodb": "^6.5.0",

--- a/packages/keymaster/package.json
+++ b/packages/keymaster/package.json
@@ -93,19 +93,45 @@
   },
   "typesVersions": {
     "*": {
-      "client": ["./dist/types/keymaster-client.d.ts"],
-      "wallet/json": ["./dist/types/db/json.d.ts"],
-      "wallet/json-enc": ["./dist/types/db/json-enc.d.ts"],
-      "wallet/json-memory": ["./dist/types/db/json-memory.d.ts"],
-      "wallet/redis": ["./dist/types/db/redis.d.ts"],
-      "wallet/mongo": ["./dist/types/db/mongo.d.ts"],
-      "wallet/sqlite": ["./dist/types/db/sqlite.d.ts"],
-      "wallet/cache": ["./dist/types/db/cache.d.ts"],
-      "wallet/web": ["./dist/types/db/web.d.ts"],
-      "wallet/web-enc": ["./dist/types/db/web-enc.d.ts"],
-      "wallet/chrome": ["./dist/types/db/chrome.d.ts"],
-      "wallet/typeGuards": ["./dist/types/db/typeGuards.d.ts"],
-      "types": ["./dist/types/types.d.ts"]
+      "client": [
+        "./dist/types/keymaster-client.d.ts"
+      ],
+      "wallet/json": [
+        "./dist/types/db/json.d.ts"
+      ],
+      "wallet/json-enc": [
+        "./dist/types/db/json-enc.d.ts"
+      ],
+      "wallet/json-memory": [
+        "./dist/types/db/json-memory.d.ts"
+      ],
+      "wallet/redis": [
+        "./dist/types/db/redis.d.ts"
+      ],
+      "wallet/mongo": [
+        "./dist/types/db/mongo.d.ts"
+      ],
+      "wallet/sqlite": [
+        "./dist/types/db/sqlite.d.ts"
+      ],
+      "wallet/cache": [
+        "./dist/types/db/cache.d.ts"
+      ],
+      "wallet/web": [
+        "./dist/types/db/web.d.ts"
+      ],
+      "wallet/web-enc": [
+        "./dist/types/db/web-enc.d.ts"
+      ],
+      "wallet/chrome": [
+        "./dist/types/db/chrome.d.ts"
+      ],
+      "wallet/typeGuards": [
+        "./dist/types/db/typeGuards.d.ts"
+      ],
+      "types": [
+        "./dist/types/types.d.ts"
+      ]
     }
   },
   "scripts": {
@@ -120,6 +146,7 @@
   "dependencies": {
     "@mdip/common": "*",
     "axios": "^1.7.7",
+    "file-type": "^21.0.0",
     "image-size": "^2.0.1",
     "ioredis": "^5.4.1",
     "mongodb": "^6.5.0",

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -2864,19 +2864,28 @@ export default class Keymaster implements KeymasterInterface {
         const encryptedData = this.cipher.encryptBytes(groupVault.publicJwk, privateJwk, buffer);
         const cid = await this.gatekeeper.addText(encryptedData);
         const sha256 = this.cipher.hashMessage(buffer);
-        const fileType = await fileTypeFromBuffer(buffer);
+        let fileType = await fileTypeFromBuffer(buffer);
+
+        if (!fileType) {
+            try {
+                JSON.parse(buffer.toString('utf8'));
+                fileType = { ext: 'json', mime: 'application/json' };
+            } catch (e) {
+                fileType = { ext: 'bin', mime: 'application/octet-stream' };
+            }
+        }
 
         items[validName] = {
             cid,
             sha256,
             bytes: buffer.length,
-            type: fileType ? fileType.mime : 'application/octet-stream',
+            type: fileType.mime,
             added: new Date().toISOString(),
         };
 
         groupVault.items = this.cipher.encryptMessage(groupVault.publicJwk, privateJwk, JSON.stringify(items));
         groupVault.sha256 = this.cipher.hashJSON(items);
-        
+
         return this.updateAsset(vaultId, { groupVault });
     }
 

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -1,4 +1,5 @@
 import { imageSize } from 'image-size';
+import { fileTypeFromBuffer } from 'file-type';
 import {
     InvalidDIDError,
     InvalidParameterError,
@@ -2863,15 +2864,19 @@ export default class Keymaster implements KeymasterInterface {
         const encryptedData = this.cipher.encryptBytes(groupVault.publicJwk, privateJwk, buffer);
         const cid = await this.gatekeeper.addText(encryptedData);
         const sha256 = this.cipher.hashMessage(buffer);
+        const fileType = await fileTypeFromBuffer(buffer);
 
         items[validName] = {
             cid,
             sha256,
             bytes: buffer.length,
+            type: fileType ? fileType.mime : 'application/octet-stream',
+            added: new Date().toISOString(),
         };
 
         groupVault.items = this.cipher.encryptMessage(groupVault.publicJwk, privateJwk, JSON.stringify(items));
         groupVault.sha256 = this.cipher.hashJSON(items);
+        
         return this.updateAsset(vaultId, { groupVault });
     }
 

--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -200,6 +200,12 @@ export interface GroupVaultOptions extends CreateAssetOptions {
     version?: number;
 }
 
+export interface GroupVaultLogin {
+    service: string;
+    username: string;
+    password: string;
+}
+
 export type StoredWallet = EncryptedWallet | WalletFile | null;
 
 export interface WalletBase {

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -17,7 +17,7 @@ import {
     TableCell,
     TextField,
     Tooltip,
-    Typography
+    Typography,
 } from '@mui/material';
 import Autocomplete from '@mui/material/Autocomplete';
 import Dialog from '@mui/material/Dialog';
@@ -27,6 +27,7 @@ import DialogActions from '@mui/material/DialogActions';
 import {
     AccountBalanceWallet,
     Article,
+    AttachFile,
     Badge,
     Groups,
     Image,
@@ -36,9 +37,11 @@ import {
     LibraryBooks,
     List,
     Lock,
+    Login,
     Message,
     MarkunreadMailbox,
     PermIdentity,
+    PictureAsPdf,
     Schema,
     Send,
     Token,
@@ -1408,6 +1411,8 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
             setSelectedVault({ members, vaultMembers, items, vaultItems });
         } catch (error) {
+            setSelectedVaultName('');
+            setSelectedVaultOwned(false);
             setSelectedVault(null)
             showError(error);
         }
@@ -1574,6 +1579,29 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
         } catch (error) {
             showError(error);
         }
+    }
+
+    function getVaultItemIcon(item) {
+        const iconStyle = { verticalAlign: 'middle', marginRight: 4 };
+
+        if (!item || !item.type) {
+            return <AttachFile style={iconStyle} />;
+        }
+
+        if (item.type.startsWith('image/')) {
+            return <Image style={iconStyle} />;
+        }
+
+        if (item.type === 'application/pdf') {
+            return <PictureAsPdf style={iconStyle} />;
+        }
+
+        if (item.type === 'application/json') {
+            return <Login style={iconStyle} />;
+        }
+
+        // Add more types as needed, e.g. images, pdf, etc.
+        return <AttachFile style={iconStyle} />;
     }
 
     function RegistrySelect() {
@@ -2581,6 +2609,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                         {Object.entries(selectedVault.vaultItems).map(([name, item], index) => (
                                                             <TableRow key={index}>
                                                                 <TableCell>
+                                                                    {getVaultItemIcon(item)}
                                                                     {name}
                                                                 </TableCell>
                                                                 <TableCell>

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -544,6 +544,37 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
         return '';
     }
 
+    function getNameIcon(name) {
+        const iconStyle = { verticalAlign: 'middle', marginRight: 4 };
+
+        if (agentList && agentList.includes(name)) {
+            return <PermIdentity style={iconStyle} />;
+        }
+
+        if (vaultList && vaultList.includes(name)) {
+            return <Lock style={iconStyle} />;
+        }
+
+        if (groupList && groupList.includes(name)) {
+            return <Groups style={iconStyle} />;
+        }
+
+        if (schemaList && schemaList.includes(name)) {
+            return <Schema style={iconStyle} />;
+        }
+
+        if (imageList && imageList.includes(name)) {
+            return <Image style={iconStyle} />;
+        }
+
+        if (documentList && documentList.includes(name)) {
+            return <Article style={iconStyle} />;
+        }
+
+        // Add more types as needed, e.g. images, pdf, etc.
+        return <Token style={iconStyle} />;
+    }
+
     async function addName() {
         try {
             await keymaster.addName(aliasName, aliasDID);
@@ -1914,7 +1945,10 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                         </TableRow>
                                         {Object.entries(nameList).map(([name, did], index) => (
                                             <TableRow key={index}>
-                                                <TableCell>{name}</TableCell>
+                                                <TableCell>
+                                                    {getNameIcon(name)}
+                                                    {name}
+                                                </TableCell>
                                                 <TableCell>
                                                     <Typography style={{ fontSize: '.9em', fontFamily: 'Courier' }}>
                                                         {did}

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -1395,7 +1395,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
             const docs = await keymaster.resolveDID(vaultName);
 
             setSelectedVaultName(vaultName);
-            setSelectedVaultOwned(docs.didDocumentMetadata.isOwned);
+            setSelectedVaultOwned(docs.didDocument.controller === currentDID);
             setVaultMember('');
 
             const vaultMembers = await keymaster.listGroupVaultMembers(vaultName);
@@ -1475,20 +1475,18 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
     async function addLoginVaultItem(service, username, password) {
         try {
-            if (!service || !username || !password) {
+            if (
+                !service || !username || !password ||
+                !service.trim() || !username.trim() || !password.trim()
+            ) {
                 showError("Service, username, and password are required");
                 return;
             }
 
-            let hostname = "";
-            try {
-                hostname = new URL(service).hostname;
-            } catch (e) {
-                showError("Service URL is invalid");
-                return;
-            }
+            service = service.trim();
+            username = username.trim();
 
-            const name = `login: ${username}@${hostname}`;
+            const name = `login: ${service}`;
             const login = {
                 service,
                 username,

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -1514,8 +1514,9 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
     async function addLoginVaultItem(service, username, password) {
         try {
             if (
-                !service || !username || !password ||
-                !service.trim() || !username.trim() || !password.trim()
+                !service || !service.trim() ||
+                !username || !username.trim() ||
+                !password || !password.trim()
             ) {
                 showError("Service, username, and password are required");
                 return;

--- a/tests/keymaster.test.ts
+++ b/tests/keymaster.test.ts
@@ -10,6 +10,7 @@ import {
     Seed,
     WalletFile,
     GroupVault,
+    GroupVaultLogin,
 } from '@mdip/keymaster/types';
 import CipherNode from '@mdip/cipher/node';
 import DbJsonMemory from '@mdip/gatekeeper/db/json-memory';
@@ -5489,14 +5490,12 @@ describe('addGroupVaultItem', () => {
     });
 
     it('should add JSON to the groupVault', async () => {
-        const mockLogin = {
-            login: {
-                site: 'https://example.com',
-                username: 'bob',
-                password: 'secret',
-            }
+        const login: GroupVaultLogin = {
+            service: 'https://example.com',
+            username: 'bob',
+            password: 'secret',
         };
-        const buffer = Buffer.from(JSON.stringify(mockLogin), 'utf-8');
+        const buffer = Buffer.from(JSON.stringify({ login }), 'utf-8');
         const mockName = 'login: example.com';
         await keymaster.createId('Bob');
         const did = await keymaster.createGroupVault();
@@ -5711,23 +5710,21 @@ describe('getGroupVaultItem', () => {
     });
 
     it('should retrieve JSON to the groupVault', async () => {
-        const mockLogin = {
-            login: {
-                site: 'https://example.com',
-                username: 'bob',
-                password: 'secret',
-            }
+        const login: GroupVaultLogin = {
+            service: 'https://example2.com',
+            username: 'alice',
+            password: '*******',
         };
-        const buffer = Buffer.from(JSON.stringify(mockLogin), 'utf-8');
+        const buffer = Buffer.from(JSON.stringify({ login }), 'utf-8');
         const mockName = 'login: example.com';
         await keymaster.createId('Bob');
         const did = await keymaster.createGroupVault();
         await keymaster.addGroupVaultItem(did, mockName, buffer);
 
         const itemBuffer = await keymaster.getGroupVaultItem(did, mockName);
-        const login = JSON.parse(itemBuffer!.toString('utf-8'));
+        const itemLogin = JSON.parse(itemBuffer!.toString('utf-8'));
 
-        expect(login).toStrictEqual(mockLogin);
+        expect(itemLogin).toStrictEqual({ login });
     });
 });
 

--- a/tests/keymaster.test.ts
+++ b/tests/keymaster.test.ts
@@ -5496,7 +5496,7 @@ describe('addGroupVaultItem', () => {
             password: 'secret',
         };
         const buffer = Buffer.from(JSON.stringify({ login }), 'utf-8');
-        const mockName = 'login: example.com';
+        const mockName = `login: ${login.service}`;
         await keymaster.createId('Bob');
         const did = await keymaster.createGroupVault();
 
@@ -5716,7 +5716,7 @@ describe('getGroupVaultItem', () => {
             password: '*******',
         };
         const buffer = Buffer.from(JSON.stringify({ login }), 'utf-8');
-        const mockName = 'login: example.com';
+        const mockName = `login: ${login.service}`;
         await keymaster.createId('Bob');
         const did = await keymaster.createGroupVault();
         await keymaster.addGroupVaultItem(did, mockName, buffer);

--- a/tests/keymaster.test.ts
+++ b/tests/keymaster.test.ts
@@ -5482,6 +5482,31 @@ describe('addGroupVaultItem', () => {
 
         const ok = await keymaster.addGroupVaultItem(did, mockName, mockImage);
         expect(ok).toBe(true);
+
+        const items = await keymaster.listGroupVaultItems(did);
+        expect(items![mockName]).toBeDefined();
+        expect(items![mockName].type).toBe('image/png');
+    });
+
+    it('should add JSON to the groupVault', async () => {
+        const mockLogin = {
+            login: {
+                site: 'https://example.com',
+                username: 'bob',
+                password: 'secret',
+            }
+        };
+        const buffer = Buffer.from(JSON.stringify(mockLogin), 'utf-8');
+        const mockName = 'login: example.com';
+        await keymaster.createId('Bob');
+        const did = await keymaster.createGroupVault();
+
+        const ok = await keymaster.addGroupVaultItem(did, mockName, buffer);
+        expect(ok).toBe(true);
+
+        const items = await keymaster.listGroupVaultItems(did);
+        expect(items![mockName]).toBeDefined();
+        expect(items![mockName].type).toBe('application/json');
     });
 
     it('should be able to add a new item after key rotation', async () => {
@@ -5683,6 +5708,26 @@ describe('getGroupVaultItem', () => {
         const item = await keymaster.getGroupVaultItem(did, mockDocumentName);
 
         expect(item).toBe(null);
+    });
+
+    it('should retrieve JSON to the groupVault', async () => {
+        const mockLogin = {
+            login: {
+                site: 'https://example.com',
+                username: 'bob',
+                password: 'secret',
+            }
+        };
+        const buffer = Buffer.from(JSON.stringify(mockLogin), 'utf-8');
+        const mockName = 'login: example.com';
+        await keymaster.createId('Bob');
+        const did = await keymaster.createGroupVault();
+        await keymaster.addGroupVaultItem(did, mockName, buffer);
+
+        const itemBuffer = await keymaster.getGroupVaultItem(did, mockName);
+        const login = JSON.parse(itemBuffer!.toString('utf-8'));
+
+        expect(login).toStrictEqual(mockLogin);
     });
 });
 


### PR DESCRIPTION
Adds first‐class support for storing and retrieving login credentials in group vaults, including core type updates, tests, and UI enhancements.

-    Define a new GroupVaultLogin type and detect MIME types in addGroupVaultItem
-    Add tests covering adding and retrieving JSON‐encoded login items
-    Enhance the Keymaster UI to add, display, and reveal login entries with dialogs and icons
