### PR TITLE
feat: Adds PoW primitives to Cipher classes

### DIFF
--- a/packages/cipher/src/cipher-node.ts
+++ b/packages/cipher/src/cipher-node.ts
@@ -138,11 +138,15 @@ export default class CipherNode implements Cipher {
     }
 
     hasLeadingZeroBits(hexHash: string, bits: number): boolean {
-        const binary = BigInt('0x' + hexHash).toString(2).padStart(256, '0');
+        const binary = BigInt('0x' + hexHash).toString(2).padStart(hexHash.length * 4, '0');
         return binary.startsWith('0'.repeat(bits));
     }
 
-    addPoW(obj: object, difficulty: number): object {
+    addProofOfWork(obj: object, difficulty: number): object {
+        if (!Number.isInteger(difficulty) || difficulty < 0 || difficulty > 256) {
+            throw new Error('Invalid difficulty: must be an integer between 0 and 256.');
+        }
+
         let nonce = 0;
 
         while (true) {
@@ -163,7 +167,7 @@ export default class CipherNode implements Cipher {
         }
     }
 
-    checkPoW(obj: object): boolean {
+    checkProofOfWork(obj: object): boolean {
         // Check if pow field exists and has required properties
         if (
             !obj ||

--- a/packages/cipher/src/cipher-web.ts
+++ b/packages/cipher/src/cipher-web.ts
@@ -148,11 +148,15 @@ export default class CipherWeb implements Cipher {
     }
 
     hasLeadingZeroBits(hexHash: string, bits: number): boolean {
-        const binary = BigInt('0x' + hexHash).toString(2).padStart(256, '0');
+        const binary = BigInt('0x' + hexHash).toString(2).padStart(hexHash.length * 4, '0');
         return binary.startsWith('0'.repeat(bits));
     }
 
-    addPoW(obj: object, difficulty: number): object {
+    addProofOfWork(obj: object, difficulty: number): object {
+        if (!Number.isInteger(difficulty) || difficulty < 0 || difficulty > 256) {
+            throw new Error('Invalid difficulty: must be an integer between 0 and 256.');
+        }
+
         let nonce = 0;
 
         while (true) {
@@ -173,7 +177,7 @@ export default class CipherWeb implements Cipher {
         }
     }
 
-    checkPoW(obj: object): boolean {
+    checkProofOfWork(obj: object): boolean {
         // Check if pow field exists and has required properties
         if (
             !obj ||

--- a/packages/cipher/src/cipher-web.ts
+++ b/packages/cipher/src/cipher-web.ts
@@ -146,4 +146,48 @@ export default class CipherWeb implements Cipher {
         }
         return base64url.encode(array);
     }
+
+    hasLeadingZeroBits(hexHash: string, bits: number): boolean {
+        const binary = BigInt('0x' + hexHash).toString(2).padStart(256, '0');
+        return binary.startsWith('0'.repeat(bits));
+    }
+
+    addPoW(obj: object, difficulty: number): object {
+        let nonce = 0;
+
+        while (true) {
+            const candidate = {
+                ...obj,
+                pow: {
+                    nonce: nonce.toString(16),
+                    difficulty,
+                }
+            };
+            const hash = this.hashJSON(candidate);
+
+            if (this.hasLeadingZeroBits(hash, difficulty)) {
+                return candidate;
+            }
+
+            nonce++;
+        }
+    }
+
+    checkPoW(obj: object): boolean {
+        // Check if pow field exists and has required properties
+        if (
+            !obj ||
+            typeof obj !== 'object' ||
+            !('pow' in obj) ||
+            typeof (obj as any).pow !== 'object' ||
+            typeof (obj as any).pow.nonce !== 'string' ||
+            typeof (obj as any).pow.difficulty !== 'number'
+        ) {
+            return false;
+        }
+
+        const hash = this.hashJSON(obj);
+
+        return this.hasLeadingZeroBits(hash, (obj as any).pow.difficulty);
+    }
 }

--- a/packages/cipher/src/types.ts
+++ b/packages/cipher/src/types.ts
@@ -26,6 +26,11 @@ export interface EcdsaJwkPair {
     privateJwk: EcdsaJwkPrivate,
 }
 
+export interface ProofOfWork {
+    difficulty: number,
+    nonce: string,
+}
+
 export interface Cipher {
     generateMnemonic(): string,
 

--- a/packages/cipher/src/types.ts
+++ b/packages/cipher/src/types.ts
@@ -72,4 +72,7 @@ export interface Cipher {
     ): string,
 
     generateRandomSalt(): string,
+
+    addProofOfWork(obj: unknown, difficulty: number): unknown,
+    checkProofOfWork(obj: unknown): boolean,
 }

--- a/tests/cipher.test.ts
+++ b/tests/cipher.test.ts
@@ -1,5 +1,6 @@
 import CipherNode from '@mdip/cipher/node';
 import { ProofOfWork } from '@mdip/cipher/types';
+import { ExpectedExceptionError } from '@mdip/common/errors';
 
 const cipher = new CipherNode();
 
@@ -8,10 +9,10 @@ const mockObject = {
     age: 42
 };
 
-describe('addPoW', () => {
+describe('addProofOfWork', () => {
     it('should add valid PoW to an object', async () => {
         const difficulty = 8;
-        const result = cipher.addPoW(mockObject, difficulty) as { pow: ProofOfWork };
+        const result = cipher.addProofOfWork(mockObject, difficulty) as { pow: ProofOfWork };
 
         expect(result).toHaveProperty('pow');
         expect(result.pow.difficulty).toBe(difficulty);
@@ -22,7 +23,7 @@ describe('addPoW', () => {
 
     it('should add valid PoW with specified difficulty', async () => {
         for (let difficulty = 1; difficulty <= 12; difficulty++) {
-            const result = cipher.addPoW(mockObject, difficulty) as { pow: ProofOfWork };
+            const result = cipher.addProofOfWork(mockObject, difficulty) as { pow: ProofOfWork };
 
             expect(result).toHaveProperty('pow');
             expect(result.pow.difficulty).toBe(difficulty);
@@ -31,34 +32,52 @@ describe('addPoW', () => {
             expect(cipher.hasLeadingZeroBits(hash, difficulty)).toBe(true);
         }
     });
+
+    it('should throw exception on difficulty out of range', async () => {
+        try {
+            cipher.addProofOfWork(mockObject, -1);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe('Invalid difficulty: must be an integer between 0 and 256.');
+        }
+
+        try {
+            cipher.addProofOfWork(mockObject, 512);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe('Invalid difficulty: must be an integer between 0 and 256.');
+        }
+    });
 });
 
-describe('checkPoW', () => {
+describe('checkProofOfWork', () => {
     it('should return true if PoW is valid', async () => {
         const difficulty = 8;
-        const result = cipher.addPoW(mockObject, difficulty) as { pow: ProofOfWork };
-        const isValid = cipher.checkPoW(result);
+        const result = cipher.addProofOfWork(mockObject, difficulty) as { pow: ProofOfWork };
+        const isValid = cipher.checkProofOfWork(result);
 
         expect(isValid).toBe(true);
     });
 
     it('should return false if PoW is not valid', async () => {
         const difficulty = 8;
-        const result = cipher.addPoW(mockObject, difficulty) as { pow: ProofOfWork };
+        const result = cipher.addProofOfWork(mockObject, difficulty) as { pow: ProofOfWork };
 
         result.pow.difficulty = 20; // tamper with difficulty
-        const isValid = cipher.checkPoW(result);
+        const isValid = cipher.checkProofOfWork(result);
 
         expect(isValid).toBe(false);
     });
 
     it('should return false if PoW missing', async () => {
-        const result = cipher.checkPoW(mockObject);
+        const result = cipher.checkProofOfWork(mockObject);
         expect(result).toBe(false);
     });
 
     it('should return false for invalid object', async () => {
-        const result = cipher.checkPoW({});
+        const result = cipher.checkProofOfWork({});
         expect(result).toBe(false);
     });
 });

--- a/tests/cipher.test.ts
+++ b/tests/cipher.test.ts
@@ -1,0 +1,65 @@
+import CipherNode from '@mdip/cipher/node';
+import { ProofOfWork } from '@mdip/cipher/types';
+
+const cipher = new CipherNode();
+
+const mockObject = {
+    name: 'Bob',
+    age: 42
+};
+
+describe('addPoW', () => {
+    it('should add valid PoW to an object', async () => {
+        const difficulty = 8;
+        const result = cipher.addPoW(mockObject, difficulty) as { pow: ProofOfWork };
+
+        expect(result).toHaveProperty('pow');
+        expect(result.pow.difficulty).toBe(difficulty);
+
+        const hash = cipher.hashJSON(result);
+        expect(cipher.hasLeadingZeroBits(hash, difficulty)).toBe(true);
+    });
+
+    it('should add valid PoW with specified difficulty', async () => {
+        for (let difficulty = 1; difficulty <= 12; difficulty++) {
+            const result = cipher.addPoW(mockObject, difficulty) as { pow: ProofOfWork };
+
+            expect(result).toHaveProperty('pow');
+            expect(result.pow.difficulty).toBe(difficulty);
+
+            const hash = cipher.hashJSON(result);
+            expect(cipher.hasLeadingZeroBits(hash, difficulty)).toBe(true);
+        }
+    });
+});
+
+describe('checkPoW', () => {
+    it('should return true if PoW is valid', async () => {
+        const difficulty = 8;
+        const result = cipher.addPoW(mockObject, difficulty) as { pow: ProofOfWork };
+        const isValid = cipher.checkPoW(result);
+
+        expect(isValid).toBe(true);
+    });
+
+    it('should return false if PoW is not valid', async () => {
+        const difficulty = 8;
+        const result = cipher.addPoW(mockObject, difficulty) as { pow: ProofOfWork };
+
+        result.pow.difficulty = 20; // tamper with difficulty
+        const isValid = cipher.checkPoW(result);
+
+        expect(isValid).toBe(false);
+    });
+
+    it('should return false if PoW missing', async () => {
+        const result = cipher.checkPoW(mockObject);
+        expect(result).toBe(false);
+    });
+
+    it('should return false for invalid object', async () => {
+        const result = cipher.checkPoW({});
+        expect(result).toBe(false);
+    });
+});
+

--- a/tests/gatekeeper.test.ts
+++ b/tests/gatekeeper.test.ts
@@ -3085,9 +3085,6 @@ describe('Test operation validation errors', () => {
 });
 
 describe('addJSON', () => {
-    beforeEach(() => {    });
-
-
     const data = { key: 'mock' };
     const hash = 'z3v8AuaXiw9ZVBhPuQdTJySePBjwpBtvsSCRLXuPLzwqokHV8cS';
 
@@ -3099,9 +3096,6 @@ describe('addJSON', () => {
 });
 
 describe('getJSON', () => {
-    beforeEach(() => {    });
-
-
     const mockData = { key: 'mock' };
 
     it('should return JSON data from CID', async () => {
@@ -3113,9 +3107,6 @@ describe('getJSON', () => {
 });
 
 describe('addText', () => {
-    beforeEach(() => {    });
-
-
     const mockData = 'mock text data';
     const hash = 'zb2rhgNGdyFtViUWRk4oYLGrwdkgbt4GnF2s15k3ZujX6w3QW';
 
@@ -3127,9 +3118,6 @@ describe('addText', () => {
 });
 
 describe('getText', () => {
-    beforeEach(() => {    });
-
-
     const mockData = 'mock text data';
 
     it('should return text data from CID', async () => {
@@ -3141,9 +3129,6 @@ describe('getText', () => {
 });
 
 describe('addData', () => {
-    beforeEach(() => {    });
-
-
     const mockData = Buffer.from('mock data');
     const hash = 'zb2rhYuMKCR7pY51Tzv52NmTW9zYU2P53XFUJitvDwtSpCDhd';
 
@@ -3155,9 +3140,6 @@ describe('addData', () => {
 });
 
 describe('getData', () => {
-    beforeEach(() => {    });
-
-
     const mockData = Buffer.from('mock data');
 
     it('should return text data from CID', async () => {
@@ -3181,9 +3163,6 @@ const mockBlock2: BlockInfo = {
 };
 
 describe('addBlock', () => {
-    beforeEach(() => {    });
-
-
     it('should add a new block', async () => {
         const ok = await gatekeeper.addBlock('local', mockBlock);
 
@@ -3202,9 +3181,6 @@ describe('addBlock', () => {
 });
 
 describe('getBlock', () => {
-    beforeEach(() => {    });
-
-
     it('should get a block by height', async () => {
         await gatekeeper.addBlock('local', mockBlock);
         const block = await gatekeeper.getBlock('local', mockBlock.height);


### PR DESCRIPTION
This PR adds proof-of-work support to both web and node Cipher implementations, updates types, and adds related tests.

-    Introduces a ProofOfWork interface 
-    Implements hasLeadingZeroBits, addProofOfWork, and checkProofOfWork in both CipherWeb and CipherNode.
-    Adds comprehensive unit tests for PoW functionality in cipher.test.ts.
-    Cleans up gatekeeper.test.ts by removing redundant empty beforeEach hooks.
