### PR TITLE
feat: Adds ability to mark dmails as read or unread

### DIFF
--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -74,6 +74,7 @@ export enum DmailTags {
     SENT = 'sent',
     ARCHIVED = 'archived',
     DELETED = 'deleted',
+    UNREAD = 'unread',
 }
 
 export enum PollTags {
@@ -3252,7 +3253,7 @@ export default class Keymaster implements KeymasterInterface {
             return false;
         }
 
-        return this.fileDmail(did, [DmailTags.INBOX]);
+        return this.fileDmail(did, [DmailTags.INBOX, DmailTags.UNREAD]);
     }
 
     async verifyDIDList(didList: string[]): Promise<string[]> {

--- a/tests/keymaster/dmail.test.ts
+++ b/tests/keymaster/dmail.test.ts
@@ -284,7 +284,7 @@ describe('listDmail', () => {
         expect(dmails[did].message).toStrictEqual(mock);
         expect(dmails[did].to).toStrictEqual(['Alice']);
         expect(dmails[did].cc).toStrictEqual([bob]);
-        expect(dmails[did].tags).toStrictEqual(['inbox']);
+        expect(dmails[did].tags).toStrictEqual([DmailTags.INBOX, DmailTags.UNREAD]);
     });
 
     it('should include attachments', async () => {
@@ -499,7 +499,7 @@ describe('importDmail', () => {
         expect(ok).toBe(true);
 
         const dmails = await keymaster.listDmail();
-        expect(dmails[did].tags).toStrictEqual(['inbox']);
+        expect(dmails[did].tags).toStrictEqual([DmailTags.INBOX, DmailTags.UNREAD]);
     });
 
     it('should return false for invalid dmail', async () => {


### PR DESCRIPTION
Adds the ability to mark dmails as read or unread by introducing a new UNREAD tag, updating backend defaults, adjusting tests, and extending the UI with toggle buttons and styling for unread items.

-    Introduce DmailTags.UNREAD in both client and package enums
-    Default new/incoming dmails to include the UNREAD tag
-    Update tests to expect the new tag and extend UI with mark-as-read/unread controls
