### PR TITLE
fix: Adds dmail attachment forwarding

### DIFF
--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -4694,14 +4694,21 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                             />
                                         </Grid>
                                         {!dmailDID &&
-                                            <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
-                                                <Grid item>
-                                                    <Button variant="contained" color="primary" onClick={createDmail} disabled={!registry}>
-                                                        Create Dmail
-                                                    </Button>
+                                            <Grid item>
+                                                <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
+                                                    <Grid item>
+                                                        <Button variant="contained" color="primary" onClick={createDmail} disabled={!registry}>
+                                                            Create Dmail
+                                                        </Button>
+                                                    </Grid>
+                                                    <Grid item>
+                                                        <RegistrySelect />
+                                                    </Grid>
                                                 </Grid>
                                                 <Grid item>
-                                                    <RegistrySelect />
+                                                    <Button variant="contained" color="primary" onClick={clearSendDmail}>
+                                                        Clear Dmail
+                                                    </Button>
                                                 </Grid>
                                             </Grid>
                                         }

--- a/services/keymaster/client/src/KeymasterUI.js
+++ b/services/keymaster/client/src/KeymasterUI.js
@@ -159,6 +159,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
     const [dmailAttachments, setDmailAttachments] = useState({});
     const [dmailSortBy, setDmailSortBy] = useState('date');
     const [dmailSortOrder, setDmailSortOrder] = useState('desc');
+    const [dmailForwarding, setDmailForwarding] = useState('');
     const [assetsTab, setAssetsTab] = useState('');
     const [imageList, setImageList] = useState(null);
     const [selectedImageName, setSelectedImageName] = useState('');
@@ -1115,13 +1116,8 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
         try {
             await keymaster.refreshNotices();
             await refreshInbox();
+            await clearSendDmail();
             setSelectedDmailDID('');
-            setDmailSubject('');
-            setDmailBody('');
-            setDmailTo('');
-            setDmailCc('');
-            setDmailAttachments({});
-            setDmailDID('');
         } catch (error) {
             showError(error);
         }
@@ -1230,6 +1226,16 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
         try {
             const did = await keymaster.createDmail(dmail, { registry });
             setDmailDID(did);
+
+            if (dmailForwarding) {
+                const attachments = await keymaster.listDmailAttachments(dmailForwarding) || {};
+                for (const name of Object.keys(attachments)) {
+                    const buffer = await keymaster.getDmailAttachment(dmailForwarding, name);
+                    await keymaster.addDmailAttachment(did, name, buffer);
+                }
+
+                setDmailAttachments(await keymaster.listDmailAttachments(did) || {});
+            }
         } catch (error) {
             showError(error);
         }
@@ -1411,6 +1417,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
         setDmailSubject('');
         setDmailBody('');
         setDmailAttachments({});
+        setDmailForwarding('');
     }
 
     async function forwardDmail() {
@@ -1418,6 +1425,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
         clearSendDmail();
 
+        setDmailForwarding(selectedDmailDID);
         setDmailSubject(`Fwd: ${selectedDmail.message.subject}`);
         setDmailBody(`On ${selectedDmail.date} ${selectedDmail.sender} wrote:\n\n${selectedDmail.message.body}`);
         setDmailTab('send');
@@ -2763,8 +2771,8 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
         const direction = dmailSortOrder;
 
         const compare = (a, b) => {
-            const [_, itemA] = a;
-            const [__, itemB] = b;
+            const itemA = a[1];
+            const itemB = b[1];
             let valA, valB;
             if (column === 'sender') {
                 valA = itemA.sender?.toLowerCase() || '';
@@ -4694,14 +4702,21 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                             />
                                         </Grid>
                                         {!dmailDID &&
-                                            <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
-                                                <Grid item>
-                                                    <Button variant="contained" color="primary" onClick={createDmail} disabled={!registry}>
-                                                        Create Dmail
-                                                    </Button>
+                                            <Grid item>
+                                                <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
+                                                    <Grid item>
+                                                        <Button variant="contained" color="primary" onClick={createDmail} disabled={!registry}>
+                                                            Create Dmail
+                                                        </Button>
+                                                    </Grid>
+                                                    <Grid item>
+                                                        <RegistrySelect />
+                                                    </Grid>
                                                 </Grid>
                                                 <Grid item>
-                                                    <RegistrySelect />
+                                                    <Button variant="contained" color="primary" onClick={clearSendDmail}>
+                                                        Clear Dmail
+                                                    </Button>
                                                 </Grid>
                                             </Grid>
                                         }


### PR DESCRIPTION
This PR adds the ability to forward attachments when forwarding a dmail

-    Adds dmailForwarding state and populates it when forwarding a message
-    Implements copying of attachments in createDmail if dmailForwarding is set
-    Adds a “Clear Dmail” button in the send UI and calls clearSendDmail after refresh
-    Refactors the compare function to use direct array indexing instead of unused variables
