### PR TITLE
feat: Adds notice asset type

### DIFF
--- a/doc/keymaster-api.json
+++ b/doc/keymaster-api.json
@@ -6534,7 +6534,152 @@
         ],
         "responses": {
           "200": {
-            "description": "Indicates whether the send operation was successful.",
+            "description": "The DID of the notice created for the sent Dmail message.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "did": {
+                      "type": "string",
+                      "description": "The DID of the notice created for this sent Dmail."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notices": {
+      "post": {
+        "summary": "Create a new notice asset.",
+        "description": "Creates a new notice asset (e.g., for Dmail delivery) and returns its DID.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "object",
+                    "description": "The NoticeMessage object to create.",
+                    "example": {
+                      "to": [
+                        "did:mdip:abc123",
+                        "did:mdip:def456"
+                      ],
+                      "dids": [
+                        "did:mdip:dmail1",
+                        "did:mdip:dmail2"
+                      ]
+                    }
+                  },
+                  "options": {
+                    "type": "object",
+                    "description": "Additional creation options (e.g., registry, validUntil)."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The DID of the newly created notice.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "did": {
+                      "type": "string",
+                      "description": "The DID representing the new notice."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notices/{id}": {
+      "put": {
+        "summary": "Update an existing notice asset.",
+        "description": "Updates the NoticeMessage data for the specified notice DID.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The DID of the notice to update."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "message": {
+                    "type": "object",
+                    "description": "The updated NoticeMessage object.",
+                    "example": {
+                      "to": [
+                        "did:mdip:abc123",
+                        "did:mdip:def456"
+                      ],
+                      "dids": [
+                        "did:mdip:dmail1",
+                        "did:mdip:dmail2"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates whether the update was successful.",
             "content": {
               "application/json": {
                 "schema": {
@@ -6542,6 +6687,45 @@
                   "properties": {
                     "ok": {
                       "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notices/refresh": {
+      "post": {
+        "summary": "Refresh all notices.",
+        "description": "Refreshes the state of all notice assets, updating any that have changed.",
+        "responses": {
+          "200": {
+            "description": "Indicates whether the refresh operation was successful.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "description": "true if the refresh was successful, otherwise false."
                     }
                   }
                 }

--- a/packages/keymaster/src/keymaster-client.ts
+++ b/packages/keymaster/src/keymaster-client.ts
@@ -21,6 +21,7 @@ import {
     IssueCredentialsOptions,
     KeymasterClientOptions,
     KeymasterInterface,
+    NoticeMessage,
     Poll,
     StoredWallet,
     VerifiableCredential,
@@ -1234,6 +1235,42 @@ export default class KeymasterClient implements KeymasterInterface {
     async importDmail(did: string): Promise<boolean> {
         try {
             const response = await axios.post(`${this.API}/dmail/import`, { did });
+            return response.data.ok;
+        }
+        catch (error) {
+            throwError(error);
+        }
+    }
+
+    async createNotice(
+        message: NoticeMessage,
+        options: CreateAssetOptions = {}
+    ): Promise<string> {
+        try {
+            const response = await axios.post(`${this.API}/notices`, { message, options });
+            return response.data.did;
+        }
+        catch (error) {
+            throwError(error);
+        }
+    }
+
+    async updateNotice(
+        did: string,
+        message: NoticeMessage
+    ): Promise<boolean> {
+        try {
+            const response = await axios.put(`${this.API}/notices/${did}`, { message });
+            return response.data.ok;
+        }
+        catch (error) {
+            throwError(error);
+        }
+    }
+
+    async refreshNotices(): Promise<boolean> {
+        try {
+            const response = await axios.post(`${this.API}/notices/refresh`);
             return response.data.ok;
         }
         catch (error) {

--- a/packages/keymaster/src/keymaster-client.ts
+++ b/packages/keymaster/src/keymaster-client.ts
@@ -1201,10 +1201,10 @@ export default class KeymasterClient implements KeymasterInterface {
         }
     }
 
-    async sendDmail(did: string): Promise<boolean> {
+    async sendDmail(did: string): Promise<string | null> {
         try {
             const response = await axios.post(`${this.API}/dmail/${did}/send`);
-            return response.data.ok;
+            return response.data.did;
         }
         catch (error) {
             throwError(error);

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -3146,8 +3146,6 @@ export default class Keymaster implements KeymasterInterface {
             return null;
         }
 
-        this.addToDmail(did, [DmailTags.SENT]);
-
         const registry = this.ephemeralRegistry;
         const validUntil = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(); // Default to 7 days
         const message: NoticeMessage = {
@@ -3155,7 +3153,13 @@ export default class Keymaster implements KeymasterInterface {
             dids: [did],
         };
 
-        return this.createNotice(message, { registry, validUntil });
+        const notice = await this.createNotice(message, { registry, validUntil });
+
+        if (notice) {
+            await this.addToDmail(did, [DmailTags.SENT]);
+        }
+
+        return notice;
     }
 
     async removeDmail(did: string): Promise<boolean> {

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -3139,16 +3139,23 @@ export default class Keymaster implements KeymasterInterface {
         return this.addGroupVaultItem(did, DmailTags.DMAIL, buffer);
     }
 
-    async sendDmail(did: string): Promise<boolean> {
+    async sendDmail(did: string): Promise<string | null> {
         const dmail = await this.getDmailMessage(did);
 
         if (!dmail) {
-            return false;
+            return null;
         }
 
-        // TBD create notice for the recipients
+        this.addToDmail(did, [DmailTags.SENT]);
 
-        return this.addToDmail(did, [DmailTags.SENT]);
+        const registry = this.ephemeralRegistry;
+        const validUntil = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(); // Default to 7 days
+        const message: NoticeMessage = {
+            to: [...dmail.to, ...dmail.cc],
+            dids: [did],
+        };
+
+        return this.createNotice(message, { registry, validUntil });
     }
 
     async removeDmail(did: string): Promise<boolean> {

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -34,6 +34,7 @@ import {
     IssueCredentialsOptions,
     KeymasterInterface,
     KeymasterOptions,
+    NoticeMessage,
     Poll,
     PollResults,
     PossiblySigned,
@@ -2999,7 +3000,7 @@ export default class Keymaster implements KeymasterInterface {
         return dmailList;
     }
 
-    verifyDmailTags(tags: string[]): string[] {
+    verifyTagList(tags: string[]): string[] {
         if (!Array.isArray(tags)) {
             throw new InvalidParameterError('tags');
         }
@@ -3024,7 +3025,7 @@ export default class Keymaster implements KeymasterInterface {
     ): Promise<boolean> {
         const wallet = await this.loadWallet();
         const id = await this.fetchIdInfo(undefined, wallet);
-        const verifiedTags = this.verifyDmailTags(tags);
+        const verifiedTags = this.verifyTagList(tags);
 
         if (!id.dmail) {
             id.dmail = {};
@@ -3048,7 +3049,7 @@ export default class Keymaster implements KeymasterInterface {
         return this.saveWallet(wallet);
     }
 
-    async verifyDmailList(list: string[]): Promise<string[]> {
+    async verifyRecipientList(list: string[]): Promise<string[]> {
         if (!Array.isArray(list)) {
             throw new InvalidParameterError('list');
         }
@@ -3085,8 +3086,8 @@ export default class Keymaster implements KeymasterInterface {
     }
 
     async verifyDmail(message: DmailMessage): Promise<DmailMessage> {
-        const to = await this.verifyDmailList(message.to);
-        const cc = await this.verifyDmailList(message.cc);
+        const to = await this.verifyRecipientList(message.to);
+        const cc = await this.verifyRecipientList(message.cc);
 
         if (to.length === 0) {
             throw new InvalidParameterError('dmail.to');
@@ -3190,5 +3191,116 @@ export default class Keymaster implements KeymasterInterface {
         }
 
         return this.addToDmail(did, [DmailTags.INBOX]);
+    }
+
+    async verifyDIDList(didList: string[]): Promise<string[]> {
+        if (!Array.isArray(didList)) {
+            throw new InvalidParameterError('didList');
+        }
+
+        for (const did of didList) {
+            if (!isValidDID(did)) {
+                throw new InvalidParameterError(`Invalid DID: ${did}`);
+            }
+        }
+
+        return didList;
+    }
+
+    async verifyNotice(notice: NoticeMessage): Promise<NoticeMessage> {
+        const to = await this.verifyRecipientList(notice.to);
+        const dids = await this.verifyDIDList(notice.dids);
+
+        if (to.length === 0) {
+            throw new InvalidParameterError('notice.to');
+        }
+
+        if (dids.length === 0) {
+            throw new InvalidParameterError('notice.dids');
+        }
+
+        return { to, dids };
+    }
+
+    async createNotice(
+        message: NoticeMessage,
+        options: CreateAssetOptions = {}
+    ): Promise<string> {
+        const notice = await this.verifyNotice(message);
+        return this.createAsset({ notice }, options);
+    }
+
+    async updateNotice(
+        id: string,
+        message: NoticeMessage,
+    ): Promise<boolean> {
+        const notice = await this.verifyNotice(message);
+        return this.updateAsset(id, { notice });
+    }
+
+    async addToNotices(
+        did: string,
+        tags: string[]
+    ): Promise<boolean> {
+        const wallet = await this.loadWallet();
+        const id = await this.fetchIdInfo(undefined, wallet);
+        const verifiedTags = this.verifyTagList(tags);
+
+        if (!id.notices) {
+            id.notices = {};
+        }
+
+        id.notices[did] = { tags: verifiedTags };
+
+        return this.saveWallet(wallet);
+    }
+
+    async importNotice(did: string): Promise<boolean> {
+        const wallet = await this.loadWallet();
+        const id = await this.fetchIdInfo(undefined, wallet);
+
+        if (id.notices && id.notices[did]) {
+            return true; // Already imported
+        }
+
+        const asset = await this.resolveAsset(did) as { notice?: NoticeMessage };
+
+        if (!asset || !asset.notice) {
+            return false; // Not a notice
+        }
+
+        if (!asset.notice.to.includes(id.did)) {
+            return false; // Not for this user
+        }
+
+        for (const noticeDID of asset.notice.dids) {
+            const dmail = await this.getDmailMessage(noticeDID);
+
+            if (dmail) {
+                await this.importDmail(noticeDID);
+                await this.addToNotices(did, [DmailTags.DMAIL]);
+            }
+        }
+
+        return true;
+    }
+
+    async refreshNotices(): Promise<boolean> {
+        const wallet = await this.loadWallet();
+        const id = await this.fetchIdInfo(undefined, wallet);
+
+        if (!id.notices) {
+            return true; // No notices to refresh
+        }
+
+        for (const did of Object.keys(id.notices)) {
+            const asset = await this.resolveAsset(did) as { notice?: NoticeMessage };
+
+            if (!asset || !asset.notice) {
+                delete id.notices[did]; // expired
+            }
+        }
+
+        return this.saveWallet(wallet);
     }
 }

--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -399,4 +399,9 @@ export interface KeymasterInterface {
     getDmailMessage(did: string): Promise<DmailMessage | null>;
     listDmail(): Promise<Record<string, DmailItem>>;
     sendDmail(did: string): Promise<string | null>;
+
+    // Notices
+    createNotice(message: NoticeMessage, options: CreateAssetOptions): Promise<string>;
+    updateNotice(did: string, message: NoticeMessage): Promise<boolean>;
+    refreshNotices(): Promise<boolean>;
 }

--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -6,36 +6,37 @@ import {
 } from '@mdip/gatekeeper/types';
 
 export interface EncryptedWallet {
-    salt: string
-    iv: string
-    data: string
+    salt: string;
+    iv: string;
+    data: string;
 }
 
 export interface HDKey {
-    xpriv: string
-    xpub: string
+    xpriv: string;
+    xpub: string;
 }
 
 export interface Seed {
-    mnemonic: string
-    hdkey: HDKey
+    mnemonic: string;
+    hdkey: HDKey;
 }
 
 export interface IDInfo {
-    did: string
-    account: number
-    index: number
-    held?: string[]
-    owned?: string[]
-    dmail?: Record<string, any>
+    did: string;
+    account: number;
+    index: number;
+    held?: string[];
+    owned?: string[];
+    dmail?: Record<string, any>;
+    notices?: Record<string, any>;
 }
 
 export interface WalletFile {
-    seed: Seed
-    counter: number
-    ids: Record<string, IDInfo>
-    current?: string
-    names?: Record<string, string>
+    seed: Seed;
+    counter: number;
+    ids: Record<string, IDInfo>;
+    current?: string;
+    names?: Record<string, string>;
 }
 
 export interface CheckWalletResult {
@@ -267,6 +268,11 @@ export interface DmailItem {
     date: string;
     tags: string[];
     docs?: any;
+}
+
+export interface NoticeMessage {
+    to: string[];
+    dids: string[];
 }
 
 export interface KeymasterInterface {

--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -394,9 +394,9 @@ export interface KeymasterInterface {
     // Dmail
     createDmail(message: DmailMessage, options?: CreateAssetOptions): Promise<string>;
     updateDmail(did: string, message: DmailMessage): Promise<boolean>;
-    sendDmail(did: string): Promise<boolean>;
     removeDmail(did: string): Promise<boolean>;
     importDmail(did: string): Promise<boolean>;
     getDmailMessage(did: string): Promise<DmailMessage | null>;
     listDmail(): Promise<Record<string, DmailItem>>;
+    sendDmail(did: string): Promise<string | null>;
 }

--- a/services/keymaster/server/src/keymaster-api.ts
+++ b/services/keymaster/server/src/keymaster-api.ts
@@ -5523,8 +5523,8 @@ v1router.delete('/dmail/:id', async (req, res) => {
  */
 v1router.post('/dmail/:id/send', async (req, res) => {
     try {
-        const ok = await keymaster.sendDmail(req.params.id);
-        res.json({ ok });
+        const did = await keymaster.sendDmail(req.params.id);
+        res.json({ did });
     } catch (error: any) {
         res.status(500).send({ error: error.toString() });
     }

--- a/services/keymaster/server/src/keymaster-api.ts
+++ b/services/keymaster/server/src/keymaster-api.ts
@@ -5503,7 +5503,116 @@ v1router.delete('/dmail/:id', async (req, res) => {
  *         description: The DID of the Dmail message to send.
  *     responses:
  *       200:
- *         description: Indicates whether the send operation was successful.
+ *         description: The DID of the notice created for the sent Dmail message.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 did:
+ *                   type: string
+ *                   description: The DID of the notice created for this sent Dmail.
+ *       500:
+ *         description: Internal server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ */
+v1router.post('/dmail/:id/send', async (req, res) => {
+    try {
+        const did = await keymaster.sendDmail(req.params.id);
+        res.json({ did });
+    } catch (error: any) {
+        res.status(500).send({ error: error.toString() });
+    }
+});
+
+/**
+ * @swagger
+ * /notices:
+ *   post:
+ *     summary: Create a new notice asset.
+ *     description: Creates a new notice asset (e.g., for Dmail delivery) and returns its DID.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               message:
+ *                 type: object
+ *                 description: The NoticeMessage object to create.
+ *                 example:
+ *                   to: ["did:mdip:abc123", "did:mdip:def456"]
+ *                   dids: ["did:mdip:dmail1", "did:mdip:dmail2"]
+ *               options:
+ *                 type: object
+ *                 description: Additional creation options (e.g., registry, validUntil).
+ *     responses:
+ *       200:
+ *         description: The DID of the newly created notice.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 did:
+ *                   type: string
+ *                   description: The DID representing the new notice.
+ *       500:
+ *         description: Internal server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ */
+v1router.post('/notices', async (req, res) => {
+    try {
+        const { message, options } = req.body;
+        const did = await keymaster.createNotice(message, options);
+        res.json({ did });
+    } catch (error: any) {
+        res.status(500).send({ error: error.toString() });
+    }
+});
+
+/**
+ * @swagger
+ * /notices/{id}:
+ *   put:
+ *     summary: Update an existing notice asset.
+ *     description: Updates the NoticeMessage data for the specified notice DID.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The DID of the notice to update.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               message:
+ *                 type: object
+ *                 description: The updated NoticeMessage object.
+ *                 example:
+ *                   to: ["did:mdip:abc123", "did:mdip:def456"]
+ *                   dids: ["did:mdip:dmail1", "did:mdip:dmail2"]
+ *     responses:
+ *       200:
+ *         description: Indicates whether the update was successful.
  *         content:
  *           application/json:
  *             schema:
@@ -5521,10 +5630,47 @@ v1router.delete('/dmail/:id', async (req, res) => {
  *                 error:
  *                   type: string
  */
-v1router.post('/dmail/:id/send', async (req, res) => {
+v1router.put('/notices/:id', async (req, res) => {
     try {
-        const did = await keymaster.sendDmail(req.params.id);
-        res.json({ did });
+        const { message } = req.body;
+        const ok = await keymaster.updateNotice(req.params.id, message);
+        res.json({ ok });
+    } catch (error: any) {
+        res.status(500).send({ error: error.toString() });
+    }
+});
+
+/**
+ * @swagger
+ * /notices/refresh:
+ *   post:
+ *     summary: Refresh all notices.
+ *     description: Refreshes the state of all notice assets, updating any that have changed.
+ *     responses:
+ *       200:
+ *         description: Indicates whether the refresh operation was successful.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                   description: true if the refresh was successful, otherwise false.
+ *       500:
+ *         description: Internal server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 error:
+ *                   type: string
+ */
+v1router.post('/notices/refresh', async (req, res) => {
+    try {
+        const ok = await keymaster.refreshNotices();
+        res.json({ ok });
     } catch (error: any) {
         res.status(500).send({ error: error.toString() });
     }

--- a/tests/keymaster/client.test.ts
+++ b/tests/keymaster/client.test.ts
@@ -44,6 +44,7 @@ const Endpoints = {
     documents: '/api/v1/documents',
     groupVaults: `/api/v1/groupVaults`,
     dmail: '/api/v1/dmail',
+    notices: '/api/v1/notices',
 };
 
 const mockConsole = {
@@ -3180,6 +3181,96 @@ describe('listDmail', () => {
 
         try {
             await keymaster.listDmail();
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(ServerError.message);
+        }
+    });
+});
+
+const mockNoticeId = 'did:mdip:notice';
+const mockNotice = { to: ['mockTo'], dids: ['mockDID'] };
+
+describe('createNotice', () => {
+    it('should return dmail DID', async () => {
+        nock(KeymasterURL)
+            .post(`${Endpoints.notices}`)
+            .reply(200, { did: mockNoticeId });
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const did = await keymaster.createNotice(mockNotice);
+
+        expect(did).toStrictEqual(mockNoticeId);
+    });
+
+    it('should throw exception on createNotice server error', async () => {
+        nock(KeymasterURL)
+            .post(`${Endpoints.notices}`)
+            .reply(500, ServerError);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+
+        try {
+            await keymaster.createNotice(mockNotice);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(ServerError.message);
+        }
+    });
+});
+
+describe('updateNotice', () => {
+    it('should update notice DID', async () => {
+        nock(KeymasterURL)
+            .put(`${Endpoints.notices}/${mockNoticeId}`)
+            .reply(200, { ok: true });
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const ok = await keymaster.updateNotice(mockNoticeId, mockNotice);
+
+        expect(ok).toBe(true);
+    });
+
+    it('should throw exception on updateNotice server error', async () => {
+        nock(KeymasterURL)
+            .put(`${Endpoints.notices}/${mockNoticeId}`)
+            .reply(500, ServerError);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+
+        try {
+            await keymaster.updateNotice(mockNoticeId, mockNotice);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(ServerError.message);
+        }
+    });
+});
+
+describe('refreshNotices', () => {
+    it('should refresh notices', async () => {
+        nock(KeymasterURL)
+            .post(`${Endpoints.notices}/refresh`)
+            .reply(200, { ok: true });
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const ok = await keymaster.refreshNotices();
+
+        expect(ok).toBe(true);
+    });
+
+    it('should throw exception on refreshNotices server error', async () => {
+        nock(KeymasterURL)
+            .post(`${Endpoints.notices}/refresh`)
+            .reply(500, ServerError);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+
+        try {
+            await keymaster.refreshNotices();
             throw new ExpectedExceptionError();
         }
         catch (error: any) {

--- a/tests/keymaster/client.test.ts
+++ b/tests/keymaster/client.test.ts
@@ -3040,15 +3040,17 @@ describe('updateDmail', () => {
 });
 
 describe('sendDmail', () => {
+    const mockNotice = 'mockNotice';
+
     it('should send dmail DID', async () => {
         nock(KeymasterURL)
             .post(`${Endpoints.dmail}/${mockDmailId}/send`)
-            .reply(200, { ok: true });
+            .reply(200, { did: mockNotice });
 
         const keymaster = await KeymasterClient.create({ url: KeymasterURL });
-        const ok = await keymaster.sendDmail(mockDmailId);
+        const did = await keymaster.sendDmail(mockDmailId);
 
-        expect(ok).toBe(true);
+        expect(did).toBe(mockNotice);
     });
 
     it('should throw exception on sendDmail server error', async () => {

--- a/tests/keymaster/dmail.test.ts
+++ b/tests/keymaster/dmail.test.ts
@@ -32,37 +32,37 @@ beforeEach(() => {
     keymaster = new Keymaster({ gatekeeper, wallet, cipher });
 });
 
-describe('verifyDmailTags', () => {
+describe('verifyTagList', () => {
     it('should return same list of valid tags', async () => {
         const tags = ['tag1', 'tag2', 'tag3'];
-        const verified = keymaster.verifyDmailTags(tags);
+        const verified = keymaster.verifyTagList(tags);
 
         expect(verified).toStrictEqual(tags);
     });
 
     it('should remove duplicate tags', async () => {
         const tags = ['tag1', 'tag2', 'tag2', 'tag3', 'tag3', 'tag3'];
-        const verified = keymaster.verifyDmailTags(tags);
+        const verified = keymaster.verifyTagList(tags);
 
         expect(verified).toStrictEqual(['tag1', 'tag2', 'tag3']);
     });
 
     it('should remove whitespace from tags', async () => {
         const tags = ['   tag1', 'tag2   ', '   tag3    '];
-        const verified = keymaster.verifyDmailTags(tags);
+        const verified = keymaster.verifyTagList(tags);
 
         expect(verified).toStrictEqual(['tag1', 'tag2', 'tag3']);
     });
 
     it('should handle empty list', async () => {
-        const verified = keymaster.verifyDmailTags([]);
+        const verified = keymaster.verifyTagList([]);
 
         expect(verified).toStrictEqual([]);
     });
 
     it('should throw an exception on invalid tags', async () => {
         try {
-            keymaster.verifyDmailTags(123 as any);
+            keymaster.verifyTagList(123 as any);
             throw new ExpectedExceptionError();
         }
         catch (error: any) {
@@ -70,7 +70,7 @@ describe('verifyDmailTags', () => {
         }
 
         try {
-            keymaster.verifyDmailTags([1, 2, 3] as any);
+            keymaster.verifyTagList([1, 2, 3] as any);
             throw new ExpectedExceptionError();
         }
         catch (error: any) {
@@ -78,7 +78,7 @@ describe('verifyDmailTags', () => {
         }
 
         try {
-            keymaster.verifyDmailTags(['tag1', 'tag 2', '   ']);
+            keymaster.verifyTagList(['tag1', 'tag 2', '   ']);
             throw new ExpectedExceptionError();
         }
         catch (error: any) {
@@ -87,14 +87,14 @@ describe('verifyDmailTags', () => {
     });
 });
 
-describe('verifyDmailList', () => {
+describe('verifyRecipientList', () => {
     it('should return same list of valid DIDs', async () => {
         const alice = await keymaster.createId('Alice');
         const bob = await keymaster.createId('Bob');
         const charles = await keymaster.createId('Charles');
         const to = [alice, bob, charles];
 
-        const verified = await keymaster.verifyDmailList(to);
+        const verified = await keymaster.verifyRecipientList(to);
 
         expect(verified).toStrictEqual(to);
     });
@@ -106,7 +106,7 @@ describe('verifyDmailList', () => {
         await keymaster.addName('Chuck', charles);
         const to = ['Alice', 'Bob', 'Chuck'];
 
-        const verified = await keymaster.verifyDmailList(to);
+        const verified = await keymaster.verifyRecipientList(to);
 
         expect(verified).toStrictEqual([alice, bob, charles]);
     });
@@ -116,7 +116,7 @@ describe('verifyDmailList', () => {
         await keymaster.createAsset({ mock: 'mock' }, { name: 'Asset' });
 
         try {
-            await keymaster.verifyDmailList(123 as any);
+            await keymaster.verifyRecipientList(123 as any);
             throw new ExpectedExceptionError();
         }
         catch (error: any) {
@@ -124,7 +124,7 @@ describe('verifyDmailList', () => {
         }
 
         try {
-            await keymaster.verifyDmailList([1, 2, 3] as any);
+            await keymaster.verifyRecipientList([1, 2, 3] as any);
             throw new ExpectedExceptionError();
         }
         catch (error: any) {
@@ -132,7 +132,7 @@ describe('verifyDmailList', () => {
         }
 
         try {
-            await keymaster.verifyDmailList(['Bob']);
+            await keymaster.verifyRecipientList(['Bob']);
             throw new ExpectedExceptionError();
         }
         catch (error: any) {
@@ -140,7 +140,7 @@ describe('verifyDmailList', () => {
         }
 
         try {
-            await keymaster.verifyDmailList(['Asset']);
+            await keymaster.verifyRecipientList(['Asset']);
             throw new ExpectedExceptionError();
         }
         catch (error: any) {

--- a/tests/keymaster/notice.test.ts
+++ b/tests/keymaster/notice.test.ts
@@ -1,0 +1,311 @@
+import Gatekeeper from '@mdip/gatekeeper';
+import Keymaster from '@mdip/keymaster';
+import CipherNode from '@mdip/cipher/node';
+import DbJsonMemory from '@mdip/gatekeeper/db/json-memory';
+import WalletJsonMemory from '@mdip/keymaster/wallet/json-memory';
+import { ExpectedExceptionError } from '@mdip/common/errors';
+import HeliaClient from '@mdip/ipfs/helia';
+import { NoticeMessage } from '@mdip/keymaster/types';
+
+let ipfs: HeliaClient;
+let gatekeeper: Gatekeeper;
+let wallet: WalletJsonMemory;
+let cipher: CipherNode;
+let keymaster: Keymaster;
+
+beforeAll(async () => {
+    ipfs = new HeliaClient();
+    await ipfs.start();
+});
+
+afterAll(async () => {
+    if (ipfs) {
+        await ipfs.stop();
+    }
+});
+
+beforeEach(() => {
+    const db = new DbJsonMemory('test');
+    gatekeeper = new Gatekeeper({ db, ipfs, registries: ['local', 'hyperswarm', 'TFTC'] });
+    wallet = new WalletJsonMemory();
+    cipher = new CipherNode();
+    keymaster = new Keymaster({ gatekeeper, wallet, cipher });
+});
+
+describe('verifyNotice', () => {
+    it('should return same notice if valid', async () => {
+        const alice = await keymaster.createId('Alice');
+        const bob = await keymaster.createId('Bob');
+        const asset1 = await keymaster.createAsset({});
+        const asset2 = await keymaster.createAsset({});
+
+        const notice: NoticeMessage = {
+            to: [alice, bob],
+            dids: [asset1, asset2],
+        };
+
+        const verified = await keymaster.verifyNotice(notice);
+
+        expect(verified).toStrictEqual(notice);
+    });
+
+    it('should throw an exception on invalid notice', async () => {
+        const alice = await keymaster.createId('Alice');
+
+        try {
+            const notice: NoticeMessage = {
+                to: [],
+                dids: [],
+            };
+
+            await keymaster.verifyNotice(notice);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe('Invalid parameter: notice.to');
+        }
+
+        try {
+            const dmail: NoticeMessage = {
+                to: [alice],
+                dids: [],
+            };
+
+            await keymaster.verifyNotice(dmail);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe('Invalid parameter: notice.dids');
+        }
+    });
+});
+
+describe('createNotice', () => {
+    it('should create a valid notice', async () => {
+        const alice = await keymaster.createId('Alice');
+        const bob = await keymaster.createId('Bob');
+        const asset1 = await keymaster.createAsset({});
+        const asset2 = await keymaster.createAsset({});
+
+        const notice: NoticeMessage = {
+            to: [alice, bob],
+            dids: [asset1, asset2],
+        };
+
+        const did = await keymaster.createNotice(notice);
+
+        expect(did).toBeDefined();
+    });
+});
+
+describe('updateNotice', () => {
+    it('should update a valid notice', async () => {
+        const alice = await keymaster.createId('Alice');
+        const bob = await keymaster.createId('Bob');
+        const asset1 = await keymaster.createAsset({});
+        const asset2 = await keymaster.createAsset({});
+
+        const notice1: NoticeMessage = {
+            to: [alice],
+            dids: [asset1],
+        };
+
+        const did = await keymaster.createNotice(notice1);
+
+        const notice2: NoticeMessage = {
+            to: [alice, bob],
+            dids: [asset1, asset2],
+        };
+
+        const ok = await keymaster.updateNotice(did, notice2);
+
+        expect(ok).toBe(true);
+    });
+});
+
+describe('verifyDIDList', () => {
+    it('should return same list of valid DIDs', async () => {
+        const alice = await keymaster.createId('Alice');
+        const bob = await keymaster.createId('Bob');
+        const charles = await keymaster.createId('Charles');
+        const dids = [alice, bob, charles];
+
+        const verified = await keymaster.verifyDIDList(dids);
+
+        expect(verified).toStrictEqual(dids);
+    });
+
+    it('should throw an exception on invalid list', async () => {
+        await keymaster.createId('Alice');
+
+        try {
+            await keymaster.verifyDIDList(123 as any);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe('Invalid parameter: didList');
+        }
+
+        try {
+            await keymaster.verifyDIDList([1, 2, 3] as any);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe('Invalid parameter: Invalid DID: 1');
+        }
+
+        try {
+            await keymaster.verifyDIDList(['did:mdip:123']);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe('Invalid parameter: Invalid DID: did:mdip:123');
+        }
+    });
+});
+
+describe('importNotice', () => {
+    it('should import a dmail notice', async () => {
+        const alice = await keymaster.createId('Alice');
+        const bob = await keymaster.createId('Bob');
+        await keymaster.createId('Charles');
+        const dmail = await keymaster.createDmail({
+            to: [alice],
+            cc: [bob],
+            subject: 'Test Dmail 1',
+            body: 'This is a test dmail 1.',
+        });
+
+        const notice1: NoticeMessage = {
+            to: [alice, bob],
+            dids: [dmail],
+        };
+
+        const did = await keymaster.createNotice(notice1);
+
+        await keymaster.setCurrentId('Alice');
+        const ok = await keymaster.importNotice(did);
+
+        expect(ok).toBe(true);
+    });
+
+    it('should return true if notice already imported', async () => {
+        const alice = await keymaster.createId('Alice');
+        const bob = await keymaster.createId('Bob');
+        await keymaster.createId('Charles');
+        const dmail = await keymaster.createDmail({
+            to: [alice],
+            cc: [bob],
+            subject: 'Test Dmail',
+            body: 'This is a test dmail.',
+        });
+
+        const notice1: NoticeMessage = {
+            to: [alice, bob],
+            dids: [dmail],
+        };
+
+        const did = await keymaster.createNotice(notice1);
+
+        await keymaster.setCurrentId('Alice');
+        await keymaster.importNotice(did);
+        const ok = await keymaster.importNotice(did);
+
+        expect(ok).toBe(true);
+    });
+
+    it('should not import notice if current ID is not a recipient', async () => {
+        const alice = await keymaster.createId('Alice');
+        await keymaster.createId('Bob');
+        await keymaster.createId('Charles');
+        const dmail = await keymaster.createDmail({
+            to: [alice],
+            cc: [],
+            subject: 'Test Dmail 2',
+            body: 'This is a test dmail 2.',
+        });
+
+        const notice1: NoticeMessage = {
+            to: [alice],
+            dids: [dmail],
+        };
+
+        const did = await keymaster.createNotice(notice1);
+
+        await keymaster.setCurrentId('Bob');
+        const ok = await keymaster.importNotice(did);
+
+        expect(ok).toBe(false);
+    });
+
+    it('should not import non-notice', async () => {
+        const alice = await keymaster.createId('Alice');
+        const ok = await keymaster.importNotice(alice);
+
+        expect(ok).toBe(false);
+    });
+});
+
+describe('refreshNotices', () => {
+    it('should return true if nothing to do', async () => {
+        await keymaster.createId('Alice');
+        const ok = await keymaster.refreshNotices();
+
+        expect(ok).toBe(true);
+    });
+
+    it('should return true if notice already imported', async () => {
+        const alice = await keymaster.createId('Alice');
+        const bob = await keymaster.createId('Bob');
+        await keymaster.createId('Charles');
+        const dmail = await keymaster.createDmail({
+            to: [alice],
+            cc: [bob],
+            subject: 'Test Dmail 3',
+            body: 'This is a test dmail 3.',
+        });
+
+        const notice: NoticeMessage = {
+            to: [alice, bob],
+            dids: [dmail],
+        };
+
+        const did = await keymaster.createNotice(notice);
+
+        await keymaster.setCurrentId('Alice');
+        await keymaster.importNotice(did);
+
+        const ok = await keymaster.refreshNotices();
+        expect(ok).toBe(true);
+    });
+
+    it('should remove expired notices', async () => {
+        const alice = await keymaster.createId('Alice');
+        const bob = await keymaster.createId('Bob');
+        await keymaster.createId('Charles');
+        const dmail = await keymaster.createDmail({
+            to: [alice],
+            cc: [bob],
+            subject: 'Test Dmail 4',
+            body: 'This is a test dmail 4.',
+        });
+
+        const notice: NoticeMessage = {
+            to: [alice, bob],
+            dids: [dmail],
+        };
+
+        const did = await keymaster.createNotice(notice);
+
+        await keymaster.setCurrentId('Alice');
+        await keymaster.importNotice(did);
+
+        await keymaster.setCurrentId('Bob');
+        await keymaster.revokeDID(did);
+
+        await keymaster.setCurrentId('Alice');
+        const ok = await keymaster.refreshNotices();
+
+        expect(ok).toBe(true);
+    });
+});


### PR DESCRIPTION
This PR introduces the concept of “notices” alongside existing Dmail workflows, implementing creation, verification, updating, importing, and refreshing of notice assets in both the core library and HTTP API, and adds corresponding tests.

-    Define NoticeMessage type and core methods (verifyNotice, createNotice, updateNotice, importNotice, refreshNotices) in Keymaster.
-    Extend HTTP routes (/notices, /notices/{id}, /notices/refresh) and client to support notice operations.
-    Add end-to-end tests for notice behavior and update Dmail tests to expect notice DIDs.
