### PR TITLE
ci: update cli test script to build each service it needs vs only dependencies

### DIFF
--- a/start-node-ci
+++ b/start-node-ci
@@ -5,7 +5,7 @@ source .env
 echo $KC_GATEKEEPER_URL
 
 docker compose down
-docker compose build "$@"
+docker compose build cli gatekeeper keymaster ipfs redis mongodb
 docker compose up -d "$@"
 
 echo "Waiting for all services to be 'Up'..."


### PR DESCRIPTION
GH updated the docker and docker compose versions they are using. There's a regression or unexpected change where if we call "docker compose up cli" It should build and run the service and its dependencies to run. 

For some reason that now has broken in the new version.

The fix is to "explicitly" call each service to build and run in the command so it can build locally and run it.