### PR TITLE
ci: use artifact name from previous run vs actual folder name

### DIFF
--- a/.github/workflows/e2e-test-report.yml
+++ b/.github/workflows/e2e-test-report.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: dorny/test-reporter@v2
       with:
-        artifact: test-results            # artifact name
+        artifact: E2E Artifacts            # artifact name
         name: TCL/Expect Tests                  # Name of the check run which will be created
         path: '*.xml'                     # Path to test results (inside artifact .zip)
         reporter: jest-junit              # Format of test results


### PR DESCRIPTION
Just updates the artifact name to use the artifact name vs the folder name in the project