### PR TITLE
feat: Adds ephemeral dmail

### DIFF
--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -1245,7 +1245,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                 return;
             }
 
-            const validUntilDate = new Date(dmailValidUntil);
+            const validUntilDate = new Date(dmailValidUntil + "T00:00:00Z");
             if (isNaN(validUntilDate.getTime())) {
                 showError("Invalid date format for valid until.");
                 return;
@@ -1255,9 +1255,9 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                 showError("Valid until date must be in the future.");
                 return;
             }
-
-            // Set validUntil to start of day of the next day
-            validUntilDate.setDate(validUntilDate.getDate() + 1);
+            // Set validUntil to start of day of the next day (UTC-safe)
+            validUntilDate.setUTCDate(validUntilDate.getUTCDate() + 1);
+            validUntilDate.setUTCHours(0, 0, 0, 0);
             validUntil = validUntilDate.toISOString();
         }
 

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -1237,8 +1237,33 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
         const dmail = getDmailInputOrError();
         if (!dmail) return;
 
+        let validUntil;
+
+        if (registry === 'hyperswarm' && dmailEphemeral) {
+            if (!dmailValidUntil) {
+                showError("Please set a valid until date for ephemeral Dmail.");
+                return;
+            }
+
+            const validUntilDate = new Date(dmailValidUntil);
+            if (isNaN(validUntilDate.getTime())) {
+                showError("Invalid date format for valid until.");
+                return;
+            }
+
+            if (validUntilDate <= new Date()) {
+                showError("Valid until date must be in the future.");
+                return;
+            }
+
+            // Set validUntil to start of day of the next day
+            validUntilDate.setDate(validUntilDate.getDate() + 1);
+            //validUntilDate.setHours(0, 0, 0, 0);
+            validUntil = validUntilDate.toISOString();
+        }
+
         try {
-            const did = await keymaster.createDmail(dmail, { registry });
+            const did = await keymaster.createDmail(dmail, { registry, validUntil });
             setDmailDID(did);
 
             if (dmailForwarding) {

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -1258,7 +1258,6 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
 
             // Set validUntil to start of day of the next day
             validUntilDate.setDate(validUntilDate.getDate() + 1);
-            //validUntilDate.setHours(0, 0, 0, 0);
             validUntil = validUntilDate.toISOString();
         }
 

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -165,6 +165,8 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
     const [dmailCc, setDmailCc] = useState('');
     const [dmailToList, setDmailToList] = useState([]);
     const [dmailCcList, setDmailCcList] = useState([]);
+    const [dmailEphemeral, setDmailEphemeral] = useState(false);
+    const [dmailValidUntil, setDmailValidUntil] = useState('');
     const [dmailDID, setDmailDID] = useState('');
     const [dmailAttachments, setDmailAttachments] = useState({});
     const [dmailSortBy, setDmailSortBy] = useState('date');
@@ -1430,6 +1432,8 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
         setDmailBody('');
         setDmailAttachments({});
         setDmailForwarding('');
+        setDmailEphemeral(false);
+        setDmailValidUntil('');
     }
 
     async function forwardDmail() {
@@ -4758,6 +4762,27 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                         Create Dmail
                                                     </Button>
                                                     <RegistrySelect />
+                                                    <FormControlLabel
+                                                        control={
+                                                            <Checkbox
+                                                                checked={dmailEphemeral}
+                                                                onChange={e => setDmailEphemeral(e.target.checked)}
+                                                                color="primary"
+                                                            />
+                                                        }
+                                                        label="ephemeral"
+                                                        sx={{ ml: 2 }}
+                                                        disabled={registry !== 'hyperswarm'}
+                                                    />
+                                                    <TextField
+                                                        label="Valid Until"
+                                                        type="date"
+                                                        value={dmailValidUntil}
+                                                        onChange={e => setDmailValidUntil(e.target.value)}
+                                                        InputLabelProps={{ shrink: true }}
+                                                        sx={{ ml: 2, minWidth: 180 }}
+                                                        disabled={!dmailEphemeral || registry !== 'hyperswarm'}
+                                                    />
                                                 </Box>
                                                 <Button variant="contained" color="primary" onClick={clearSendDmail}>
                                                     Clear Dmail

--- a/services/keymaster/client/src/KeymasterUI.js
+++ b/services/keymaster/client/src/KeymasterUI.js
@@ -1245,7 +1245,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                 return;
             }
 
