### PR TITLE
chore: Pinned db images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
 services:
   mongodb:
-    image: mongo:latest
+    image: mongo:8.0
     volumes:
       - ./data/mongodb:/data/db
     ports:
       - 127.0.0.1:27017:27017
 
   redis:
-    image: redis:latest
+    image: redis:8.0.4-alpine
     command: redis-server /usr/local/etc/redis/redis.conf
     volumes:
       - ./data/redis.conf:/usr/local/etc/redis/redis.conf


### PR DESCRIPTION
This PR pins database images to specific versions instead of using the latest tag to improve deployment stability and reproducibility.

-    Pinned MongoDB image from latest to version 8.0
-    Pinned Redis image from latest to version 8.0.4-alpine
