### PR TITLE
ci: add workflow for building android apk when we make a tag

### DIFF
--- a/.github/workflows/android-debug-build-release.yml
+++ b/.github/workflows/android-debug-build-release.yml
@@ -1,0 +1,75 @@
+name: Android Debug APK Attach to Release
+
+permissions:
+  contents: write
+
+on: 
+  push: 
+    tags: ['*']
+
+jobs:
+  build-android-debug:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Use Node 22.15.0
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.15.0'
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Build shared packages
+        run: npm run build
+
+      - name: Install app dependencies
+        working-directory: ./apps/android
+        run: npm ci
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          api-level: 35
+          build-tools: '35.0.0'
+
+      - name: Build Android debug APK
+        working-directory: ./apps/android
+        env:
+          CI: true
+        run: npm run android:build
+
+      - name: Upload debug APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug-artifact
+          path: apps/android/android/app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error
+       
+  create-release:
+    runs-on: ubuntu-latest
+    needs: build-android-debug
+    if: github.ref_type == 'tag'
+    steps:
+      - name: Download debug APK artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: app-debug-artifact
+      
+      # The downloaded artifact will be in the repository root
+      - name: Create Release and Upload APK
+        uses: softprops/action-gh-release@v2.4.1
+        with:
+          files: app-debug.apk
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR creates a new workflow that when a new tag is created, the workflow will run and generate a android .apk based on the tag. It will then attach the .apk to the release if its created only as a artifact. 

If the release does not yet exist it will create a new release with notes and attach the .apk. The release can still be modified before publishing. 