-            const validUntilDate = new Date(dmailValidUntil);
+            const validUntilDate = new Date(dmailValidUntil + "T00:00:00Z");
             if (isNaN(validUntilDate.getTime())) {
                 showError("Invalid date format for valid until.");
                 return;
@@ -1255,9 +1255,9 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                 showError("Valid until date must be in the future.");
                 return;
             }
-
-            // Set validUntil to start of day of the next day
-            validUntilDate.setDate(validUntilDate.getDate() + 1);
+            // Set validUntil to start of day of the next day (UTC-safe)
+            validUntilDate.setUTCDate(validUntilDate.getUTCDate() + 1);
+            validUntilDate.setUTCHours(0, 0, 0, 0);
             validUntil = validUntilDate.toISOString();
         }
 

--- a/services/keymaster/client/src/KeymasterUI.js
+++ b/services/keymaster/client/src/KeymasterUI.js
@@ -165,6 +165,8 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
     const [dmailCc, setDmailCc] = useState('');
     const [dmailToList, setDmailToList] = useState([]);
     const [dmailCcList, setDmailCcList] = useState([]);
+    const [dmailEphemeral, setDmailEphemeral] = useState(false);
+    const [dmailValidUntil, setDmailValidUntil] = useState('');
     const [dmailDID, setDmailDID] = useState('');
     const [dmailAttachments, setDmailAttachments] = useState({});
     const [dmailSortBy, setDmailSortBy] = useState('date');
@@ -1235,8 +1237,32 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
         const dmail = getDmailInputOrError();
         if (!dmail) return;
 
+        let validUntil;
+
+        if (registry === 'hyperswarm' && dmailEphemeral) {
+            if (!dmailValidUntil) {
+                showError("Please set a valid until date for ephemeral Dmail.");
+                return;
+            }
+
+            const validUntilDate = new Date(dmailValidUntil);
+            if (isNaN(validUntilDate.getTime())) {
+                showError("Invalid date format for valid until.");
+                return;
+            }
+
+            if (validUntilDate <= new Date()) {
+                showError("Valid until date must be in the future.");
+                return;
+            }
+
+            // Set validUntil to start of day of the next day
+            validUntilDate.setDate(validUntilDate.getDate() + 1);
+            validUntil = validUntilDate.toISOString();
+        }
+
         try {
-            const did = await keymaster.createDmail(dmail, { registry });
+            const did = await keymaster.createDmail(dmail, { registry, validUntil });
             setDmailDID(did);
 
             if (dmailForwarding) {
@@ -1430,6 +1456,8 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
         setDmailBody('');
         setDmailAttachments({});
         setDmailForwarding('');
+        setDmailEphemeral(false);
+        setDmailValidUntil('');
     }
 
     async function forwardDmail() {
@@ -4758,6 +4786,27 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                         Create Dmail
                                                     </Button>
                                                     <RegistrySelect />
+                                                    <FormControlLabel
+                                                        control={
+                                                            <Checkbox
+                                                                checked={dmailEphemeral}
+                                                                onChange={e => setDmailEphemeral(e.target.checked)}
+                                                                color="primary"
+                                                            />
+                                                        }
+                                                        label="ephemeral"
+                                                        sx={{ ml: 2 }}
+                                                        disabled={registry !== 'hyperswarm'}
+                                                    />
+                                                    <TextField
+                                                        label="Valid Until"
+                                                        type="date"
+                                                        value={dmailValidUntil}
+                                                        onChange={e => setDmailValidUntil(e.target.value)}
+                                                        InputLabelProps={{ shrink: true }}
+                                                        sx={{ ml: 2, minWidth: 180 }}
+                                                        disabled={!dmailEphemeral || registry !== 'hyperswarm'}
+                                                    />
                                                 </Box>
                                                 <Button variant="contained" color="primary" onClick={clearSendDmail}>
                                                     Clear Dmail


### PR DESCRIPTION
This PR adds ephemeral dmail functionality that allows users to create time-limited emails that automatically expire. The feature is specifically implemented for the hyperswarm registry with validation to ensure proper date handling and user experience.

Key changes:

-    Added ephemeral dmail toggle and expiration date selection in the UI
-    Implemented validation logic for ephemeral dmail creation with future date requirements
-    Enhanced the dmail creation process to support time-limited messages
