### PR TITLE
feat: Limits growth of IPFS peering peers

### DIFF
--- a/services/mediators/hyperswarm/src/hyperswarm-mediator.ts
+++ b/services/mediators/hyperswarm/src/hyperswarm-mediator.ts
@@ -372,12 +372,10 @@ async function addPeer(did: string): Promise<void> {
         return;
     }
 
-    if (id === nodeInfo.ipfs.id) {
+    if (id !== nodeInfo.ipfs.id) {
         // A node should never add itself as a peer node
-        return;
+        await ipfs.addPeeringPeer(id, addresses);
     }
-
-    await ipfs.addPeeringPeer(id, addresses);
 
     knownNodes[did] = {
         name: data.node.name,
@@ -606,6 +604,7 @@ async function main(): Promise<void> {
         intervalSeconds: 5,
         chatty: true,
     });
+    await ipfs.resetPeeringPeers();
 
     const ipfsID = await ipfs.getPeerID();
     const ipfsAddresses = await ipfs.getAddresses();


### PR DESCRIPTION
This PR limits unbounded growth of IPFS peering peers by filtering out unreachable addresses, preventing self-peering, and resetting peers on startup.

-    Reverse self-add check in the Hyperswarm mediator and clear existing peers at launch
-    In KuboClient, silently skip self adds, test connectivity before adding addresses, deduplicate valid addresses, and introduce a reset method

Also resolves #870
