### PR TITLE
feat: Adds custom headers to GatekeeperClient

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -216,7 +216,7 @@ services:
       - gatekeeper
       - keymaster
 
-  signet-inscription-mediator:
+  sig-ins-mediator:
     build:
       context: .
       dockerfile: Dockerfile.satoshi-inscription

--- a/packages/gatekeeper/src/gatekeeper-client.ts
+++ b/packages/gatekeeper/src/gatekeeper-client.ts
@@ -15,10 +15,6 @@ import {
     VerifyDbResult,
 } from './types.js';
 
-const axios =
-    (axiosModule as AxiosStatic & { default?: AxiosInstance })?.default ??
-    (axiosModule as AxiosInstance);
-
 const VERSION = '/api/v1';
 
 function throwError(error: AxiosError | any): never {
@@ -30,6 +26,7 @@ function throwError(error: AxiosError | any): never {
 
 export default class GatekeeperClient implements GatekeeperInterface {
     private API: string;
+    private axios: AxiosInstance;
 
     // Factory method
     static async create(options: GatekeeperClientOptions): Promise<GatekeeperClient> {
@@ -39,15 +36,20 @@ export default class GatekeeperClient implements GatekeeperInterface {
     }
 
     constructor() {
+        const axios =
+            (axiosModule as AxiosStatic & { default?: AxiosInstance })?.default ??
+            (axiosModule as AxiosInstance);
+
         this.API = VERSION;
+        this.axios = axios.create();
     }
 
     addCustomHeader(header: string, value: string): void {
-        axios.defaults.headers.common[header] = value;
+        this.axios.defaults.headers.common[header] = value;
     }
 
     removeCustomHeader(header: string): void {
-        delete axios.defaults.headers.common[header];
+        delete this.axios.defaults.headers.common[header];
     }
 
     async connect(options?: GatekeeperClientOptions) {
@@ -106,7 +108,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async listRegistries(): Promise<string[]> {
         try {
-            const response = await axios.get(`${this.API}/registries`);
+            const response = await this.axios.get(`${this.API}/registries`);
             return response.data;
         }
         catch (error) {
@@ -116,7 +118,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async resetDb(): Promise<boolean> {
         try {
-            const response = await axios.get(`${this.API}/db/reset`);
+            const response = await this.axios.get(`${this.API}/db/reset`);
             return response.data;
         }
         catch (error) {
@@ -126,7 +128,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async verifyDb(): Promise<VerifyDbResult> {
         try {
-            const response = await axios.get(`${this.API}/db/verify`);
+            const response = await this.axios.get(`${this.API}/db/verify`);
             return response.data;
         }
         catch (error) {
@@ -136,7 +138,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async isReady(): Promise<boolean> {
         try {
-            const response = await axios.get(`${this.API}/ready`);
+            const response = await this.axios.get(`${this.API}/ready`);
             return response.data;
         }
         catch (error) {
@@ -146,7 +148,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async getVersion(): Promise<number> {
         try {
-            const response = await axios.get(`${this.API}/version`);
+            const response = await this.axios.get(`${this.API}/version`);
             return response.data;
         }
         catch (error) {
@@ -156,7 +158,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async getStatus(): Promise<GetStatusResult> {
         try {
-            const response = await axios.get(`${this.API}/status`);
+            const response = await this.axios.get(`${this.API}/status`);
             return response.data;
         }
         catch (error) {
@@ -166,7 +168,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async createDID(operation: Operation): Promise<string> {
         try {
-            const response = await axios.post(`${this.API}/did`, operation);
+            const response = await this.axios.post(`${this.API}/did`, operation);
             return response.data;
         }
         catch (error) {
@@ -178,11 +180,11 @@ export default class GatekeeperClient implements GatekeeperInterface {
         try {
             if (options) {
                 const queryParams = new URLSearchParams(options as Record<string, string>);
-                const response = await axios.get(`${this.API}/did/${did}?${queryParams.toString()}`);
+                const response = await this.axios.get(`${this.API}/did/${did}?${queryParams.toString()}`);
                 return response.data;
             }
             else {
-                const response = await axios.get(`${this.API}/did/${did}`);
+                const response = await this.axios.get(`${this.API}/did/${did}`);
                 return response.data;
             }
         }
@@ -194,7 +196,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
     // eslint-disable-next-line sonarjs/no-identical-functions
     async updateDID(operation: Operation): Promise<boolean> {
         try {
-            const response = await axios.post(`${this.API}/did`, operation);
+            const response = await this.axios.post(`${this.API}/did`, operation);
             return response.data;
         }
         catch (error) {
@@ -205,7 +207,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
     // eslint-disable-next-line sonarjs/no-identical-functions
     async deleteDID(operation: Operation): Promise<boolean> {
         try {
-            const response = await axios.post(`${this.API}/did`, operation);
+            const response = await this.axios.post(`${this.API}/did`, operation);
             return response.data;
         }
         catch (error) {
@@ -215,7 +217,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async getDIDs(options?: GetDIDOptions): Promise<string[] | MdipDocument[]> {
         try {
-            const response = await axios.post(`${this.API}/dids`, options);
+            const response = await this.axios.post(`${this.API}/dids`, options);
             return response.data;
         }
         catch (error) {
@@ -225,7 +227,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async exportDIDs(dids?: string[]): Promise<GatekeeperEvent[][]> {
         try {
-            const response = await axios.post(`${this.API}/dids/export`, { dids });
+            const response = await this.axios.post(`${this.API}/dids/export`, { dids });
             return response.data;
         }
         catch (error) {
@@ -235,7 +237,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async importDIDs(dids: GatekeeperEvent[][]): Promise<ImportBatchResult> {
         try {
-            const response = await axios.post(`${this.API}/dids/import`, dids);
+            const response = await this.axios.post(`${this.API}/dids/import`, dids);
             return response.data;
         }
         catch (error) {
@@ -245,7 +247,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async exportBatch(dids?: string[]): Promise<GatekeeperEvent[]> {
         try {
-            const response = await axios.post(`${this.API}/batch/export`, { dids });
+            const response = await this.axios.post(`${this.API}/batch/export`, { dids });
             return response.data;
         }
         catch (error) {
@@ -255,7 +257,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async importBatch(batch: GatekeeperEvent[]): Promise<ImportBatchResult> {
         try {
-            const response = await axios.post(`${this.API}/batch/import`, batch);
+            const response = await this.axios.post(`${this.API}/batch/import`, batch);
             return response.data;
         }
         catch (error) {
@@ -265,7 +267,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async removeDIDs(dids: string[]): Promise<boolean> {
         try {
-            const response = await axios.post(`${this.API}/dids/remove`, dids);
+            const response = await this.axios.post(`${this.API}/dids/remove`, dids);
             return response.data;
         }
         catch (error) {
@@ -275,7 +277,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async getQueue(registry: string): Promise<Operation[]> {
         try {
-            const response = await axios.get(`${this.API}/queue/${registry}`);
+            const response = await this.axios.get(`${this.API}/queue/${registry}`);
             return response.data;
         }
         catch (error) {
@@ -285,7 +287,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async clearQueue(registry: string, events: Operation[]): Promise<boolean> {
         try {
-            const response = await axios.post(`${this.API}/queue/${registry}/clear`, events);
+            const response = await this.axios.post(`${this.API}/queue/${registry}/clear`, events);
             return response.data;
         }
         catch (error) {
@@ -295,7 +297,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async processEvents(): Promise<ProcessEventsResult> {
         try {
-            const response = await axios.post(`${this.API}/events/process`);
+            const response = await this.axios.post(`${this.API}/events/process`);
             return response.data;
         }
         catch (error) {
@@ -305,7 +307,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async addJSON(data: object): Promise<string> {
         try {
-            const response = await axios.post(`${this.API}/cas/json`, data);
+            const response = await this.axios.post(`${this.API}/cas/json`, data);
             return response.data;
         }
         catch (error) {
@@ -315,7 +317,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async getJSON(cid: string): Promise<object> {
         try {
-            const response = await axios.get(`${this.API}/cas/json/${cid}`);
+            const response = await this.axios.get(`${this.API}/cas/json/${cid}`);
             return response.data;
         }
         catch (error) {
@@ -325,7 +327,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async addText(data: string): Promise<string> {
         try {
-            const response = await axios.post(`${this.API}/cas/text`, data, {
+            const response = await this.axios.post(`${this.API}/cas/text`, data, {
                 headers: {
                     'Content-Type': 'text/plain'
                 }
@@ -338,7 +340,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async getText(cid: string): Promise<string> {
         try {
-            const response = await axios.get(`${this.API}/cas/text/${cid}`);
+            const response = await this.axios.get(`${this.API}/cas/text/${cid}`);
             return response.data;
         }
         catch (error) {
@@ -348,7 +350,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async addData(data: Buffer): Promise<string> {
         try {
-            const response = await axios.post(`${this.API}/cas/data`, data, {
+            const response = await this.axios.post(`${this.API}/cas/data`, data, {
                 headers: {
                     'Content-Type': 'application/octet-stream'
                 }
@@ -362,7 +364,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async getData(cid: string): Promise<Buffer> {
         try {
-            const response = await axios.get(`${this.API}/cas/data/${cid}`, {
+            const response = await this.axios.get(`${this.API}/cas/data/${cid}`, {
                 responseType: 'arraybuffer'
             });
             return Buffer.from(response.data);
@@ -382,7 +384,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
             const url = block
                 ? `${this.API}/block/${registry}/${block}`
                 : `${this.API}/block/${registry}/latest`;
-            const response = await axios.get(url);
+            const response = await this.axios.get(url);
             return response.data;
         } catch (error) {
             throwError(error);
@@ -391,7 +393,7 @@ export default class GatekeeperClient implements GatekeeperInterface {
 
     async addBlock(registry: string, block: BlockInfo): Promise<boolean> {
         try {
-            const response = await axios.post(`${this.API}/block/${registry}`, block);
+            const response = await this.axios.post(`${this.API}/block/${registry}`, block);
             return response.data;
         }
         catch (error) {

--- a/packages/gatekeeper/src/gatekeeper-client.ts
+++ b/packages/gatekeeper/src/gatekeeper-client.ts
@@ -42,6 +42,14 @@ export default class GatekeeperClient implements GatekeeperInterface {
         this.API = VERSION;
     }
 
+    addCustomHeader(header: string, value: string): void {
+        axios.defaults.headers.common[header] = value;
+    }
+
+    removeCustomHeader(header: string): void {
+        delete axios.defaults.headers.common[header];
+    }
+
     async connect(options?: GatekeeperClientOptions) {
         if (options?.url) {
             this.API = `${options.url}${VERSION}`;

--- a/tests/gatekeeper/client.test.ts
+++ b/tests/gatekeeper/client.test.ts
@@ -1,5 +1,4 @@
 import nock from 'nock';
-import axios from 'axios';
 import GatekeeperClient from '@mdip/gatekeeper/client';
 import { ExpectedExceptionError } from '@mdip/common/errors';
 

--- a/tests/gatekeeper/client.test.ts
+++ b/tests/gatekeeper/client.test.ts
@@ -900,23 +900,26 @@ describe('getBlock', () => {
     });
 });
 
+const CustomHeader = 'X-Custom-Header';
+const CustomHeaderValue = 'CustomHeaderValue';
+
 describe('addCustomHeader', () => {
     it('should add a custom header', async () => {
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
-        gatekeeper.addCustomHeader('X-Custom-Header', 'CustomHeaderValue');
+        gatekeeper.addCustomHeader(CustomHeader, CustomHeaderValue);
 
         const headers = axios.defaults.headers.common;
-        expect(headers['X-Custom-Header']).toBe('CustomHeaderValue');
+        expect(headers[CustomHeader]).toBe(CustomHeaderValue);
     });
 });
 
 describe('removeCustomHeader', () => {
     it('should remove a custom header', async () => {
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
-        gatekeeper.addCustomHeader('X-Custom-Header', 'CustomHeaderValue');
-        gatekeeper.removeCustomHeader('X-Custom-Header');
+        gatekeeper.addCustomHeader(CustomHeader, CustomHeaderValue);
+        gatekeeper.removeCustomHeader(CustomHeader);
 
         const headers = axios.defaults.headers.common;
-        expect(headers['X-Custom-Header']).toBeUndefined();
+        expect(headers[CustomHeader]).toBeUndefined();
     });
 });

--- a/tests/gatekeeper/client.test.ts
+++ b/tests/gatekeeper/client.test.ts
@@ -1,4 +1,5 @@
 import nock from 'nock';
+import axios from 'axios';
 import GatekeeperClient from '@mdip/gatekeeper/client';
 import { ExpectedExceptionError } from '@mdip/common/errors';
 
@@ -896,5 +897,26 @@ describe('getBlock', () => {
         catch (error: any) {
             expect(error.message).toBe(ServerError.message);
         }
+    });
+});
+
+describe('addCustomHeader', () => {
+    it('should add a custom header', async () => {
+        const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
+        gatekeeper.addCustomHeader('X-Custom-Header', 'CustomHeaderValue');
+
+        const headers = axios.defaults.headers.common;
+        expect(headers['X-Custom-Header']).toBe('CustomHeaderValue');
+    });
+});
+
+describe('removeCustomHeader', () => {
+    it('should remove a custom header', async () => {
+        const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
+        gatekeeper.addCustomHeader('X-Custom-Header', 'CustomHeaderValue');
+        gatekeeper.removeCustomHeader('X-Custom-Header');
+
+        const headers = axios.defaults.headers.common;
+        expect(headers['X-Custom-Header']).toBeUndefined();
     });
 });

--- a/tests/gatekeeper/client.test.ts
+++ b/tests/gatekeeper/client.test.ts
@@ -908,7 +908,8 @@ describe('addCustomHeader', () => {
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
         gatekeeper.addCustomHeader(CustomHeader, CustomHeaderValue);
 
-        const headers = axios.defaults.headers.common;
+        // Access the private axios instance's headers
+        const headers = gatekeeper['axios'].defaults.headers.common;
         expect(headers[CustomHeader]).toBe(CustomHeaderValue);
     });
 });
@@ -919,7 +920,8 @@ describe('removeCustomHeader', () => {
         gatekeeper.addCustomHeader(CustomHeader, CustomHeaderValue);
         gatekeeper.removeCustomHeader(CustomHeader);
 
-        const headers = axios.defaults.headers.common;
+        // Access the private axios instance's headers
+        const headers = gatekeeper['axios'].defaults.headers.common;
         expect(headers[CustomHeader]).toBeUndefined();
     });
 });

--- a/tests/gatekeeper/client.test.ts
+++ b/tests/gatekeeper/client.test.ts
@@ -5,6 +5,37 @@ import { ExpectedExceptionError } from '@mdip/common/errors';
 const GatekeeperURL = 'http://gatekeeper.org';
 const ServerError = { message: 'Server error' };
 const MockDID = 'did:mock:1234';
+const Endpoints = {
+    ready: '/api/v1/ready',
+    version: '/api/v1/version',
+    status: '/api/v1/status',
+    did: '/api/v1/did',
+    db: {
+        reset: '/api/v1/db/reset',
+        verify: '/api/v1/db/verify',
+    },
+    dids: {
+        list: '/api/v1/dids',
+        export: '/api/v1/dids/export',
+        import: '/api/v1/dids/import',
+        remove: '/api/v1/dids/remove',
+    },
+    batch: {
+        export: '/api/v1/batch/export',
+        import: '/api/v1/batch/import',
+    },
+    registries: '/api/v1/registries',
+    queue: '/api/v1/queue',
+    events: {
+        process: '/api/v1/events/process',
+    },
+    cas: {
+        json: '/api/v1/cas/json',
+        text: '/api/v1/cas/text',
+        data: '/api/v1/cas/data',
+    },
+    block: '/api/v1/block',
+};
 
 const mockConsole = {
     log: () => { },
@@ -16,8 +47,7 @@ const mockConsole = {
 describe('isReady', () => {
     it('should return ready flag', async () => {
         nock(GatekeeperURL)
-            // eslint-disable-next-line
-            .get('/api/v1/ready')
+            .get(Endpoints.ready)
             .reply(200, 'true');
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -28,7 +58,7 @@ describe('isReady', () => {
 
     it('should return false on server error', async () => {
         nock(GatekeeperURL)
-            .get('/api/v1/ready')
+            .get(Endpoints.ready)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -39,7 +69,7 @@ describe('isReady', () => {
 
     it('should wait until ready', async () => {
         nock(GatekeeperURL)
-            .get('/api/v1/ready')
+            .get(Endpoints.ready)
             .reply(200, 'true');
 
         const gatekeeper = await GatekeeperClient.create({
@@ -54,7 +84,7 @@ describe('isReady', () => {
 
     it('should timeout if not ready', async () => {
         nock(GatekeeperURL)
-            .get('/api/v1/ready')
+            .get(Endpoints.ready)
             .reply(200, 'false');
 
         const gatekeeper = await GatekeeperClient.create({
@@ -73,7 +103,7 @@ describe('isReady', () => {
 describe('getVersion', () => {
     it('should return version', async () => {
         nock(GatekeeperURL)
-            .get('/api/v1/version')
+            .get(Endpoints.version)
             .reply(200, '1');
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -84,7 +114,7 @@ describe('getVersion', () => {
 
     it('should throw exception on getVersion server error', async () => {
         nock(GatekeeperURL)
-            .get('/api/v1/version')
+            .get(Endpoints.version)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -102,7 +132,7 @@ describe('getVersion', () => {
 describe('resetDb', () => {
     it('should return reset status', async () => {
         nock(GatekeeperURL)
-            .get('/api/v1/db/reset')
+            .get(Endpoints.db.reset)
             .reply(200, 'true');
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -113,7 +143,7 @@ describe('resetDb', () => {
 
     it('should throw exception on resetDb server error', async () => {
         nock(GatekeeperURL)
-            .get('/api/v1/db/reset')
+            .get(Endpoints.db.reset)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -131,7 +161,7 @@ describe('resetDb', () => {
 describe('verifyDb', () => {
     it('should return verify status', async () => {
         nock(GatekeeperURL)
-            .get('/api/v1/db/verify')
+            .get(Endpoints.db.verify)
             .reply(200, 'true');
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -142,7 +172,7 @@ describe('verifyDb', () => {
 
     it('should throw exception on verifyDb server error', async () => {
         nock(GatekeeperURL)
-            .get('/api/v1/db/verify')
+            .get(Endpoints.db.verify)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -160,7 +190,7 @@ describe('verifyDb', () => {
 describe('getStatus', () => {
     it('should return server status', async () => {
         nock(GatekeeperURL)
-            .get('/api/v1/status')
+            .get(Endpoints.status)
             .reply(200, { uptimeSeconds: 1234 });
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -171,7 +201,7 @@ describe('getStatus', () => {
 
     it('should throw exception on getStatus server error', async () => {
         nock(GatekeeperURL)
-            .get('/api/v1/status')
+            .get(Endpoints.status)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -200,7 +230,7 @@ describe('listRegistries', () => {
 
     it('should throw exception on listRegistries server error', async () => {
         nock(GatekeeperURL)
-            .get('/api/v1/registries')
+            .get(Endpoints.registries)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -218,7 +248,7 @@ describe('listRegistries', () => {
 describe('createDID', () => {
     it('should return a DID', async () => {
         nock(GatekeeperURL)
-            .post('/api/v1/did')
+            .post(Endpoints.did)
             .reply(200, 'did:mock:4321');
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -229,7 +259,7 @@ describe('createDID', () => {
 
     it('should throw exception on createDID server error', async () => {
         nock(GatekeeperURL)
-            .post('/api/v1/did')
+            .post(Endpoints.did)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -249,7 +279,7 @@ describe('resolveDID', () => {
 
     it('should return DID documents', async () => {
         nock(GatekeeperURL)
-            .get(`/api/v1/did/${MockDID}`)
+            .get(`${Endpoints.did}/${MockDID}`)
             .reply(200, mockDocs);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -260,7 +290,7 @@ describe('resolveDID', () => {
 
     it('should return specified DID documents', async () => {
         nock(GatekeeperURL)
-            .get(`/api/v1/did/${MockDID}?version=1&confirm=true`)
+            .get(`${Endpoints.did}/${MockDID}?version=1&confirm=true`)
             .reply(200, mockDocs);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -271,7 +301,7 @@ describe('resolveDID', () => {
 
     it('should throw exception when DID not found', async () => {
         nock(GatekeeperURL)
-            .get(`/api/v1/did/${MockDID}`)
+            .get(`${Endpoints.did}/${MockDID}`)
             .reply(404, { message: 'DID not found' });
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -289,7 +319,7 @@ describe('resolveDID', () => {
 describe('updateDID', () => {
     it('should return update status', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/did`)
+            .post(Endpoints.did)
             .reply(200, 'true');
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -300,7 +330,7 @@ describe('updateDID', () => {
 
     it('should throw exception on updateDID server error', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/did`)
+            .post(Endpoints.did)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -318,7 +348,7 @@ describe('updateDID', () => {
 describe('deleteDID', () => {
     it('should return delete status', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/did`)
+            .post(Endpoints.did)
             .reply(200, 'true');
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -329,7 +359,7 @@ describe('deleteDID', () => {
 
     it('should throw exception on getDIDs server error', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/did`)
+            .post(Endpoints.did)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -347,7 +377,7 @@ describe('deleteDID', () => {
 describe('getDIDs', () => {
     it('should return DID list', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/dids`)
+            .post(Endpoints.dids.list)
             .reply(200, []);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -358,7 +388,7 @@ describe('getDIDs', () => {
 
     it('should throw exception on getDIDs server error', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/dids`)
+            .post(Endpoints.dids.list)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -376,7 +406,7 @@ describe('getDIDs', () => {
 describe('removeDIDs', () => {
     it('should return remove status', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/dids/remove`)
+            .post(Endpoints.dids.remove)
             .reply(200, 'true');
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -388,7 +418,7 @@ describe('removeDIDs', () => {
 
     it('should throw exception on removeDIDs server error', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/dids/remove`)
+            .post(Endpoints.dids.remove)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -407,7 +437,7 @@ describe('removeDIDs', () => {
 describe('exportDIDs', () => {
     it('should return exported DID list', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/dids/export`)
+            .post(Endpoints.dids.export)
             .reply(200, []);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -418,7 +448,7 @@ describe('exportDIDs', () => {
 
     it('should throw exception on exportDIDs server error', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/dids/export`)
+            .post(Endpoints.dids.export)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -436,7 +466,7 @@ describe('exportDIDs', () => {
 describe('importDIDs', () => {
     it('should return imported DID results', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/dids/import`)
+            .post(Endpoints.dids.import)
             .reply(200, { queued: 0, processed: 0 });
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -448,7 +478,7 @@ describe('importDIDs', () => {
 
     it('should throw exception on importDIDs server error', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/dids/import`)
+            .post(Endpoints.dids.import)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -467,7 +497,7 @@ describe('importDIDs', () => {
 describe('exportBatch', () => {
     it('should return exported batch', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/batch/export`)
+            .post(Endpoints.batch.export)
             .reply(200, []);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -478,7 +508,7 @@ describe('exportBatch', () => {
 
     it('should throw exception on exportBatch server error', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/batch/export`)
+            .post(Endpoints.batch.export)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -496,7 +526,7 @@ describe('exportBatch', () => {
 describe('importBatch', () => {
     it('should return imported batch results', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/batch/import`)
+            .post(Endpoints.batch.import)
             .reply(200, { queued: 0, processed: 0 });
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -508,7 +538,7 @@ describe('importBatch', () => {
 
     it('should throw exception on importBatch server error', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/batch/import`)
+            .post(Endpoints.batch.import)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -529,7 +559,7 @@ describe('getQueue', () => {
 
     it('should return queue', async () => {
         nock(GatekeeperURL)
-            .get(`/api/v1/queue/${mockRegistry}`)
+            .get(`${Endpoints.queue}/${mockRegistry}`)
             .reply(200, []);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -562,7 +592,7 @@ describe('clearQueue', () => {
 
     it('should return clear status', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/queue/${mockRegistry}/clear`)
+            .post(`${Endpoints.queue}/${mockRegistry}/clear`)
             .reply(200, 'true');
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -576,7 +606,7 @@ describe('clearQueue', () => {
         const mockRegistry = 'local';
 
         nock(GatekeeperURL)
-            .post(`/api/v1/queue/${mockRegistry}/clear`)
+            .post(`${Endpoints.queue}/${mockRegistry}/clear`)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -595,7 +625,7 @@ describe('clearQueue', () => {
 describe('processEvents', () => {
     it('should return process status', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/events/process`)
+            .post(Endpoints.events.process)
             .reply(200, { added: 0, merged: 0, pending: 0 });
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -606,7 +636,7 @@ describe('processEvents', () => {
 
     it('should throw exception on processEvents server error', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/events/process`)
+            .post(Endpoints.events.process)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -627,7 +657,7 @@ describe('addJSON', () => {
 
     it('should return a CID for JSON', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/cas/json`)
+            .post(Endpoints.cas.json)
             .reply(200, mockCID);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -638,7 +668,7 @@ describe('addJSON', () => {
 
     it('should throw exception on addJSON server error', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/cas/json`)
+            .post(Endpoints.cas.json)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -659,7 +689,7 @@ describe('getJSON', () => {
 
     it('should return JSON', async () => {
         nock(GatekeeperURL)
-            .get(`/api/v1/cas/json/${mockCID}`)
+            .get(`${Endpoints.cas.json}/${mockCID}`)
             .reply(200, mockJSON);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -670,7 +700,7 @@ describe('getJSON', () => {
 
     it('should throw exception on getJSON server error', async () => {
         nock(GatekeeperURL)
-            .get(`/api/v1/cas/json/${mockCID}`)
+            .get(`${Endpoints.cas.json}/${mockCID}`)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -691,7 +721,7 @@ describe('addText', () => {
 
     it('should return a CID for text', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/cas/text`)
+            .post(Endpoints.cas.text)
             .reply(200, mockCID);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -702,7 +732,7 @@ describe('addText', () => {
 
     it('should throw exception on addText server error', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/cas/text`)
+            .post(Endpoints.cas.text)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -723,7 +753,7 @@ describe('getText', () => {
 
     it('should return text', async () => {
         nock(GatekeeperURL)
-            .get(`/api/v1/cas/text/${mockCID}`)
+            .get(`${Endpoints.cas.text}/${mockCID}`)
             .reply(200, mockText);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -734,7 +764,7 @@ describe('getText', () => {
 
     it('should throw exception on getText server error', async () => {
         nock(GatekeeperURL)
-            .get(`/api/v1/cas/text/${mockCID}`)
+            .get(`${Endpoints.cas.text}/${mockCID}`)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -755,7 +785,7 @@ describe('addData', () => {
 
     it('should return a CID for data', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/cas/data`)
+            .post(Endpoints.cas.data)
             .reply(200, mockCID);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -766,7 +796,7 @@ describe('addData', () => {
 
     it('should throw exception on addData server error', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/cas/data`)
+            .post(Endpoints.cas.data)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -787,7 +817,7 @@ describe('getData', () => {
 
     it('should return text', async () => {
         nock(GatekeeperURL)
-            .get(`/api/v1/cas/data/${mockCID}`)
+            .get(`${Endpoints.cas.data}/${mockCID}`)
             .reply(200, mockData);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -798,7 +828,7 @@ describe('getData', () => {
 
     it('should throw exception on getData server error', async () => {
         nock(GatekeeperURL)
-            .get(`/api/v1/cas/data/${mockCID}`)
+            .get(`${Endpoints.cas.data}/${mockCID}`)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -819,7 +849,7 @@ describe('addBlock', () => {
 
     it('should add a block', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/block/${mockRegistry}`)
+            .post(`${Endpoints.block}/${mockRegistry}`)
             .reply(200, 'true');
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -830,7 +860,7 @@ describe('addBlock', () => {
 
     it('should throw exception on addBlock server error', async () => {
         nock(GatekeeperURL)
-            .post(`/api/v1/block/${mockRegistry}`)
+            .post(`${Endpoints.block}/${mockRegistry}`)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -851,7 +881,7 @@ describe('getBlock', () => {
 
     it('should return the latest block', async () => {
         nock(GatekeeperURL)
-            .get(`/api/v1/block/${mockRegistry}/latest`)
+            .get(`${Endpoints.block}/${mockRegistry}/latest`)
             .reply(200, mockBlock);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -862,7 +892,7 @@ describe('getBlock', () => {
 
     it('should return the block by hash', async () => {
         nock(GatekeeperURL)
-            .get(`/api/v1/block/${mockRegistry}/${mockBlock.hash}`)
+            .get(`${Endpoints.block}/${mockRegistry}/${mockBlock.hash}`)
             .reply(200, mockBlock);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -873,7 +903,7 @@ describe('getBlock', () => {
 
     it('should return the block by height', async () => {
         nock(GatekeeperURL)
-            .get(`/api/v1/block/${mockRegistry}/${mockBlock.height}`)
+            .get(`${Endpoints.block}/${mockRegistry}/${mockBlock.height}`)
             .reply(200, mockBlock);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -884,7 +914,7 @@ describe('getBlock', () => {
 
     it('should throw exception on getBlock server error', async () => {
         nock(GatekeeperURL)
-            .get(`/api/v1/block/${mockRegistry}/latest`)
+            .get(`${Endpoints.block}/${mockRegistry}/latest`)
             .reply(500, ServerError);
 
         const gatekeeper = await GatekeeperClient.create({ url: GatekeeperURL });
@@ -909,7 +939,7 @@ describe('addCustomHeader', () => {
 
         // Use nock to intercept and inspect the header
         const scope = nock(GatekeeperURL)
-            .get('/api/v1/registries')
+            .get(Endpoints.registries)
             .matchHeader(CustomHeader, CustomHeaderValue)
             .reply(200, ['local', 'hyperswarm']);
 
@@ -926,7 +956,7 @@ describe('removeCustomHeader', () => {
 
         // Use nock to intercept and ensure the header is not present
         const scope = nock(GatekeeperURL)
-            .get('/api/v1/registries')
+            .get(Endpoints.registries)
             .matchHeader(CustomHeader, (val) => val === undefined)
             .reply(200, ['local', 'hyperswarm']);
 


### PR DESCRIPTION
This PR adds functionality to the GatekeeperClient to manage custom HTTP headers, allowing users to add and remove headers that will be included in all requests made by the client.

-    Adds addCustomHeader and removeCustomHeader methods to the GatekeeperClient class
-    Includes comprehensive test coverage for the new header management functionality
-    Also shortens docker-compose service name for the signet inscription mediator
