### PR TITLE
chore: Release 1.4-beta.2

### DIFF
--- a/apps/chrome-extension/package.json
+++ b/apps/chrome-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdip-chrome-extension",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "description": "MDIP Chrome Extension",
   "main": "index.js",
   "scripts": {

--- a/apps/react-wallet/package.json
+++ b/apps/react-wallet/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdip/react-wallet",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "description": "MDIP Android Demo",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keychain",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "type": "module",
   "description": "",
   "private": true,

--- a/packages/cipher/package.json
+++ b/packages/cipher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdip/cipher",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "description": "MDIP cipher lib",
   "type": "module",
   "main": "./dist/cjs/cipher-web.cjs",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdip/common",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "description": "MDIP common",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/packages/gatekeeper/package.json
+++ b/packages/gatekeeper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdip/gatekeeper",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "description": "MDIP Gatekeeper",
   "type": "module",
   "module": "./dist/esm/index.js",

--- a/packages/inscription/package.json
+++ b/packages/inscription/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdip/inscription",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "description": "MDIP Inscription",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/packages/ipfs/package.json
+++ b/packages/ipfs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdip/ipfs",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "description": "MDIP IPFS lib",
   "type": "module",
   "module": "./dist/esm/index.js",

--- a/packages/keymaster/package.json
+++ b/packages/keymaster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mdip/keymaster",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "description": "MDIP Keymaster",
   "type": "module",
   "module": "./dist/esm/index.js",

--- a/services/explorer/package.json
+++ b/services/explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mdip-explorer",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "type": "module",
   "scripts": {
     "start": "npm run build && node server.js",

--- a/services/gatekeeper/client/package.json
+++ b/services/gatekeeper/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatekeeper-client",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.11.0",

--- a/services/gatekeeper/server/package-lock.json
+++ b/services/gatekeeper/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gatekeeper-server",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gatekeeper-server",
-      "version": "1.4.0-beta.1",
+      "version": "1.4.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.5",

--- a/services/gatekeeper/server/package.json
+++ b/services/gatekeeper/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatekeeper-server",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "type": "module",
   "description": "MDIP Gatekeeper REST API server",
   "main": "src/index.js",

--- a/services/keymaster/client/package.json
+++ b/services/keymaster/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keymaster-client",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "private": true,
   "dependencies": {
     "@emotion/react": "^11.11.0",

--- a/services/keymaster/server/package.json
+++ b/services/keymaster/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keymaster-server",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "type": "module",
   "description": "MDIP Keymaster REST API server",
   "main": "src/index.js",

--- a/services/mediators/hyperswarm/package.json
+++ b/services/mediators/hyperswarm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyperswarm-mediator",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "type": "module",
   "description": "MDIP hyperswarm network mediator",
   "main": "src/index.js",

--- a/services/mediators/satoshi-inscription/package.json
+++ b/services/mediators/satoshi-inscription/package.json
@@ -1,6 +1,6 @@
 {
   "name": "inscription-mediator",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "type": "module",
   "description": "MDIP satoshi blockchain mediator",
   "main": "src/index.js",

--- a/services/mediators/satoshi/package.json
+++ b/services/mediators/satoshi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satoshi-mediator",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "type": "module",
   "description": "MDIP satoshi blockchain mediator",
   "main": "src/index.js",

--- a/services/search-server/package.json
+++ b/services/search-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "search-server",
-  "version": "1.4.0-beta.1",
+  "version": "1.4.0-beta.2",
   "type": "module",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
This PR bumps the version number from 1.4.0-beta.1 to 1.4.0-beta.2 across all packages and services in the monorepo, preparing for a beta release.

- Version increment from 1.4.0-beta.1 to 1.4.0-beta.2 across all packages