### PR TITLE
chore: Replaced compose dmail icon

### DIFF
--- a/apps/android/package-lock.json
+++ b/apps/android/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mdip-android-demo",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mdip-android-demo",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor-mlkit/barcode-scanning": "^7.3.0",
@@ -8125,21 +8125,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/apps/android/src/components/DmailTab.tsx
+++ b/apps/android/src/components/DmailTab.tsx
@@ -24,7 +24,7 @@ import {
     Inbox,
     Outbox,
     Refresh,
-    Send,
+    Create,
     Tune,
     UploadFile,
     Reply,
@@ -1365,7 +1365,7 @@ const DmailTab: React.FC = () => {
                     variant="scrollable"
                     scrollButtons="auto"
                 >
-                    <Tab label="Compose" value="send"    icon={<Send />} />
+                    <Tab label="Compose" value="send"    icon={<Create />} />
                     <Tab label="Inbox"   value="inbox"   icon={<Inbox />} />
                     <Tab label="Sent"    value="outbox"  icon={<Outbox />} />
                     <Tab label="Drafts"  value="drafts"  icon={<Drafts />} />

--- a/apps/chrome-extension/package-lock.json
+++ b/apps/chrome-extension/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mdip-chrome-extension",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mdip-chrome-extension",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "@emotion/react": "^11.14.0",

--- a/apps/chrome-extension/src/browser/components/DmailTab.tsx
+++ b/apps/chrome-extension/src/browser/components/DmailTab.tsx
@@ -26,7 +26,7 @@ import {
     Inbox,
     Outbox,
     Refresh,
-    Send,
+    Create,
     Tune,
     UploadFile,
     Reply,
@@ -1542,7 +1542,7 @@ const DmailTab: React.FC = () => {
                 variant="scrollable"
                 scrollButtons="auto"
             >
-                <Tab label="Compose" value="send"    icon={<Send />} />
+                <Tab label="Compose" value="send"    icon={<Create />} />
                 <Tab label="Inbox"   value="inbox"   icon={<Inbox />} />
                 <Tab label="Sent"    value="outbox"  icon={<Outbox />} />
                 <Tab label="Drafts"  value="drafts"  icon={<Drafts />} />

--- a/services/gatekeeper/client/src/KeymasterUI.js
+++ b/services/gatekeeper/client/src/KeymasterUI.js
@@ -44,6 +44,7 @@ import {
     BarChart,
     Block,
     Clear,
+    Create,
     Groups,
     Delete,
     Download,
@@ -4443,6 +4444,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                     variant="scrollable"
                                     scrollButtons="auto"
                                 >
+                                    <Tab key="compose" value="compose" label={'Compose'} icon={<Create />} />
                                     <Tab key="inbox" value="inbox" label={'Inbox'} icon={<Inbox />} />
                                     <Tab key="outbox" value="outbox" label={'Outbox'} icon={<Outbox />} />
                                     <Tab key="drafts" value="drafts" label={'Drafts'} icon={<Drafts />} />
@@ -4450,10 +4452,9 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                     <Tab key="trash" value="trash" label={'Trash'} icon={<Delete />} />
                                     <Tab key="all" value="all" label={'All Dmail'} icon={<AllInbox />} />
                                     <Tab key="results" value="results" label={'Results'} icon={<Search />} />
-                                    <Tab key="send" value="send" label={'Send'} icon={<Send />} />
                                 </Tabs>
                             </Box>
-                            {dmailTab !== 'send' &&
+                            {dmailTab !== 'compose' &&
                                 <Box>
                                     <Box>
                                         <TableContainer component={Paper} style={{ maxHeight: '300px', overflow: 'auto' }}>
@@ -4761,7 +4762,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                     </Box>
                                 </Box>
                             }
-                            {dmailTab === 'send' &&
+                            {dmailTab === 'compose' &&
                                 <Box>
                                     <Grid container direction="column" spacing={1}>
                                         <Grid container direction="row" spacing={1} alignItems={'center'}>

--- a/services/keymaster/client/src/KeymasterUI.js
+++ b/services/keymaster/client/src/KeymasterUI.js
@@ -44,6 +44,7 @@ import {
     BarChart,
     Block,
     Clear,
+    Create,
     Groups,
     Delete,
     Download,
@@ -4443,6 +4444,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                     variant="scrollable"
                                     scrollButtons="auto"
                                 >
+                                    <Tab key="compose" value="compose" label={'Compose'} icon={<Create />} />
                                     <Tab key="inbox" value="inbox" label={'Inbox'} icon={<Inbox />} />
                                     <Tab key="outbox" value="outbox" label={'Outbox'} icon={<Outbox />} />
                                     <Tab key="drafts" value="drafts" label={'Drafts'} icon={<Drafts />} />
@@ -4450,10 +4452,9 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                     <Tab key="trash" value="trash" label={'Trash'} icon={<Delete />} />
                                     <Tab key="all" value="all" label={'All Dmail'} icon={<AllInbox />} />
                                     <Tab key="results" value="results" label={'Results'} icon={<Search />} />
-                                    <Tab key="send" value="send" label={'Send'} icon={<Send />} />
                                 </Tabs>
                             </Box>
-                            {dmailTab !== 'send' &&
+                            {dmailTab !== 'compose' &&
                                 <Box>
                                     <Box>
                                         <TableContainer component={Paper} style={{ maxHeight: '300px', overflow: 'auto' }}>
@@ -4761,7 +4762,7 @@ function KeymasterUI({ keymaster, title, challengeDID, encryption }) {
                                     </Box>
                                 </Box>
                             }
-                            {dmailTab === 'send' &&
+                            {dmailTab === 'compose' &&
                                 <Box>
                                     <Grid container direction="column" spacing={1}>
                                         <Grid container direction="row" spacing={1} alignItems={'center'}>


### PR DESCRIPTION
This PR replaces the "Send" icon with a more semantically appropriate "Create" icon for the compose email functionality across multiple platforms. The change improves the user interface by using an icon that better represents the action of composing new messages.

-    Replaced Send icon with Create icon for compose tabs
-    Updated tab values from "send" to "compose" in some components
-    Applied changes consistently across web services and mobile apps
