### PR TITLE
feat: Add dmail contact to names

### DIFF
--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -65,6 +65,7 @@ import {
     MarkEmailUnread,
     Outbox,
     PermIdentity,
+    PersonAdd,
     PictureAsPdf,
     Poll,
     Refresh,
@@ -1579,6 +1580,12 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
     async function clearDmailSearch() {
         setDmailSearchQuery('');
         setDmailSearchResults({});
+    }
+
+    async function addDmailContact(senderDID) {
+        setAliasDID(senderDID);
+        resolveName(senderDID);
+        setTab('names');
     }
 
     async function showMnemonic() {
@@ -4612,7 +4619,16 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                             </TableRow>
                                                             <TableRow>
                                                                 <TableCell><b>From</b></TableCell>
-                                                                <TableCell>{selectedDmail.sender}</TableCell>
+                                                                <TableCell>
+                                                                    {selectedDmail.sender}
+                                                                    {selectedDmail.sender.startsWith('did:') && (
+                                                                        <Tooltip title="Add Contact">
+                                                                            <IconButton onClick={() => addDmailContact(selectedDmail.sender)}>
+                                                                                <PersonAdd />
+                                                                            </IconButton>
+                                                                        </Tooltip>
+                                                                    )}
+                                                                </TableCell>
                                                             </TableRow>
                                                             <TableRow>
                                                                 <TableCell><b>Date</b></TableCell>

--- a/services/keymaster/client/src/KeymasterUI.js
+++ b/services/keymaster/client/src/KeymasterUI.js
@@ -65,6 +65,7 @@ import {
     MarkEmailUnread,
     Outbox,
     PermIdentity,
+    PersonAdd,
     PictureAsPdf,
     Poll,
     Refresh,
@@ -1579,6 +1580,12 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
     async function clearDmailSearch() {
         setDmailSearchQuery('');
         setDmailSearchResults({});
+    }
+
+    async function addDmailContact(senderDID) {
+        setAliasDID(senderDID);
+        resolveName(senderDID);
+        setTab('names');
     }
 
     async function showMnemonic() {
@@ -4612,7 +4619,16 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                                             </TableRow>
                                                             <TableRow>
                                                                 <TableCell><b>From</b></TableCell>
-                                                                <TableCell>{selectedDmail.sender}</TableCell>
+                                                                <TableCell>
+                                                                    {selectedDmail.sender}
+                                                                    {selectedDmail.sender.startsWith('did:') && (
+                                                                        <Tooltip title="Add Contact">
+                                                                            <IconButton onClick={() => addDmailContact(selectedDmail.sender)}>
+                                                                                <PersonAdd />
+                                                                            </IconButton>
+                                                                        </Tooltip>
+                                                                    )}
+                                                                </TableCell>
                                                             </TableRow>
                                                             <TableRow>
                                                                 <TableCell><b>Date</b></TableCell>


### PR DESCRIPTION
This PR adds functionality to allow users to add dmail senders as contacts directly from the dmail interface. The feature provides a convenient way to quickly add contacts from received messages.

-    Added a new addDmailContact function that sets up a sender's DID as a contact and navigates to the names tab
-    Added a "PersonAdd" icon button next to sender information in the dmail view
-    The contact addition is only shown for senders with DID identifiers
