### PR TITLE
feat: Adds dmail attachments

### DIFF
--- a/doc/keymaster-api.json
+++ b/doc/keymaster-api.json
@@ -6649,6 +6649,219 @@
         }
       }
     },
+    "/dmail/{id}/attachments": {
+      "get": {
+        "summary": "List all attachments for a specific Dmail message.",
+        "description": "Returns a mapping of attachment names to their metadata for the specified Dmail DID.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The DID of the Dmail message whose attachments should be listed."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A mapping of attachment names to their metadata.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "attachments": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "object"
+                      },
+                      "description": "An object where each key is an attachment name, and each value is the associated metadata."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Dmail message or attachments not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Add an attachment to a specific Dmail message.",
+        "description": "Uploads a binary attachment and associates it with the specified Dmail message. The attachment name must be provided in the X-Options header as JSON.\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The DID of the Dmail message to attach the file to."
+          },
+          {
+            "in": "header",
+            "name": "X-Options",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "A JSON string containing additional options, including the attachment name. Example: {\"name\":\"myfile.txt\"}\n"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              },
+              "description": "The binary data of the attachment to upload."
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Indicates whether the attachment was successfully added.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "description": "true if the attachment was added, otherwise false."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dmail/{id}/attachments/{name}": {
+      "delete": {
+        "summary": "Remove an attachment from a specific Dmail message.",
+        "description": "Deletes the specified attachment from the Dmail message identified by its DID.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The DID of the Dmail message."
+          },
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The name of the attachment to remove."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Indicates whether the attachment was successfully removed.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean",
+                      "description": "true if the attachment was removed, otherwise false."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Dmail message or attachment not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "Download a specific attachment from a Dmail message.",
+        "description": "Returns the binary data for the specified attachment associated with the given Dmail DID.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The DID of the Dmail message."
+          },
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The name of the attachment to download."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The binary data of the requested attachment.",
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Attachment or Dmail message not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/notices": {
       "post": {
         "summary": "Create a new notice asset.",

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -2997,6 +2997,9 @@ export default class Keymaster implements KeymasterInterface {
             const date = docs.didDocumentMetadata?.updated ?? '';
             const to = message.to.map(did => didToName[did] ?? did);
             const cc = message.cc.map(did => didToName[did] ?? did);
+            const attachments = await this.listGroupVaultItems(did);
+
+            delete attachments[DmailTags.DMAIL]; // Remove the dmail item itself from attachments
 
             dmailList[did] = {
                 message,
@@ -3005,6 +3008,7 @@ export default class Keymaster implements KeymasterInterface {
                 tags,
                 sender,
                 date,
+                attachments,
                 docs,
             };
         }

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -3231,6 +3231,10 @@ export default class Keymaster implements KeymasterInterface {
         return this.removeGroupVaultItem(did, name);
     }
 
+    async getDmailAttachment(did: string, name: string): Promise<Buffer | null> {
+        return this.getGroupVaultItem(did, name);
+    }
+
     async importDmail(did: string): Promise<boolean> {
         const dmail = await this.getDmailMessage(did);
 

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -2997,9 +2997,7 @@ export default class Keymaster implements KeymasterInterface {
             const date = docs.didDocumentMetadata?.updated ?? '';
             const to = message.to.map(did => didToName[did] ?? did);
             const cc = message.cc.map(did => didToName[did] ?? did);
-            const attachments = await this.listGroupVaultItems(did);
-
-            delete attachments[DmailTags.DMAIL]; // Remove the dmail item itself from attachments
+            const attachments = await this.listDmailAttachments(did);
 
             dmailList[did] = {
                 message,
@@ -3207,6 +3205,30 @@ export default class Keymaster implements KeymasterInterface {
         catch (error) {
             return null;
         }
+    }
+
+    async listDmailAttachments(did: string): Promise<Record<string, any>> {
+        let items = await this.listGroupVaultItems(did);
+
+        delete items[DmailTags.DMAIL]; // Remove the dmail item itself from attachments
+
+        return items;
+    }
+
+    async addDmailAttachment(did: string, name: string, buffer: Buffer): Promise<boolean> {
+        if (name === DmailTags.DMAIL) {
+            throw new InvalidParameterError('Cannot add attachment with reserved name "dmail"');
+        }
+
+        return this.addGroupVaultItem(did, name, buffer);
+    }
+
+    async removeDmailAttachment(did: string, name: string): Promise<boolean> {
+        if (name === DmailTags.DMAIL) {
+            throw new InvalidParameterError('Cannot remove attachment with reserved name "dmail"');
+        }
+
+        return this.removeGroupVaultItem(did, name);
     }
 
     async importDmail(did: string): Promise<boolean> {

--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -278,6 +278,7 @@ export interface DmailItem {
     sender: string;
     date: string;
     tags: string[];
+    attachments?: any;
     docs?: any;
 }
 

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -1225,6 +1225,48 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
         }
     }
 
+    async function uploadDmailAttachment(event) {
+        try {
+            const fileInput = event.target; // Reference to the input element
+            const file = fileInput.files[0];
+
+            if (!file) return;
+
+            // Reset the input value to allow selecting the same file again
+            fileInput.value = "";
+
+            // Read the file as a binary buffer
+            const reader = new FileReader();
+
+            reader.onload = async (e) => {
+                try {
+                    const arrayBuffer = e.target.result;
+                    const buffer = Buffer.from(arrayBuffer);
+
+                    const ok = await keymaster.addGroupVaultItem(dmailDID, file.name, buffer);
+
+                    if (ok) {
+                        showAlert(`Attachment uploaded successfully: ${file.name}`);
+                        //refreshVault(selectedVaultName);
+                    } else {
+                        showAlert(`Error uploading file: ${file.name}`);
+                    }
+                } catch (error) {
+                    // Catch errors from the Keymaster API or other logic
+                    showError(`Error uploading file: ${error}`);
+                }
+            };
+
+            reader.onerror = (error) => {
+                showError(`Error uploading file: ${error}`);
+            };
+
+            reader.readAsArrayBuffer(file);
+        } catch (error) {
+            showError(`Error uploading file: ${error}`);
+        }
+    }
+
     async function sendDmail() {
         try {
             const ok = await keymaster.sendDmail(dmailDID);
@@ -1995,12 +2037,12 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
     // Check notices and update DMail and polls every 30 seconds
     useEffect(() => {
-        const interval = setInterval(async() => {
+        const interval = setInterval(async () => {
             try {
                 await keymaster.refreshNotices();
                 await refreshInbox();
                 await refreshPoll();
-            } catch {}
+            } catch { }
         }, 30000);
 
         return () => clearInterval(interval);
@@ -2034,7 +2076,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                     if (doc?.didDocumentData?.poll) {
                         polls.push(name);
                     }
-                } catch {}
+                } catch { }
             }
 
             if (!arraysEqual(polls, pollList)) {
@@ -2048,7 +2090,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                 }
                 setPollList(polls);
             }
-        } catch {}
+        } catch { }
     }
 
     const buildPoll = async () => {
@@ -3608,7 +3650,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                 <Box sx={{ maxWidth: 650 }}>
                                     {pollList.length > 0 ? (
                                         <Box sx={{ mt: 2 }}>
-                                            <Box display="flex" flexDirection="row" sx={{ gap: 1}}>
+                                            <Box display="flex" flexDirection="row" sx={{ gap: 1 }}>
                                                 <Select
                                                     value={selectedPollName}
                                                     onChange={handleSelectPoll}
@@ -3664,7 +3706,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
                                             {selectedPollDid && (
                                                 <Box>
-                                                    <Box display="flex" flexDirection="row" sx={{ mt: 2, gap: 1}}>
+                                                    <Box display="flex" flexDirection="row" sx={{ mt: 2, gap: 1 }}>
                                                         <Typography variant="h6">
                                                             Poll:
                                                         </Typography>
@@ -4351,13 +4393,46 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                             </Grid>
                                         }
                                         {dmailDID &&
+                                            <Box>
+                                                <Typography style={{ fontSize: '1em', fontFamily: 'Courier' }}>
+                                                    {dmailDID}
+                                                </Typography>
+                                            </Box>
+                                        }
+                                        {dmailDID &&
                                             <Grid container direction="column" spacing={1}>
                                                 <Grid item>
-                                                    <p>
-                                                        <Typography style={{ fontSize: '1em', fontFamily: 'Courier' }}>
-                                                            {dmailDID}
-                                                        </Typography>
-                                                    </p>
+                                                    Attachments:
+                                                    <Button
+                                                        variant="contained"
+                                                        color="primary"
+                                                        sx={{ ml: 2 }}
+                                                        onClick={() => document.getElementById('attachmentUpload').click()}
+                                                    >
+                                                        Upload...
+                                                    </Button>
+                                                    <input
+                                                        type="file"
+                                                        id="attachmentUpload"
+                                                        style={{ display: 'none' }}
+                                                        onChange={uploadDmailAttachment}
+                                                    />
+                                                </Grid>
+                                                <Grid item>1</Grid>
+                                                <Grid item>2</Grid>
+                                                <Grid item>3</Grid>
+                                                <Grid item>4</Grid>
+                                                <Grid item>5</Grid>
+                                                <Grid item>6</Grid>
+                                                <Grid item>7</Grid>
+                                            </Grid>
+                                        }
+                                        {dmailDID &&
+                                            <Grid container direction="column" spacing={1}>
+                                                <Grid item>
+                                                    <Typography style={{ fontSize: '1em', fontFamily: 'Courier' }}>
+                                                        {dmailDID}
+                                                    </Typography>
                                                 </Grid>
                                                 <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
                                                     <Grid item>

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -768,7 +768,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
             if (newController) {
                 await keymaster.transferAsset(name, newController);
                 resolveName(name);
-                showAlert(`Transferred ${name} to ${newController}`);
+                showSuccess(`Transferred ${name} to ${newController}`);
             }
         } catch (error) {
             showError(error);
@@ -1114,7 +1114,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
             const ok = await keymaster.importDmail(did);
 
             if (ok) {
-                showAlert("Dmail import successful");
+                showSuccess("Dmail import successful");
                 refreshDmail();
             } else {
                 showError("Dmail import failed");
@@ -1218,7 +1218,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
         try {
             const ok = await keymaster.updateDmail(dmailDID, dmail);
             if (ok) {
-                showAlert("Dmail updated successfully");
+                showSuccess("Dmail updated successfully");
             } else {
                 showError("Dmail update failed");
             }
@@ -1229,12 +1229,8 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
     async function refreshDmailAttachments() {
         try {
-            const msgs = await keymaster.listDmail();
-
-            if (msgs && msgs[dmailDID]) {
-                const attachments = msgs[dmailDID].attachments || {};
-                setDmailAttachments(attachments);
-            }
+            const attachments = await keymaster.listDmailAttachments(dmailDID);
+            setDmailAttachments(attachments || {});
         } catch (error) {
             showError(error);
         }
@@ -1258,7 +1254,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                     const arrayBuffer = e.target.result;
                     const buffer = Buffer.from(arrayBuffer);
 
-                    const ok = await keymaster.addGroupVaultItem(dmailDID, file.name, buffer);
+                    const ok = await keymaster.addDmailAttachment(dmailDID, file.name, buffer);
 
                     if (ok) {
                         showSuccess(`Attachment uploaded successfully: ${file.name}`);
@@ -1284,7 +1280,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
     async function removeDmailAttachment(name) {
         try {
-            await keymaster.removeGroupVaultItem(dmailDID, name);
+            await keymaster.removeDmailAttachment(dmailDID, name);
             refreshDmailAttachments();
         } catch (error) {
             showError(error);
@@ -1296,7 +1292,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
             const ok = await keymaster.sendDmail(dmailDID);
 
             if (ok) {
-                showAlert("Dmail sent successfully");
+                showSuccess("Dmail sent successfully");
             } else {
                 showError("Dmail send failed");
             }
@@ -1589,7 +1585,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                     }
 
                     await keymaster.addName(name, did);
-                    showAlert(`Image uploaded successfully: ${name}`);
+                    showSuccess(`Image uploaded successfully: ${name}`);
 
                     refreshNames();
                     selectImage(name);
@@ -1629,7 +1625,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
                     await keymaster.updateImage(selectedImageName, buffer);
 
-                    showAlert(`Image updated successfully`);
+                    showSuccess(`Image updated successfully`);
                     selectImage(selectedImageName);
                 } catch (error) {
                     showError(`Error processing image: ${error}`);
@@ -1709,7 +1705,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                     }
 
                     await keymaster.createDocument(buffer, { registry, name, filename: file.name });
-                    showAlert(`Document uploaded successfully: ${name}`);
+                    showSuccess(`Document uploaded successfully: ${name}`);
                     refreshNames();
                 } catch (error) {
                     // Catch errors from the Keymaster API or other logic
@@ -1746,7 +1742,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                     const buffer = Buffer.from(arrayBuffer);
 
                     await keymaster.updateDocument(selectedDocumentName, buffer, { filename: file.name });
-                    showAlert(`Document updated successfully`);
+                    showSuccess(`Document updated successfully`);
                     selectDocument(selectedDocumentName);
                 } catch (error) {
                     // Catch errors from the Keymaster API or other logic
@@ -1936,10 +1932,10 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
             setEditLoginOpen(false);
 
             if (ok) {
-                showAlert(`Login added successfully: ${service}`);
+                showSuccess(`Login added successfully: ${service}`);
                 refreshVault(selectedVaultName);
             } else {
-                showAlert(`Error adding login: ${service}`);
+                showError(`Error adding login: ${service}`);
             }
         } catch (error) {
             showError(error);

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -1247,7 +1247,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
                     if (ok) {
                         showAlert(`Attachment uploaded successfully: ${file.name}`);
-                        //refreshVault(selectedVaultName);
+                        refreshInbox();
                     } else {
                         showAlert(`Error uploading file: ${file.name}`);
                     }
@@ -4418,22 +4418,14 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                         onChange={uploadDmailAttachment}
                                                     />
                                                 </Grid>
-                                                <Grid item>1</Grid>
-                                                <Grid item>2</Grid>
-                                                <Grid item>3</Grid>
-                                                <Grid item>4</Grid>
-                                                <Grid item>5</Grid>
-                                                <Grid item>6</Grid>
-                                                <Grid item>7</Grid>
+
+                                                {Object.entries(selectedDmail.attachments).map(([name, item], index) => (
+                                                    <Grid item>{getVaultItemIcon(name, item)} {name}</Grid>
+                                                ))}
                                             </Grid>
                                         }
                                         {dmailDID &&
                                             <Grid container direction="column" spacing={1}>
-                                                <Grid item>
-                                                    <Typography style={{ fontSize: '1em', fontFamily: 'Courier' }}>
-                                                        {dmailDID}
-                                                    </Typography>
-                                                </Grid>
                                                 <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
                                                     <Grid item>
                                                         <Button variant="contained" color="primary" onClick={updateDmail} disabled={!dmailDID}>

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -4406,42 +4406,44 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                     InputProps={{ readOnly: true }}
                                                     variant="outlined"
                                                 />
-                                                <TableContainer>
-                                                    <Table size="small" sx={{ tableLayout: 'auto', width: 'auto' }}>
-                                                        <TableBody>
-                                                            <TableRow>
-                                                                <TableCell sx={{ fontWeight: 'bold', backgroundColor: '#f5f5f5' }}>
-                                                                    Attachment
-                                                                </TableCell>
-                                                                <TableCell sx={{ fontWeight: 'bold', backgroundColor: '#f5f5f5' }}>
-                                                                    Size (bytes)
-                                                                </TableCell>
-                                                                <TableCell sx={{ fontWeight: 'bold', backgroundColor: '#f5f5f5' }}>
-                                                                </TableCell>
-                                                            </TableRow>
-                                                            {Object.entries(selectedDmail.attachments).map(([name, item], index) => (
-                                                                <TableRow key={index}>
-                                                                    <TableCell>
-                                                                        {getVaultItemIcon(name, item)}
-                                                                        {name}
+                                                {selectedDmail.attachments && Object.keys(selectedDmail.attachments).length > 0 &&
+                                                    <TableContainer>
+                                                        <Table size="small" sx={{ tableLayout: 'auto', width: 'auto' }}>
+                                                            <TableBody>
+                                                                <TableRow>
+                                                                    <TableCell sx={{ fontWeight: 'bold', backgroundColor: '#f5f5f5' }}>
+                                                                        Attachment
                                                                     </TableCell>
-                                                                    <TableCell>
-                                                                        {item.bytes}
+                                                                    <TableCell sx={{ fontWeight: 'bold', backgroundColor: '#f5f5f5' }}>
+                                                                        Size (bytes)
                                                                     </TableCell>
-                                                                    <TableCell>
-                                                                        <Button
-                                                                            variant="contained"
-                                                                            color="primary"
-                                                                            onClick={() => downloadDmailAttachment(name)}
-                                                                        >
-                                                                            Download
-                                                                        </Button>
+                                                                    <TableCell sx={{ fontWeight: 'bold', backgroundColor: '#f5f5f5' }}>
                                                                     </TableCell>
                                                                 </TableRow>
-                                                            ))}
-                                                        </TableBody>
-                                                    </Table>
-                                                </TableContainer>
+                                                                {Object.entries(selectedDmail.attachments).map(([name, item], index) => (
+                                                                    <TableRow key={index}>
+                                                                        <TableCell>
+                                                                            {getVaultItemIcon(name, item)}
+                                                                            {name}
+                                                                        </TableCell>
+                                                                        <TableCell>
+                                                                            {item.bytes}
+                                                                        </TableCell>
+                                                                        <TableCell>
+                                                                            <Button
+                                                                                variant="contained"
+                                                                                color="primary"
+                                                                                onClick={() => downloadDmailAttachment(name)}
+                                                                            >
+                                                                                Download
+                                                                            </Button>
+                                                                        </TableCell>
+                                                                    </TableRow>
+                                                                ))}
+                                                            </TableBody>
+                                                        </Table>
+                                                    </TableContainer>
+                                                }
                                             </Paper>
                                         }
                                     </Box>
@@ -4568,10 +4570,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                 <Typography style={{ fontSize: '1em', fontFamily: 'Courier' }}>
                                                     {dmailDID}
                                                 </Typography>
-                                            </Box>
-                                        }
-                                        {dmailDID &&
-                                            <Box>
+                                                <p></p>
                                                 <Grid container direction="column" spacing={1}>
                                                     <Grid item>
                                                         Attachments:
@@ -4598,22 +4597,17 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                         </Grid>
                                                     ))}
                                                 </Grid>
-                                            </Box>
-                                        }
-                                        {dmailDID &&
-                                            <Box>
-                                                <Grid container direction="column" spacing={1}>
-                                                    <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
-                                                        <Grid item>
-                                                            <Button variant="contained" color="primary" onClick={updateDmail} disabled={!dmailDID}>
-                                                                Update Dmail
-                                                            </Button>
-                                                        </Grid>
-                                                        <Grid item>
-                                                            <Button variant="contained" color="primary" onClick={sendDmail} disabled={!dmailDID}>
-                                                                Send Dmail
-                                                            </Button>
-                                                        </Grid>
+                                                <p></p>
+                                                <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
+                                                    <Grid item>
+                                                        <Button variant="contained" color="primary" onClick={updateDmail} disabled={!dmailDID}>
+                                                            Update Dmail
+                                                        </Button>
+                                                    </Grid>
+                                                    <Grid item>
+                                                        <Button variant="contained" color="primary" onClick={sendDmail} disabled={!dmailDID}>
+                                                            Send Dmail
+                                                        </Button>
                                                     </Grid>
                                                 </Grid>
                                             </Box>

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -1241,8 +1241,9 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
     async function refreshDmailAttachments() {
         try {
-            const attachments = await keymaster.listDmailAttachments(dmailDID);
-            setDmailAttachments(attachments || {});
+            const attachments = await keymaster.listDmailAttachments(dmailDID) || {};
+            setDmailAttachments(attachments);
+            dmailList[dmailDID].attachments = attachments;
         } catch (error) {
             showError(error);
         }
@@ -4227,7 +4228,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                 <Box>
                                     <Box>
                                         <TableContainer component={Paper} style={{ maxHeight: '300px', overflow: 'auto' }}>
-                                            <Table size="small">
+                                            <Table size="small" sx={{ tableLayout: 'auto', width: 'auto' }}>
                                                 <TableHead>
                                                     <TableRow>
                                                         <TableCell sx={{ fontWeight: 'bold', backgroundColor: '#f5f5f5' }}>Sender</TableCell>
@@ -4367,7 +4368,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                         {selectedDmail &&
                                             <Paper style={{ padding: 16 }}>
                                                 <TableContainer>
-                                                    <Table size="small">
+                                                    <Table size="small" sx={{ tableLayout: 'auto', width: 'auto' }}>
                                                         <TableBody>
                                                             <TableRow>
                                                                 <TableCell><b>To</b></TableCell>
@@ -4406,16 +4407,16 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                     variant="outlined"
                                                 />
                                                 <TableContainer>
-                                                    <Table size="small">
+                                                    <Table size="small" sx={{ tableLayout: 'auto', width: 'auto' }}>
                                                         <TableBody>
                                                             <TableRow>
-                                                                <TableCell>
+                                                                <TableCell sx={{ fontWeight: 'bold', backgroundColor: '#f5f5f5' }}>
                                                                     Attachment
                                                                 </TableCell>
-                                                                <TableCell>
+                                                                <TableCell sx={{ fontWeight: 'bold', backgroundColor: '#f5f5f5' }}>
                                                                     Size (bytes)
                                                                 </TableCell>
-                                                                <TableCell>
+                                                                <TableCell sx={{ fontWeight: 'bold', backgroundColor: '#f5f5f5' }}>
                                                                 </TableCell>
                                                             </TableRow>
                                                             {Object.entries(selectedDmail.attachments).map(([name, item], index) => (

--- a/services/keymaster/server/src/keymaster-api.ts
+++ b/services/keymaster/server/src/keymaster-api.ts
@@ -5598,6 +5598,39 @@ v1router.post('/dmail/:id/file', async (req, res) => {
     }
 });
 
+/**
+ * @swagger
+ * /dmail/{id}/attachments:
+ *   get:
+ *     summary: List all attachments for a specific Dmail message.
+ *     description: Returns a mapping of attachment names to their metadata for the specified Dmail DID.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The DID of the Dmail message whose attachments should be listed.
+ *     responses:
+ *       200:
+ *         description: A mapping of attachment names to their metadata.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 attachments:
+ *                   type: object
+ *                   additionalProperties:
+ *                     type: object
+ *                   description: An object where each key is an attachment name, and each value is the associated metadata.
+ *       404:
+ *         description: Dmail message or attachments not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: string
+ */
 v1router.get('/dmail/:id/attachments', async (req, res) => {
     try {
         const dmailId = req.params.id;
@@ -5608,6 +5641,54 @@ v1router.get('/dmail/:id/attachments', async (req, res) => {
     }
 });
 
+/**
+ * @swagger
+ * /dmail/{id}/attachments:
+ *   post:
+ *     summary: Add an attachment to a specific Dmail message.
+ *     description: >
+ *       Uploads a binary attachment and associates it with the specified Dmail message. The attachment name must be provided in the X-Options header as JSON.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The DID of the Dmail message to attach the file to.
+ *       - in: header
+ *         name: X-Options
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: >
+ *           A JSON string containing additional options, including the attachment name.
+ *           Example: {"name":"myfile.txt"}
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/octet-stream:
+ *           schema:
+ *             type: string
+ *             format: binary
+ *           description: The binary data of the attachment to upload.
+ *     responses:
+ *       200:
+ *         description: Indicates whether the attachment was successfully added.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                   description: true if the attachment was added, otherwise false.
+ *       500:
+ *         description: Internal server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: string
+ */
 v1router.post('/dmail/:id/attachments', express.raw({ type: 'application/octet-stream', limit: '10mb' }), async (req, res) => {
     try {
         const dmailId = req.params.id;
@@ -5622,6 +5703,43 @@ v1router.post('/dmail/:id/attachments', express.raw({ type: 'application/octet-s
     }
 });
 
+/**
+ * @swagger
+ * /dmail/{id}/attachments/{name}:
+ *   delete:
+ *     summary: Remove an attachment from a specific Dmail message.
+ *     description: Deletes the specified attachment from the Dmail message identified by its DID.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The DID of the Dmail message.
+ *       - in: path
+ *         name: name
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The name of the attachment to remove.
+ *     responses:
+ *       200:
+ *         description: Indicates whether the attachment was successfully removed.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 ok:
+ *                   type: boolean
+ *                   description: true if the attachment was removed, otherwise false.
+ *       404:
+ *         description: Dmail message or attachment not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: string
+ */
 v1router.delete('/dmail/:id/attachments/:name', async (req, res) => {
     try {
         const dmailId = req.params.id;
@@ -5633,6 +5751,40 @@ v1router.delete('/dmail/:id/attachments/:name', async (req, res) => {
     }
 });
 
+/**
+ * @swagger
+ * /dmail/{id}/attachments/{name}:
+ *   get:
+ *     summary: Download a specific attachment from a Dmail message.
+ *     description: Returns the binary data for the specified attachment associated with the given Dmail DID.
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The DID of the Dmail message.
+ *       - in: path
+ *         name: name
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The name of the attachment to download.
+ *     responses:
+ *       200:
+ *         description: The binary data of the requested attachment.
+ *         content:
+ *           application/octet-stream:
+ *             schema:
+ *               type: string
+ *               format: binary
+ *       404:
+ *         description: Attachment or Dmail message not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: string
+ */
 v1router.get('/dmail/:id/attachments/:name', async (req, res) => {
     try {
         const dmailId = req.params.id;

--- a/services/keymaster/server/src/keymaster-api.ts
+++ b/services/keymaster/server/src/keymaster-api.ts
@@ -5598,6 +5598,53 @@ v1router.post('/dmail/:id/file', async (req, res) => {
     }
 });
 
+v1router.get('/dmail/:id/attachments', async (req, res) => {
+    try {
+        const dmailId = req.params.id;
+        const attachments = await keymaster.listDmailAttachments(dmailId);
+        res.json({ attachments });
+    } catch (error: any) {
+        res.status(404).send(error.toString());
+    }
+});
+
+v1router.post('/dmail/:id/attachments', express.raw({ type: 'application/octet-stream', limit: '10mb' }), async (req, res) => {
+    try {
+        const dmailId = req.params.id;
+        const data = req.body;
+        const headers = req.headers;
+        const options = typeof headers['x-options'] === 'string' ? JSON.parse(headers['x-options']) : {};
+        const { name } = options;
+        const ok = await keymaster.addDmailAttachment(dmailId, name, data);
+        res.json({ ok });
+    } catch (error: any) {
+        res.status(500).send(error.toString());
+    }
+});
+
+v1router.delete('/dmail/:id/attachments/:name', async (req, res) => {
+    try {
+        const dmailId = req.params.id;
+        const name = req.params.name;
+        const ok = await keymaster.removeDmailAttachment(dmailId, name);
+        res.json({ ok });
+    } catch (error: any) {
+        res.status(404).send(error.toString());
+    }
+});
+
+v1router.get('/dmail/:id/attachments/:name', async (req, res) => {
+    try {
+        const dmailId = req.params.id;
+        const name = req.params.name;
+        const response = await keymaster.getDmailAttachment(dmailId, name);
+        res.set('Content-Type', 'application/octet-stream');
+        res.send(response);
+    } catch (error: any) {
+        res.status(404).send(error.toString());
+    }
+});
+
 /**
  * @swagger
  * /notices:

--- a/tests/keymaster/client.test.ts
+++ b/tests/keymaster/client.test.ts
@@ -3127,6 +3127,158 @@ describe('removeDmail', () => {
     });
 });
 
+describe('addDmailAttachment', () => {
+    const mockDmailId = 'dmail1';
+    const mockName = 'mockName';
+    const mockBuffer = Buffer.from('mockBuffer');
+
+    it('should add dmail attachment', async () => {
+        nock(KeymasterURL)
+            .post(`${Endpoints.dmail}/${mockDmailId}/attachments`)
+            .reply(200, { ok: true });
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const result = await keymaster.addDmailAttachment(mockDmailId, mockName, mockBuffer);
+
+        expect(result).toBe(true);
+    });
+
+    it('should throw exception on addDmailAttachment server error', async () => {
+        nock(KeymasterURL)
+            .post(`${Endpoints.dmail}/${mockDmailId}/attachments`)
+            .reply(500, ServerError);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+
+        try {
+            await keymaster.addDmailAttachment(mockDmailId, mockName, mockBuffer);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(ServerError.message);
+        }
+    });
+});
+
+describe('removeDmailAttachment', () => {
+    const mockDmailId = 'dmail2';
+    const mockName = 'mockName';
+
+    it('should remove dmail attachment', async () => {
+        nock(KeymasterURL)
+            .delete(`${Endpoints.dmail}/${mockDmailId}/attachments/${mockName}`)
+            .reply(200, { ok: true });
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const result = await keymaster.removeDmailAttachment(mockDmailId, mockName);
+
+        expect(result).toBe(true);
+    });
+
+    it('should throw exception on removeDmailAttachment server error', async () => {
+        nock(KeymasterURL)
+            .delete(`${Endpoints.dmail}/${mockDmailId}/attachments/${mockName}`)
+            .reply(500, ServerError);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+
+        try {
+            await keymaster.removeDmailAttachment(mockDmailId, mockName);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(ServerError.message);
+        }
+    });
+});
+
+describe('listDmailAttachments', () => {
+    const mockDmailId = 'dmail3';
+    const mockAttachments = { item1: 'item1', item2: 'item2' };
+
+    it('should list vault items', async () => {
+        nock(KeymasterURL)
+            .get(`${Endpoints.dmail}/${mockDmailId}/attachments`)
+            .reply(200, { attachments: mockAttachments });
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const items = await keymaster.listDmailAttachments(mockDmailId);
+
+        expect(items).toStrictEqual(mockAttachments);
+    });
+
+    it('should throw exception on listDmailAttachments server error', async () => {
+        nock(KeymasterURL)
+            .get(`${Endpoints.dmail}/${mockDmailId}/attachments`)
+            .reply(500, ServerError);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+
+        try {
+            await keymaster.listDmailAttachments(mockDmailId);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(ServerError.message);
+        }
+    });
+});
+
+describe('getDmailAttachment', () => {
+    const mockVaultId = 'vault7';
+    const mockName = 'mockName';
+    const mockData = Buffer.from('mockData');
+
+    it('should return attachment data', async () => {
+        nock(KeymasterURL)
+            .get(`${Endpoints.dmail}/${mockVaultId}/attachments/${mockName}`)
+            .reply(200, mockData);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const data = await keymaster.getDmailAttachment(mockVaultId, mockName);
+
+        expect(data).toStrictEqual(mockData);
+    });
+
+    it('should return null when missing data', async () => {
+        nock(KeymasterURL)
+            .get(`${Endpoints.dmail}/${mockVaultId}/attachments/${mockName}`)
+            .reply(200);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const data = await keymaster.getDmailAttachment(mockVaultId, mockName);
+
+        expect(data).toStrictEqual(null);
+    });
+
+    it('should return null on 404 not found', async () => {
+        nock(KeymasterURL)
+            .get(`${Endpoints.dmail}/${mockVaultId}/attachments/${mockName}`)
+            .reply(404);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const data = await keymaster.getDmailAttachment(mockVaultId, mockName);
+
+        expect(data).toStrictEqual(null);
+    });
+
+    it('should throw exception on getDmailAttachment server error', async () => {
+        nock(KeymasterURL)
+            .get(`${Endpoints.dmail}/${mockVaultId}/attachments/${mockName}`)
+            .reply(500, ServerError);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+
+        try {
+            await keymaster.getDmailAttachment(mockVaultId, mockName);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(ServerError.message);
+        }
+    });
+});
+
 describe('importDmail', () => {
     it('should import dmail DID', async () => {
         nock(KeymasterURL)

--- a/tests/keymaster/dmail.test.ts
+++ b/tests/keymaster/dmail.test.ts
@@ -301,7 +301,7 @@ describe('listDmail', () => {
 
         const mockDocument = Buffer.from('This is a mock binary document 1.', 'utf-8');
         const mockName = 'mockDocument1.txt';
-        const ok = await keymaster.addGroupVaultItem(did, mockName, mockDocument);
+        const ok = await keymaster.addDmailAttachment(did, mockName, mockDocument);
         expect(ok).toBe(true);
 
         const dmails = await keymaster.listDmail();
@@ -355,7 +355,7 @@ describe('getDmailMessage', () => {
         expect(dmail).toStrictEqual(mock);
     });
 
-    it('should retrieve null if DID is not a GroupVault', async () => {
+    it('should retrieve null if DID is not a dmail', async () => {
         const alice = await keymaster.createId('Alice');
         const dmail = await keymaster.getDmailMessage(alice);
 
@@ -507,5 +507,88 @@ describe('importDmail', () => {
 
         const ok = await keymaster.importDmail(alice);
         expect(ok).toBe(false);
+    });
+});
+
+describe('addDmailAttachment', () => {
+    const mockDocument = Buffer.from('This is a mock binary document 11.', 'utf-8');
+
+    it('should add an attachment to the dmail', async () => {
+        await keymaster.createId('Alice');
+        await keymaster.createId('Bob');
+        const mock1: DmailMessage = {
+            to: ['Alice'],
+            cc: [],
+            subject: 'Test Dmail 11',
+            body: 'This is a test dmail message 11.',
+        };
+
+        const did = await keymaster.createDmail(mock1);
+        const mockName = 'mockDocument11.txt';
+
+        const ok = await keymaster.addDmailAttachment(did, mockName, mockDocument);
+        expect(ok).toBe(true);
+    });
+
+    it('should throw an exception if invalid attachment name', async () => {
+        await keymaster.createId('Alice');
+        await keymaster.createId('Bob');
+        const mock1: DmailMessage = {
+            to: ['Alice'],
+            cc: [],
+            subject: 'Test Dmail 111',
+            body: 'This is a test dmail message 111.',
+        };
+
+        const did = await keymaster.createDmail(mock1);
+
+        try {
+            await keymaster.addDmailAttachment(did, 'dmail', mockDocument);
+            throw new ExpectedExceptionError();
+        } catch (error: any) {
+            expect(error.message).toBe('Invalid parameter: Cannot add attachment with reserved name "dmail"');
+        }
+    });
+});
+
+describe('removeDmailAttachment', () => {
+    const mockDocument = Buffer.from('This is a mock binary document 1.', 'utf-8');
+
+    it('should remove an attachment to the dmail', async () => {
+        await keymaster.createId('Alice');
+        await keymaster.createId('Bob');
+        const mock1: DmailMessage = {
+            to: ['Alice'],
+            cc: [],
+            subject: 'Test Dmail 12',
+            body: 'This is a test dmail message 12.',
+        };
+
+        const did = await keymaster.createDmail(mock1);
+        const mockName = 'mockDocument1.txt';
+
+        await keymaster.addDmailAttachment(did, mockName, mockDocument);
+        const ok = await keymaster.removeDmailAttachment(did, mockName);
+        expect(ok).toBe(true);
+    });
+
+    it('should throw an exception if invalid attachment name', async () => {
+        await keymaster.createId('Alice');
+        await keymaster.createId('Bob');
+        const mock1: DmailMessage = {
+            to: ['Alice'],
+            cc: [],
+            subject: 'Test Dmail 13',
+            body: 'This is a test dmail message 13.',
+        };
+
+        const did = await keymaster.createDmail(mock1);
+
+        try {
+            await keymaster.removeDmailAttachment(did, 'dmail');
+            throw new ExpectedExceptionError();
+        } catch (error: any) {
+            expect(error.message).toBe('Invalid parameter: Cannot remove attachment with reserved name "dmail"');
+        }
     });
 });

--- a/tests/keymaster/dmail.test.ts
+++ b/tests/keymaster/dmail.test.ts
@@ -299,7 +299,7 @@ describe('listDmail', () => {
 
         const did = await keymaster.createDmail(mock);
 
-        const mockDocument = Buffer.from('This is a mock binary document 1.', 'utf-8');
+        const mockDocument = Buffer.from('This is a mock binary document 52.', 'utf-8');
         const mockName = 'mockDocument1.txt';
         const ok = await keymaster.addDmailAttachment(did, mockName, mockDocument);
         expect(ok).toBe(true);
@@ -310,7 +310,7 @@ describe('listDmail', () => {
         expect(dmails[did]).toBeDefined();
         expect(dmails[did].attachments).toBeDefined();
         expect(dmails[did].attachments[mockName]).toBeDefined();
-        expect(dmails[did].attachments[mockName].bytes).toBe(33);
+        expect(dmails[did].attachments[mockName].bytes).toBe(34);
         expect(dmails[did].attachments[mockName].type).toBe('text/plain');
     });
 
@@ -552,7 +552,7 @@ describe('addDmailAttachment', () => {
 });
 
 describe('removeDmailAttachment', () => {
-    const mockDocument = Buffer.from('This is a mock binary document 1.', 'utf-8');
+    const mockDocument = Buffer.from('This is a mock binary document 12.', 'utf-8');
 
     it('should remove an attachment to the dmail', async () => {
         await keymaster.createId('Alice');
@@ -590,5 +590,27 @@ describe('removeDmailAttachment', () => {
         } catch (error: any) {
             expect(error.message).toBe('Invalid parameter: Cannot remove attachment with reserved name "dmail"');
         }
+    });
+});
+
+describe('getDmailAttachment', () => {
+    const mockDocument = Buffer.from('This is a mock binary document 14.', 'utf-8');
+
+    it('should remove an attachment to the dmail', async () => {
+        await keymaster.createId('Alice');
+        await keymaster.createId('Bob');
+        const mock1: DmailMessage = {
+            to: ['Alice'],
+            cc: [],
+            subject: 'Test Dmail 14',
+            body: 'This is a test dmail message 14.',
+        };
+
+        const did = await keymaster.createDmail(mock1);
+        const mockName = 'mockDocument14.txt';
+        await keymaster.addDmailAttachment(did, mockName, mockDocument);
+
+        const attachment = await keymaster.getDmailAttachment(did, mockName);
+        expect(attachment).toStrictEqual(mockDocument);
     });
 });

--- a/tests/keymaster/dmail.test.ts
+++ b/tests/keymaster/dmail.test.ts
@@ -287,6 +287,33 @@ describe('listDmail', () => {
         expect(dmails[did].tags).toStrictEqual(['inbox']);
     });
 
+    it('should include attachments', async () => {
+        const alice = await keymaster.createId('Alice');
+        const bob = await keymaster.createId('Bob');
+        const mock: DmailMessage = {
+            to: [alice],
+            cc: [bob],
+            subject: 'Test Dmail 52',
+            body: 'This is a test dmail message 52.',
+        };
+
+        const did = await keymaster.createDmail(mock);
+
+        const mockDocument = Buffer.from('This is a mock binary document 1.', 'utf-8');
+        const mockName = 'mockDocument1.txt';
+        const ok = await keymaster.addGroupVaultItem(did, mockName, mockDocument);
+        expect(ok).toBe(true);
+
+        const dmails = await keymaster.listDmail();
+
+        expect(dmails).toBeDefined();
+        expect(dmails[did]).toBeDefined();
+        expect(dmails[did].attachments).toBeDefined();
+        expect(dmails[did].attachments[mockName]).toBeDefined();
+        expect(dmails[did].attachments[mockName].bytes).toBe(33);
+        expect(dmails[did].attachments[mockName].type).toBe('text/plain');
+    });
+
     it('should retrieve an empty set when no dmails', async () => {
         await keymaster.createId('Alice');
         const dmails = await keymaster.listDmail();

--- a/tests/keymaster/dmail.test.ts
+++ b/tests/keymaster/dmail.test.ts
@@ -596,7 +596,7 @@ describe('removeDmailAttachment', () => {
 describe('getDmailAttachment', () => {
     const mockDocument = Buffer.from('This is a mock binary document 14.', 'utf-8');
 
-    it('should remove an attachment to the dmail', async () => {
+    it('should retrieve an attachment', async () => {
         await keymaster.createId('Alice');
         await keymaster.createId('Bob');
         const mock1: DmailMessage = {


### PR DESCRIPTION
This PR adds full support for Dmail attachments across the stack, including tests, API endpoints, client implementations, and UI integration.

-    Introduces new server routes and client methods to list, add, remove, and retrieve attachments.
-    Extends the Keymaster core and client packages with attachment operations.
-    Updates tests and the React UI to cover and display Dmail attachments.
