### PR TITLE
feat: Adds dmail revocation

### DIFF
--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -3215,7 +3215,11 @@ export default class Keymaster implements KeymasterInterface {
         return items;
     }
 
-    async addDmailAttachment(did: string, name: string, buffer: Buffer): Promise<boolean> {
+    async addDmailAttachment(
+        did: string,
+        name: string,
+        buffer: Buffer
+    ): Promise<boolean> {
         if (name === DmailTags.DMAIL) {
             throw new InvalidParameterError('Cannot add attachment with reserved name "dmail"');
         }
@@ -3223,7 +3227,10 @@ export default class Keymaster implements KeymasterInterface {
         return this.addGroupVaultItem(did, name, buffer);
     }
 
-    async removeDmailAttachment(did: string, name: string): Promise<boolean> {
+    async removeDmailAttachment(
+        did: string,
+        name: string
+    ): Promise<boolean> {
         if (name === DmailTags.DMAIL) {
             throw new InvalidParameterError('Cannot remove attachment with reserved name "dmail"');
         }
@@ -3231,7 +3238,10 @@ export default class Keymaster implements KeymasterInterface {
         return this.removeGroupVaultItem(did, name);
     }
 
-    async getDmailAttachment(did: string, name: string): Promise<Buffer | null> {
+    async getDmailAttachment(
+        did: string,
+        name: string
+    ): Promise<Buffer | null> {
         return this.getGroupVaultItem(did, name);
     }
 

--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -406,11 +406,16 @@ export interface KeymasterInterface {
     // Dmail
     createDmail(message: DmailMessage, options?: CreateAssetOptions): Promise<string>;
     updateDmail(did: string, message: DmailMessage): Promise<boolean>;
+    fileDmail(did: string, tags: string[]): Promise<boolean>
     removeDmail(did: string): Promise<boolean>;
     importDmail(did: string): Promise<boolean>;
     getDmailMessage(did: string): Promise<DmailMessage | null>;
     listDmail(): Promise<Record<string, DmailItem>>;
     sendDmail(did: string): Promise<string | null>;
+    addDmailAttachment(did: string, name: string, buffer: Buffer): Promise<boolean>;
+    removeDmailAttachment(did: string, name: string): Promise<boolean>;
+    listDmailAttachments(did: string): Promise<Record<string, any>>;
+    getDmailAttachment(did: string, name: string): Promise<Buffer | null>;
 
     // Notices
     createNotice(message: NoticeMessage, options: CreateAssetOptions): Promise<string>;

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -1107,6 +1107,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
             setSelectedDmailDID('');
             setDmailSubject('');
             setDmailBody('');
+            setDmailTo('');
             setDmailCc('');
             setDmailAttachments({});
             setDmailDID('');
@@ -1373,6 +1374,18 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
             const tags = dmailList[selectedDmailDID]?.tags || [];
             await keymaster.fileDmail(selectedDmailDID, tags.filter(tag => tag !== DmailTags.DELETED));
             refreshDmail();
+        } catch (error) {
+            showError(error);
+        }
+    }
+
+    async function revokeDmail() {
+        try {
+            if (window.confirm(`Revoke Dmail?`)) {
+                await keymaster.removeDmail(dmailDID);
+                await keymaster.revokeDID(dmailDID);
+                refreshDmail();
+            }
         } catch (error) {
             showError(error);
         }
@@ -4314,6 +4327,11 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                             Delete
                                                         </Button>
                                                     </Grid>
+                                                    <Grid item>
+                                                        <Button variant="contained" color="primary" onClick={editDmail}>
+                                                            Edit
+                                                        </Button>
+                                                    </Grid>
                                                 </Grid>
                                             </Box>
                                         }
@@ -4607,6 +4625,11 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                     <Grid item>
                                                         <Button variant="contained" color="primary" onClick={sendDmail} disabled={!dmailDID}>
                                                             Send Dmail
+                                                        </Button>
+                                                    </Grid>
+                                                    <Grid item>
+                                                        <Button variant="contained" color="primary" onClick={revokeDmail} disabled={!dmailDID}>
+                                                            Revoke Dmail...
                                                         </Button>
                                                     </Grid>
                                                 </Grid>

--- a/services/keymaster/client/src/KeymasterUI.js
+++ b/services/keymaster/client/src/KeymasterUI.js
@@ -1107,6 +1107,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
             setSelectedDmailDID('');
             setDmailSubject('');
             setDmailBody('');
+            setDmailTo('');
             setDmailCc('');
             setDmailAttachments({});
             setDmailDID('');
@@ -1373,6 +1374,18 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
             const tags = dmailList[selectedDmailDID]?.tags || [];
             await keymaster.fileDmail(selectedDmailDID, tags.filter(tag => tag !== DmailTags.DELETED));
             refreshDmail();
+        } catch (error) {
+            showError(error);
+        }
+    }
+
+    async function revokeDmail() {
+        try {
+            if (window.confirm(`Revoke Dmail?`)) {
+                await keymaster.removeDmail(dmailDID);
+                await keymaster.revokeDID(dmailDID);
+                refreshDmail();
+            }
         } catch (error) {
             showError(error);
         }
@@ -4314,6 +4327,11 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                             Delete
                                                         </Button>
                                                     </Grid>
+                                                    <Grid item>
+                                                        <Button variant="contained" color="primary" onClick={editDmail}>
+                                                            Edit
+                                                        </Button>
+                                                    </Grid>
                                                 </Grid>
                                             </Box>
                                         }
@@ -4607,6 +4625,11 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                     <Grid item>
                                                         <Button variant="contained" color="primary" onClick={sendDmail} disabled={!dmailDID}>
                                                             Send Dmail
+                                                        </Button>
+                                                    </Grid>
+                                                    <Grid item>
+                                                        <Button variant="contained" color="primary" onClick={revokeDmail} disabled={!dmailDID}>
+                                                            Revoke Dmail...
                                                         </Button>
                                                     </Grid>
                                                 </Grid>


### PR DESCRIPTION
Implements Dmail revocation controls in the UI and extends the Keymaster API with new Dmail attachment methods.

-    UI: Clears the “To” field on reset, adds Edit and Revoke Dmail buttons, and implements a revokeDmail handler.
-    API: Adds fileDmail and attachment-related signatures in KeymasterInterface, and implements add/remove/get attachment in the Keymaster class.
