### PR TITLE
feat: Adds local storage for GroupVaults

### DIFF
--- a/tests/keymaster/group-vault.test.ts
+++ b/tests/keymaster/group-vault.test.ts
@@ -551,6 +551,17 @@ describe('getGroupVaultItem', () => {
         expect(item).toStrictEqual(mockDocument);
     });
 
+    it('should return a large BLOB', async () => {
+        await keymaster.createId('Bob');
+        const did = await keymaster.createGroupVault();
+        const largeDocument = Buffer.alloc(1024 * 1024, 'A'); // 1 MB of 'A's
+        await keymaster.addGroupVaultItem(did, mockDocumentName, largeDocument);
+
+        const item = await keymaster.getGroupVaultItem(did, mockDocumentName);
+
+        expect(item).toStrictEqual(largeDocument);
+    });
+
     it('should return null for unknown item', async () => {
         await keymaster.createId('Bob');
         const did = await keymaster.createGroupVault();
@@ -621,7 +632,7 @@ describe('getGroupVaultItem', () => {
         expect(item).toBe(null);
     });
 
-    it('should retrieve JSON to the groupVault', async () => {
+    it('should retrieve JSON', async () => {
         const login: GroupVaultLogin = {
             service: 'https://example2.com',
             username: 'alice',


### PR DESCRIPTION
This PR implements a feature in GroupVaults to store copies of small items within the DID docs. Key changes include:

-    Adding tests to verify that large BLOBs are handled separately and small items are stored inline.
-    Introducing a new property (maxDataLength) in the Keymaster class to determine when to store data inline.
-    Updating logic in Keymaster to conditionally include inline data for items below the size threshold.
