### PR TITLE
feat: Adds cc list to dmail

### DIFF
--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -3365,10 +3365,14 @@ export default class Keymaster implements KeymasterInterface {
         }
 
         for (const did of Object.keys(id.notices)) {
-            const asset = await this.resolveAsset(did) as { notice?: NoticeMessage };
+            try {
+                const asset = await this.resolveAsset(did) as { notice?: NoticeMessage };
 
-            if (!asset || !asset.notice) {
-                delete id.notices[did]; // expired or revoked or otherwise invalid
+                if (!asset || !asset.notice) {
+                    delete id.notices[did]; // revoked or invalid
+                }
+            } catch (error) {
+                delete id.notices[did]; // expired
             }
         }
 

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -3157,6 +3157,15 @@ export default class Keymaster implements KeymasterInterface {
         message: DmailMessage
     ): Promise<boolean> {
         const dmail = await this.verifyDmail(message);
+
+        for (const toDID of dmail.to) {
+            await this.addGroupVaultMember(did, toDID);
+        }
+
+        for (const ccDID of dmail.cc) {
+            await this.addGroupVaultMember(did, ccDID);
+        }
+        
         const buffer = Buffer.from(JSON.stringify({ dmail }), 'utf-8');
         return this.addGroupVaultItem(did, DmailTags.DMAIL, buffer);
     }

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -3175,7 +3175,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                             {dmailTab === 'inbox' &&
                                 <Box>
                                     <Box>
-                                        <TableContainer component={Paper} style={{ maxHeight: '600px', overflow: 'auto' }}>
+                                        <TableContainer component={Paper} style={{ maxHeight: '300px', overflow: 'auto' }}>
                                             <Table size="small">
                                                 <TableHead>
                                                     <TableRow>
@@ -3338,10 +3338,15 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                             />
                                         </Grid>
                                         <Grid item>
-                                            <textarea
+                                            <TextField
+                                                margin="normal"
+                                                label="Body"
+                                                style={{ width: '800px' }}
+                                                multiline
+                                                minRows={12}
+                                                maxRows={12}
                                                 value={dmailBody}
-                                                onChange={(e) => setDmailBody(e.target.value)}
-                                                style={{ width: '800px', height: '600px', overflow: 'auto' }}
+                                                onChange={e => setDmailBody(e.target.value)}
                                             />
                                         </Grid>
                                         {!dmailDID &&

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -117,7 +117,8 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
     const [selectedDmail, setSelectedDmail] = useState(null);
     const [dmailSubject, setDmailSubject] = useState('');
     const [dmailBody, setDmailBody] = useState('');
-    const [dmailRecipient, setDmailRecipient] = useState('');
+    const [dmailTo, setDmailTo] = useState('');
+    const [dmailCc, setDmailCc] = useState('');
     const [dmailToList, setDmailToList] = useState([]);
     const [dmailCcList, setDmailCcList] = useState([]);
     const [dmailDID, setDmailDID] = useState('');
@@ -223,7 +224,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
             setSelectedHeld('');
             setSelectedIssued('');
             setDmailBody('');
-            setDmailRecipient('');
+            setDmailCc('');
             setDmailDID('');
             setSelectedImageName('');
             setSelectedDocumentName('');
@@ -1003,7 +1004,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
             setSelectedDmail(null);
             setDmailSubject('');
             setDmailBody('');
-            setDmailRecipient('');
+            setDmailCc('');
             setDmailDID('');
         } catch (error) {
             showError(error);
@@ -1033,19 +1034,19 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
     async function addDmailTo() {
         setDmailToList(prevToList => {
-            if (!dmailRecipient) {
+            if (!dmailTo) {
                 return prevToList;
             }
 
             // Check if recipient already exists in the list
-            if (prevToList.includes(dmailRecipient)) {
+            if (prevToList.includes(dmailTo)) {
                 return prevToList;
             }
 
             // Add recipient to the list
-            return [...prevToList, dmailRecipient];
+            return [...prevToList, dmailTo];
         });
-        setDmailRecipient(''); // Clear the input field after adding
+        setDmailTo(''); // Clear the input field after adding
     }
 
     async function removeDmailTo(recipient) {
@@ -1057,19 +1058,19 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
     async function addDmailCc() {
         setDmailCcList(prevToList => {
-            if (!dmailRecipient) {
+            if (!dmailCc) {
                 return prevToList;
             }
 
             // Check if recipient already exists in the list
-            if (prevToList.includes(dmailRecipient)) {
+            if (prevToList.includes(dmailCc)) {
                 return prevToList;
             }
 
             // Add recipient to the list
-            return [...prevToList, dmailRecipient];
+            return [...prevToList, dmailCc];
         });
-        setDmailRecipient(''); // Clear the input field after adding
+        setDmailCc(''); // Clear the input field after adding
     }
 
     async function removeDmailCc(recipient) {
@@ -3246,122 +3247,139 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                             }
                             {dmailTab === 'send' &&
                                 <Box>
-                                    <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
+                                    <Grid container direction="column" spacing={1}>
+                                        <Grid container direction="row" spacing={1} alignItems={'center'}>
+                                            <Grid item>
+                                                <Typography variant="subtitle1">To:</Typography>
+                                            </Grid>
+                                            <Grid item>
+                                                <Autocomplete
+                                                    freeSolo
+                                                    options={agentList || []} // array of options, e.g. DIDs or names
+                                                    value={dmailTo}
+                                                    onChange={(event, newValue) => setDmailTo(newValue)}
+                                                    onInputChange={(event, newInputValue) => setDmailTo(newInputValue)}
+                                                    renderInput={(params) => (
+                                                        <TextField
+                                                            {...params}
+                                                            label="Name or DID"
+                                                            style={{ width: '500px' }}
+                                                            margin="normal"
+                                                            inputProps={{ ...params.inputProps, maxLength: 80 }}
+                                                            fullWidth
+                                                        />
+                                                    )}
+                                                />
+                                            </Grid>
+                                            <Grid item>
+                                                <Button variant="contained" color="primary" onClick={addDmailTo} disabled={!dmailTo}>
+                                                    Add
+                                                </Button>
+                                            </Grid>
+                                        </Grid>
+                                        {dmailToList.map(recipient => (
+                                            <Grid container direction="row" spacing={1}>
+                                                <Grid item>
+                                                    <Button onClick={() => removeDmailTo(recipient)}><Clear /></Button>
+                                                </Grid>
+                                                <Grid item>
+                                                    <Typography variant="subtitle1">{recipient}</Typography>
+                                                </Grid>
+                                            </Grid>
+                                        ))}
+                                        <Grid container direction="row" spacing={1} alignItems={'center'}>
+                                            <Grid item>
+                                                <Typography variant="subtitle1">Cc:</Typography>
+                                            </Grid>
+                                            <Grid item>
+                                                <Autocomplete
+                                                    freeSolo
+                                                    options={agentList || []} // array of options, e.g. DIDs or names
+                                                    value={dmailCc}
+                                                    onChange={(event, newValue) => setDmailCc(newValue)}
+                                                    onInputChange={(event, newInputValue) => setDmailCc(newInputValue)}
+                                                    renderInput={(params) => (
+                                                        <TextField
+                                                            {...params}
+                                                            label="Name or DID"
+                                                            style={{ width: '500px' }}
+                                                            margin="normal"
+                                                            inputProps={{ ...params.inputProps, maxLength: 80 }}
+                                                            fullWidth
+                                                        />
+                                                    )}
+                                                />
+                                            </Grid>
+                                            <Grid item>
+                                                <Button variant="contained" color="primary" onClick={addDmailCc} disabled={!dmailCc}>
+                                                    Add
+                                                </Button>
+                                            </Grid>
+                                        </Grid>
+                                        {dmailCcList.map(recipient => (
+                                            <Grid container direction="row" spacing={1}>
+                                                <Grid item>
+                                                    <Button onClick={() => removeDmailCc(recipient)}><Clear /></Button>
+                                                </Grid>
+                                                <Grid item>
+                                                    <Typography variant="subtitle1">{recipient}</Typography>
+                                                </Grid>
+                                            </Grid>
+                                        ))}
                                         <Grid item>
-                                            <Autocomplete
-                                                freeSolo
-                                                options={agentList || []} // array of options, e.g. DIDs or names
-                                                value={dmailRecipient}
-                                                onChange={(event, newValue) => setDmailRecipient(newValue)}
-                                                onInputChange={(event, newInputValue) => setDmailRecipient(newInputValue)}
-                                                renderInput={(params) => (
-                                                    <TextField
-                                                        {...params}
-                                                        label="Name or DID"
-                                                        style={{ width: '500px' }}
-                                                        margin="normal"
-                                                        inputProps={{ ...params.inputProps, maxLength: 80 }}
-                                                        fullWidth
-                                                    />
-                                                )}
+                                            <TextField
+                                                label="Subject"
+                                                style={{ width: '800px' }}
+                                                value={dmailSubject}
+                                                onChange={e => setDmailSubject(e.target.value)}
+                                                margin="normal"
+                                                inputProps={{ maxLength: 120 }}
+                                                fullWidth
                                             />
                                         </Grid>
                                         <Grid item>
-                                            <Button variant="contained" color="primary" onClick={addDmailTo} disabled={!dmailRecipient}>
-                                                Add To
-                                            </Button>
+                                            <textarea
+                                                value={dmailBody}
+                                                onChange={(e) => setDmailBody(e.target.value)}
+                                                style={{ width: '800px', height: '600px', overflow: 'auto' }}
+                                            />
                                         </Grid>
-                                        <Grid item>
-                                            <Button variant="contained" color="primary" onClick={addDmailCc} disabled={!dmailRecipient}>
-                                                Add Cc
-                                            </Button>
-                                        </Grid>
-                                    </Grid>
-                                    <p />
-                                    <Box>
-                                        <Grid container direction="column" spacing={1}>
-                                            <Grid item>
-                                                <Typography variant="subtitle1">To:</Typography>
-                                                {dmailToList.map(recipient => (
-                                                    <Grid container direction="row" spacing={1}>
-                                                        <Grid item>
-                                                            <Button onClick={() => removeDmailTo(recipient)}><Clear /></Button>
-                                                        </Grid>
-                                                        <Grid item>
-                                                            <Typography variant="subtitle1">{recipient}</Typography>
-                                                        </Grid>
-                                                    </Grid>
-                                                ))}
+                                        {!dmailDID &&
+                                            <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
+                                                <Grid item>
+                                                    <Button variant="contained" color="primary" onClick={createDmail} disabled={!registry}>
+                                                        Create Dmail
+                                                    </Button>
+                                                </Grid>
+                                                <Grid item>
+                                                    <RegistrySelect />
+                                                </Grid>
                                             </Grid>
-                                            <Grid item>
-                                                <Typography variant="subtitle1">Cc:</Typography>
-                                                {dmailCcList.map(recipient => (
-                                                    <Grid container direction="row" spacing={1}>
-                                                        <Grid item>
-                                                            <Button onClick={() => removeDmailCc(recipient)}><Clear /></Button>
-                                                        </Grid>
-                                                        <Grid item>
-                                                            <Typography variant="subtitle1">{recipient}</Typography>
-                                                        </Grid>
-                                                    </Grid>
-                                                ))}
-                                            </Grid>
-                                            <Grid item>
-                                                <TextField
-                                                    label="Subject"
-                                                    style={{ width: '800px' }}
-                                                    value={dmailSubject}
-                                                    onChange={e => setDmailSubject(e.target.value)}
-                                                    margin="normal"
-                                                    inputProps={{ maxLength: 120 }}
-                                                    fullWidth
-                                                />
-                                            </Grid>
-                                            <Grid item>
-                                                <textarea
-                                                    value={dmailBody}
-                                                    onChange={(e) => setDmailBody(e.target.value)}
-                                                    style={{ width: '800px', height: '600px', overflow: 'auto' }}
-                                                />
-                                            </Grid>
-                                            {!dmailDID &&
+                                        }
+                                        {dmailDID &&
+                                            <Grid container direction="column" spacing={1}>
+                                                <Grid item>
+                                                    <p>
+                                                        <Typography style={{ fontSize: '1em', fontFamily: 'Courier' }}>
+                                                            {dmailDID}
+                                                        </Typography>
+                                                    </p>
+                                                </Grid>
                                                 <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
                                                     <Grid item>
-                                                        <Button variant="contained" color="primary" onClick={createDmail} disabled={!registry}>
-                                                            Create Dmail
+                                                        <Button variant="contained" color="primary" onClick={updateDmail} disabled={!dmailDID}>
+                                                            Update Dmail
                                                         </Button>
                                                     </Grid>
                                                     <Grid item>
-                                                        <RegistrySelect />
+                                                        <Button variant="contained" color="primary" onClick={sendDmail} disabled={!dmailDID}>
+                                                            Send Dmail
+                                                        </Button>
                                                     </Grid>
                                                 </Grid>
-                                            }
-                                            {dmailDID &&
-                                                <Grid container direction="column" spacing={1}>
-                                                    <Grid item>
-                                                        <p>
-                                                            <Typography style={{ fontSize: '1em', fontFamily: 'Courier' }}>
-                                                                {dmailDID}
-                                                            </Typography>
-                                                        </p>
-                                                    </Grid>
-                                                    <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
-                                                        <Grid item>
-                                                            <Button variant="contained" color="primary" onClick={updateDmail} disabled={!dmailDID}>
-                                                                Update Dmail
-                                                            </Button>
-                                                        </Grid>
-                                                        <Grid item>
-                                                            <Button variant="contained" color="primary" onClick={sendDmail} disabled={!dmailDID}>
-                                                                Send Dmail
-                                                            </Button>
-                                                        </Grid>
-                                                    </Grid>
-                                                </Grid>
-                                            }
-                                        </Grid>
-                                    </Box>
-
+                                            </Grid>
+                                        }
+                                    </Grid>
                                 </Box>
                             }
                         </Box>

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -1080,10 +1080,25 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
     }
 
     async function createDmail() {
+        if (dmailToList.length === 0) {
+            showError("Please add at least one recipient to the 'To' field.");
+            return;
+        }
+
+        if (!dmailSubject) {
+            showError("Please enter a subject for the Dmail.");
+            return;
+        }
+
+        if (!dmailBody) {
+            showError("Please enter a body for the Dmail.");
+            return;
+        }
+
         try {
             const dmail = {
-                to: [dmailRecipient],
-                cc: [],
+                to: dmailToList,
+                cc: dmailCcList,
                 subject: dmailSubject,
                 body: dmailBody,
             };
@@ -3193,6 +3208,12 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                     <Typography variant="subtitle2" style={{ marginRight: 8 }}>To:</Typography>
                                                     <Typography variant="body2">
                                                         {(selectedDmail.to).join(', ')}
+                                                    </Typography>
+                                                </Box>
+                                                <Box display="flex" alignItems="center" mb={1}>
+                                                    <Typography variant="subtitle2" style={{ marginRight: 8 }}>Cc:</Typography>
+                                                    <Typography variant="body2">
+                                                        {(selectedDmail.cc).join(', ')}
                                                     </Typography>
                                                 </Box>
                                                 <Box display="flex" alignItems="center" mb={1}>

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -30,6 +30,7 @@ import {
     Article,
     AttachFile,
     Badge,
+    Clear,
     Groups,
     Email,
     Image,
@@ -116,7 +117,9 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
     const [selectedDmail, setSelectedDmail] = useState(null);
     const [dmailSubject, setDmailSubject] = useState('');
     const [dmailBody, setDmailBody] = useState('');
-    const [dmailTo, setDmailTo] = useState('');
+    const [dmailRecipient, setDmailRecipient] = useState('');
+    const [dmailToList, setDmailToList] = useState([]);
+    const [dmailCcList, setDmailCcList] = useState([]);
     const [dmailSendDID, setDmailSendDID] = useState('');
     const [assetsTab, setAssetsTab] = useState('');
     const [imageList, setImageList] = useState(null);
@@ -220,7 +223,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
             setSelectedHeld('');
             setSelectedIssued('');
             setDmailBody('');
-            setDmailTo('');
+            setDmailRecipient('');
             setDmailSendDID('');
             setSelectedImageName('');
             setSelectedDocumentName('');
@@ -1000,7 +1003,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
             setSelectedDmail(null);
             setDmailSubject('');
             setDmailBody('');
-            setDmailTo('');
+            setDmailRecipient('');
             setDmailSendDID('');
         } catch (error) {
             showError(error);
@@ -1028,10 +1031,58 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
         }
     }
 
+    async function addDmailTo() {
+        setDmailToList(prevToList => {
+            if (!dmailRecipient) {
+                return prevToList;
+            }
+
+            // Check if recipient already exists in the list
+            if (prevToList.includes(dmailRecipient)) {
+                return prevToList;
+            }
+
+            // Add recipient to the list
+            return [...prevToList, dmailRecipient];
+        });
+        setDmailRecipient(''); // Clear the input field after adding
+    }
+
+    async function removeDmailTo(recipient) {
+        setDmailToList(prevToList => {
+            // Remove recipient from the list
+            return prevToList.filter(item => item !== recipient);
+        });
+    }
+
+    async function addDmailCc() {
+        setDmailCcList(prevToList => {
+            if (!dmailRecipient) {
+                return prevToList;
+            }
+
+            // Check if recipient already exists in the list
+            if (prevToList.includes(dmailRecipient)) {
+                return prevToList;
+            }
+
+            // Add recipient to the list
+            return [...prevToList, dmailRecipient];
+        });
+        setDmailRecipient(''); // Clear the input field after adding
+    }
+
+    async function removeDmailCc(recipient) {
+        setDmailCcList(prevToList => {
+            // Remove recipient from the list
+            return prevToList.filter(item => item !== recipient);
+        });
+    }
+
     async function createDmail() {
         try {
             const dmail = {
-                to: [dmailTo],
+                to: [dmailRecipient],
                 cc: [],
                 subject: dmailSubject,
                 body: dmailBody,
@@ -1047,7 +1098,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
     async function updateDmail() {
         try {
             const dmail = {
-                to: [dmailTo],
+                to: [dmailRecipient],
                 cc: [],
                 subject: dmailSubject,
                 body: dmailBody,
@@ -3179,9 +3230,9 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                             <Autocomplete
                                                 freeSolo
                                                 options={agentList || []} // array of options, e.g. DIDs or names
-                                                value={dmailTo}
-                                                onChange={(event, newValue) => setDmailTo(newValue)}
-                                                onInputChange={(event, newInputValue) => setDmailTo(newInputValue)}
+                                                value={dmailRecipient}
+                                                onChange={(event, newValue) => setDmailRecipient(newValue)}
+                                                onInputChange={(event, newInputValue) => setDmailRecipient(newInputValue)}
                                                 renderInput={(params) => (
                                                     <TextField
                                                         {...params}
@@ -3194,63 +3245,98 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                 )}
                                             />
                                         </Grid>
+                                        <Grid item>
+                                            <Button variant="contained" color="primary" onClick={addDmailTo} disabled={!dmailRecipient}>
+                                                Add To
+                                            </Button>
+                                        </Grid>
+                                        <Grid item>
+                                            <Button variant="contained" color="primary" onClick={addDmailCc} disabled={!dmailRecipient}>
+                                                Add Cc
+                                            </Button>
+                                        </Grid>
                                     </Grid>
                                     <p />
-                                    {dmailTo &&
-                                        <Box>
-                                            <Grid container direction="column" spacing={1}>
+                                    <Box>
+                                        <Grid container direction="column" spacing={1}>
+                                            <Grid item>
+                                                <Typography variant="subtitle1">To:</Typography>
+                                                {dmailToList.map(recipient => (
+                                                    <Grid container direction="row" spacing={1}>
+                                                        <Grid item>
+                                                            <Button onClick={() => removeDmailTo(recipient)}><Clear /></Button>
+                                                        </Grid>
+                                                        <Grid item>
+                                                            <Typography variant="subtitle1">{recipient}</Typography>
+                                                        </Grid>
+                                                    </Grid>
+                                                ))}
+                                            </Grid>
+                                            <Grid item>
+                                                <Typography variant="subtitle1">Cc:</Typography>
+                                                {dmailCcList.map(recipient => (
+                                                    <Grid container direction="row" spacing={1}>
+                                                        <Grid item>
+                                                            <Button onClick={() => removeDmailCc(recipient)}><Clear /></Button>
+                                                        </Grid>
+                                                        <Grid item>
+                                                            <Typography variant="subtitle1">{recipient}</Typography>
+                                                        </Grid>
+                                                    </Grid>
+                                                ))}
+                                            </Grid>
+                                            <Grid item>
+                                                <TextField
+                                                    label="Subject"
+                                                    style={{ width: '800px' }}
+                                                    value={dmailSubject}
+                                                    onChange={e => setDmailSubject(e.target.value)}
+                                                    margin="normal"
+                                                    inputProps={{ maxLength: 120 }}
+                                                    fullWidth
+                                                />
+                                            </Grid>
+                                            <Grid item>
+                                                <textarea
+                                                    value={dmailBody}
+                                                    onChange={(e) => setDmailBody(e.target.value)}
+                                                    style={{ width: '800px', height: '600px', overflow: 'auto' }}
+                                                />
+                                            </Grid>
+                                            <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
                                                 <Grid item>
-                                                    <TextField
-                                                        label="Subject"
-                                                        style={{ width: '800px' }}
-                                                        value={dmailSubject}
-                                                        onChange={e => setDmailSubject(e.target.value)}
-                                                        margin="normal"
-                                                        inputProps={{ maxLength: 120 }}
-                                                        fullWidth
-                                                    />
+                                                    <Button variant="contained" color="primary" onClick={createDmail} disabled={!registry}>
+                                                        Create Dmail
+                                                    </Button>
                                                 </Grid>
                                                 <Grid item>
-                                                    <textarea
-                                                        value={dmailBody}
-                                                        onChange={(e) => setDmailBody(e.target.value)}
-                                                        style={{ width: '800px', height: '600px', overflow: 'auto' }}
-                                                    />
-                                                </Grid>
-                                                <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
-                                                    <Grid item>
-                                                        <Button variant="contained" color="primary" onClick={createDmail} disabled={!dmailBody || !registry}>
-                                                            Create Dmail
-                                                        </Button>
-                                                    </Grid>
-                                                    <Grid item>
-                                                        <RegistrySelect />
-                                                    </Grid>
-                                                </Grid>
-                                                {dmailSendDID &&
-                                                    <Grid item>
-                                                        <p>
-                                                            <Typography style={{ fontSize: '1em', fontFamily: 'Courier' }}>
-                                                                {dmailSendDID}
-                                                            </Typography>
-                                                        </p>
-                                                    </Grid>
-                                                }
-                                                <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
-                                                    <Grid item>
-                                                        <Button variant="contained" color="primary" onClick={updateDmail} disabled={!dmailSendDID}>
-                                                            Update Dmail
-                                                        </Button>
-                                                    </Grid>
-                                                    <Grid item>
-                                                        <Button variant="contained" color="primary" onClick={sendDmail} disabled={!dmailSendDID}>
-                                                            Send Dmail
-                                                        </Button>
-                                                    </Grid>
+                                                    <RegistrySelect />
                                                 </Grid>
                                             </Grid>
-                                        </Box>
-                                    }
+                                            {dmailSendDID &&
+                                                <Grid item>
+                                                    <p>
+                                                        <Typography style={{ fontSize: '1em', fontFamily: 'Courier' }}>
+                                                            {dmailSendDID}
+                                                        </Typography>
+                                                    </p>
+                                                </Grid>
+                                            }
+                                            <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
+                                                <Grid item>
+                                                    <Button variant="contained" color="primary" onClick={updateDmail} disabled={!dmailSendDID}>
+                                                        Update Dmail
+                                                    </Button>
+                                                </Grid>
+                                                <Grid item>
+                                                    <Button variant="contained" color="primary" onClick={sendDmail} disabled={!dmailSendDID}>
+                                                        Send Dmail
+                                                    </Button>
+                                                </Grid>
+                                            </Grid>
+                                        </Grid>
+                                    </Box>
+
                                 </Box>
                             }
                         </Box>

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -120,7 +120,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
     const [dmailRecipient, setDmailRecipient] = useState('');
     const [dmailToList, setDmailToList] = useState([]);
     const [dmailCcList, setDmailCcList] = useState([]);
-    const [dmailSendDID, setDmailSendDID] = useState('');
+    const [dmailDID, setDmailDID] = useState('');
     const [assetsTab, setAssetsTab] = useState('');
     const [imageList, setImageList] = useState(null);
     const [selectedImageName, setSelectedImageName] = useState('');
@@ -224,7 +224,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
             setSelectedIssued('');
             setDmailBody('');
             setDmailRecipient('');
-            setDmailSendDID('');
+            setDmailDID('');
             setSelectedImageName('');
             setSelectedDocumentName('');
             setSelectedVaultName('');
@@ -1004,7 +1004,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
             setDmailSubject('');
             setDmailBody('');
             setDmailRecipient('');
-            setDmailSendDID('');
+            setDmailDID('');
         } catch (error) {
             showError(error);
         }
@@ -1079,48 +1079,48 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
         });
     }
 
-    async function createDmail() {
+    function getDmailInputOrError() {
         if (dmailToList.length === 0) {
             showError("Please add at least one recipient to the 'To' field.");
-            return;
+            return null;
         }
 
         if (!dmailSubject) {
             showError("Please enter a subject for the Dmail.");
-            return;
+            return null;
         }
 
         if (!dmailBody) {
             showError("Please enter a body for the Dmail.");
-            return;
+            return null;
         }
 
-        try {
-            const dmail = {
-                to: dmailToList,
-                cc: dmailCcList,
-                subject: dmailSubject,
-                body: dmailBody,
-            };
+        return {
+            to: dmailToList,
+            cc: dmailCcList,
+            subject: dmailSubject,
+            body: dmailBody,
+        };
+    }
 
+    async function createDmail() {
+        const dmail = getDmailInputOrError();
+        if (!dmail) return;
+
+        try {
             const did = await keymaster.createDmail(dmail, { registry });
-            setDmailSendDID(did);
+            setDmailDID(did);
         } catch (error) {
             showError(error);
         }
     }
 
     async function updateDmail() {
+        const dmail = getDmailInputOrError();
+        if (!dmail) return;
+
         try {
-            const dmail = {
-                to: [dmailRecipient],
-                cc: [],
-                subject: dmailSubject,
-                body: dmailBody,
-            };
-
-            const ok = await keymaster.updateDmail(dmailSendDID, dmail);
-
+            const ok = await keymaster.updateDmail(dmailDID, dmail);
             if (ok) {
                 showAlert("Dmail updated successfully");
             } else {
@@ -1133,7 +1133,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
     async function sendDmail() {
         try {
-            const ok = await keymaster.sendDmail(dmailSendDID);
+            const ok = await keymaster.sendDmail(dmailDID);
 
             if (ok) {
                 showAlert("Dmail sent successfully");
@@ -3324,37 +3324,41 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                     style={{ width: '800px', height: '600px', overflow: 'auto' }}
                                                 />
                                             </Grid>
-                                            <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
-                                                <Grid item>
-                                                    <Button variant="contained" color="primary" onClick={createDmail} disabled={!registry}>
-                                                        Create Dmail
-                                                    </Button>
-                                                </Grid>
-                                                <Grid item>
-                                                    <RegistrySelect />
-                                                </Grid>
-                                            </Grid>
-                                            {dmailSendDID &&
-                                                <Grid item>
-                                                    <p>
-                                                        <Typography style={{ fontSize: '1em', fontFamily: 'Courier' }}>
-                                                            {dmailSendDID}
-                                                        </Typography>
-                                                    </p>
+                                            {!dmailDID &&
+                                                <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
+                                                    <Grid item>
+                                                        <Button variant="contained" color="primary" onClick={createDmail} disabled={!registry}>
+                                                            Create Dmail
+                                                        </Button>
+                                                    </Grid>
+                                                    <Grid item>
+                                                        <RegistrySelect />
+                                                    </Grid>
                                                 </Grid>
                                             }
-                                            <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
-                                                <Grid item>
-                                                    <Button variant="contained" color="primary" onClick={updateDmail} disabled={!dmailSendDID}>
-                                                        Update Dmail
-                                                    </Button>
+                                            {dmailDID &&
+                                                <Grid container direction="column" spacing={1}>
+                                                    <Grid item>
+                                                        <p>
+                                                            <Typography style={{ fontSize: '1em', fontFamily: 'Courier' }}>
+                                                                {dmailDID}
+                                                            </Typography>
+                                                        </p>
+                                                    </Grid>
+                                                    <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
+                                                        <Grid item>
+                                                            <Button variant="contained" color="primary" onClick={updateDmail} disabled={!dmailDID}>
+                                                                Update Dmail
+                                                            </Button>
+                                                        </Grid>
+                                                        <Grid item>
+                                                            <Button variant="contained" color="primary" onClick={sendDmail} disabled={!dmailDID}>
+                                                                Send Dmail
+                                                            </Button>
+                                                        </Grid>
+                                                    </Grid>
                                                 </Grid>
-                                                <Grid item>
-                                                    <Button variant="contained" color="primary" onClick={sendDmail} disabled={!dmailSendDID}>
-                                                        Send Dmail
-                                                    </Button>
-                                                </Grid>
-                                            </Grid>
+                                            }
                                         </Grid>
                                     </Box>
 

--- a/tests/keymaster/notice.test.ts
+++ b/tests/keymaster/notice.test.ts
@@ -347,7 +347,7 @@ describe('refreshNotices', () => {
         expect(ok).toBe(true);
     });
 
-    it('should remove expired notices', async () => {
+    it('should remove revoked notices', async () => {
         const alice = await keymaster.createId('Alice');
         const bob = await keymaster.createId('Bob');
         await keymaster.createId('Charles');
@@ -370,6 +370,36 @@ describe('refreshNotices', () => {
 
         await keymaster.setCurrentId('Bob');
         await keymaster.revokeDID(did);
+
+        await keymaster.setCurrentId('Alice');
+        const ok = await keymaster.refreshNotices();
+
+        expect(ok).toBe(true);
+    });
+
+    it('should remove expired notices', async () => {
+        const alice = await keymaster.createId('Alice');
+        const bob = await keymaster.createId('Bob');
+        await keymaster.createId('Charles');
+        const dmail = await keymaster.createDmail({
+            to: [alice],
+            cc: [bob],
+            subject: 'Test Dmail 4',
+            body: 'This is a test dmail 4.',
+        });
+
+        const notice: NoticeMessage = {
+            to: [alice, bob],
+            dids: [dmail],
+        };
+
+        const did = await keymaster.createNotice(notice);
+
+        await keymaster.setCurrentId('Alice');
+        await keymaster.importNotice(did);
+
+        // Simulate expiration by removing the DID
+        await gatekeeper.removeDIDs([did]);
 
         await keymaster.setCurrentId('Alice');
         const ok = await keymaster.refreshNotices();

--- a/tests/keymaster/notice.test.ts
+++ b/tests/keymaster/notice.test.ts
@@ -355,6 +355,22 @@ describe('searchNotices', () => {
         expect(ok).toBe(false);
     });
 
+    it('should silently skip expired notices', async () => {
+        const alice = await keymaster.createId('Alice');
+
+        const notice: NoticeMessage = {
+            to: [alice],
+            dids: [alice],
+        };
+
+        const did = await keymaster.createNotice(notice);
+        search.setResults([did]);
+        await gatekeeper.removeDIDs([did]);
+
+        const ok = await keymaster.searchNotices();
+        expect(ok).toBe(true);
+    });
+
     it('should throw an exception if search engine throws', async () => {
         await keymaster.createId('Alice');
 


### PR DESCRIPTION
This PR adds support for a cc list in dmail functionality while updating corresponding UI handling and backend notice cleanup tests.

-    Modified test descriptions and added a new test for handling expired notices.
-    Refactored dmail recipient handling in the UI to support multiple "To" and "Cc" recipients.
-    Updated notice removal logic in the backend to reflect refined conditions for revoked versus expired notices.
