### PR TITLE
feat: Enables wallet metadata

### DIFF
--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -29,7 +29,7 @@ export interface IDInfo {
     owned?: string[];
     dmail?: Record<string, any>;
     notices?: Record<string, any>;
-    [key: string]: unknown; // Catch-all for truly arbitrary fields
+    [key: string]: any; // Allow custom metadata fields
 }
 
 export interface WalletFile {
@@ -38,7 +38,7 @@ export interface WalletFile {
     ids: Record<string, IDInfo>;
     current?: string;
     names?: Record<string, string>;
-    [key: string]: unknown; // Catch-all for truly arbitrary fields
+    [key: string]: any; // Allow custom metadata fields
 }
 
 export interface CheckWalletResult {

--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -29,6 +29,7 @@ export interface IDInfo {
     owned?: string[];
     dmail?: Record<string, any>;
     notices?: Record<string, any>;
+    [key: string]: unknown; // Catch-all for truly arbitrary fields
 }
 
 export interface WalletFile {
@@ -37,6 +38,7 @@ export interface WalletFile {
     ids: Record<string, IDInfo>;
     current?: string;
     names?: Record<string, string>;
+    [key: string]: unknown; // Catch-all for truly arbitrary fields
 }
 
 export interface CheckWalletResult {

--- a/tests/keymaster/wallet.test.ts
+++ b/tests/keymaster/wallet.test.ts
@@ -230,6 +230,19 @@ describe('saveWallet', () => {
 
         expect(testWallet).toStrictEqual(expectedWallet);
     });
+
+    it('should save augmented wallet', async () => {
+        await keymaster.createId('Bob');
+        const wallet = await keymaster.loadWallet();
+
+        wallet.ids['Bob'].icon = 'smiley';
+        wallet.metadata = { foo: 'bar' };
+        await keymaster.saveWallet(wallet, true);
+
+        const wallet2 = await keymaster.loadWallet();
+
+        expect(wallet).toStrictEqual(wallet2);
+    });
 });
 
 describe('decryptMnemonic', () => {

--- a/tests/keymaster/wallet.test.ts
+++ b/tests/keymaster/wallet.test.ts
@@ -341,6 +341,23 @@ describe('recoverWallet', () => {
         expect(wallet).toStrictEqual(recovered);
     });
 
+    it('should recover augmented wallet from seed bank', async () => {
+        await keymaster.createId('Bob');
+        const wallet = await keymaster.loadWallet();
+        const mnemonic = await keymaster.decryptMnemonic();
+
+        wallet.ids['Bob'].icon = 'smiley';
+        wallet.metadata = { foo: 'bar' };
+        await keymaster.saveWallet(wallet, true);
+        await keymaster.backupWallet();
+
+        // Recover wallet from mnemonic
+        await keymaster.newWallet(mnemonic, true);
+        const recovered = await keymaster.recoverWallet();
+
+        expect(wallet).toStrictEqual(recovered);
+    });
+
     it('should recover wallet from backup DID', async () => {
         await keymaster.createId('Bob');
         const wallet = await keymaster.loadWallet();


### PR DESCRIPTION
This PR enables wallet metadata by adding support for arbitrary fields in wallet and ID information structures. The changes allow users to store custom metadata alongside standard wallet data and ensure this metadata persists through save/load and backup/recovery operations.

-    Added catch-all index signatures to support arbitrary metadata fields
-    Added test coverage for saving and recovering wallets with custom metadata
-    Verified metadata persistence across wallet backup and recovery operations
