### PR TITLE
chore: mediators reorg handling

### DIFF
--- a/services/mediators/satoshi-inscription/src/db/abstract-db.ts
+++ b/services/mediators/satoshi-inscription/src/db/abstract-db.ts
@@ -20,6 +20,7 @@ export default abstract class AbstractDB implements MediatorDbInterface {
     protected defaultDb(): MediatorDb {
         return {
             height: 0,
+            hash: '',
             time: '',
             blockCount: 0,
             blocksScanned: 0,

--- a/services/mediators/satoshi-inscription/src/inscription-mediator.ts
+++ b/services/mediators/satoshi-inscription/src/inscription-mediator.ts
@@ -1,4 +1,4 @@
-import BtcClient, {Block, BlockVerbose, BlockTxVerbose} from 'bitcoin-core';
+import BtcClient, {Block, BlockVerbose, BlockHeader, BlockTxVerbose} from 'bitcoin-core';
 import * as bitcoin from 'bitcoinjs-lib';
 import * as ecc from 'tiny-secp256k1';
 import { gunzipSync } from 'zlib';
@@ -61,6 +61,102 @@ async function loadDb(): Promise<MediatorDb> {
     const db = await jsonPersister.loadDb();
 
     return db || newDb;
+}
+
+async function getBlockTxCount(hash: string, header?: BlockHeader): Promise<number> {
+    if (typeof header?.nTx === 'number') {
+        return header.nTx;
+    }
+
+    const block = await btcClient.getBlock(hash, BlockVerbosity.JSON) as Block;
+    return Array.isArray(block.tx) ? block.tx.length : 0;
+}
+
+async function resolveScanStart(blockCount: number): Promise<number> {
+    const db = await loadDb();
+
+    if (!db.hash) {
+        return db.height ? db.height + 1 : config.startBlock;
+    }
+
+    let header: BlockHeader | undefined;
+    try {
+        header = await btcClient.getBlockHeader(db.hash) as BlockHeader;
+    } catch {
+        header = undefined;
+    }
+
+    if ((header?.confirmations ?? 0) > 0) {
+        return db.height + 1;
+    }
+
+    console.log(`Reorg detected at height ${db.height}, rewinding to a confirmed block...`);
+
+    let height = db.height;
+    let hash = db.hash;
+    let txnsToSubtract = 0;
+
+    while (hash && height >= config.startBlock) {
+        let currentHeader: BlockHeader;
+        try {
+            currentHeader = await btcClient.getBlockHeader(hash) as BlockHeader;
+        } catch {
+            break;
+        }
+
+        if ((currentHeader.confirmations ?? 0) > 0) {
+            const resolvedHeight = currentHeader.height ?? height;
+            const resolvedTime = currentHeader.time ? new Date(currentHeader.time * 1000).toISOString() : '';
+            const resolvedHash = hash;
+            const resolvedBlocksPending = blockCount - resolvedHeight;
+            const resolvedTxnsToSubtract = txnsToSubtract;
+            await jsonPersister.updateDb((data) => {
+                data.height = resolvedHeight;
+                data.hash = resolvedHash;
+                data.time = resolvedTime;
+                data.blocksScanned = Math.max(0, resolvedHeight - config.startBlock + 1);
+                data.txnsScanned = Math.max(0, data.txnsScanned - resolvedTxnsToSubtract);
+                data.blockCount = blockCount;
+                data.blocksPending = resolvedBlocksPending;
+            });
+            return resolvedHeight + 1;
+        }
+
+        txnsToSubtract += await getBlockTxCount(hash, currentHeader);
+
+        if (!currentHeader.previousblockhash) {
+            break;
+        }
+
+        hash = currentHeader.previousblockhash;
+        height = (currentHeader.height ?? height) - 1;
+    }
+
+    const fallbackHeight = config.startBlock;
+    let fallbackHash = '';
+    let fallbackTime = '';
+
+    try {
+        fallbackHash = await btcClient.getBlockHash(fallbackHeight);
+        const fallbackHeader = await btcClient.getBlockHeader(fallbackHash) as BlockHeader;
+        fallbackTime = fallbackHeader.time ? new Date(fallbackHeader.time * 1000).toISOString() : '';
+    } catch {
+        fallbackHash = '';
+    }
+
+    await jsonPersister.updateDb((data) => {
+        data.height = fallbackHeight;
+        if (fallbackHash) {
+            data.hash = fallbackHash;
+        }
+        data.time = fallbackTime;
+        data.blocksScanned = 0;
+        data.txnsScanned = 0;
+        data.blockCount = blockCount;
+        data.blocksPending = blockCount - fallbackHeight;
+    });
+
+    return fallbackHeight + 1;
 }
 
 async function extractOperations(txn: BlockTxVerbose, height: number, index: number, timestamp: string): Promise<void> {
@@ -185,6 +281,7 @@ async function fetchBlock(height: number, blockCount: number): Promise<void> {
 
         await jsonPersister.updateDb((db) => {
             db.height = height;
+            db.hash = blockHash;
             db.time = timestamp;
             db.blocksScanned = height - config.startBlock + 1;
             db.txnsScanned += block.tx.length;
@@ -199,16 +296,11 @@ async function fetchBlock(height: number, blockCount: number): Promise<void> {
 }
 
 async function scanBlocks(): Promise<void> {
-    let start = config.startBlock;
     let blockCount = await btcClient.getBlockCount();
 
     console.log(`current block height: ${blockCount}`);
 
-    const db = await loadDb();
-
-    if (db.height) {
-        start = db.height + 1;
-    }
+    let start = await resolveScanStart(blockCount);
 
     for (let height = start; height <= blockCount; height++) {
         console.log(`${height}/${blockCount} blocks (${(100 * height / blockCount).toFixed(2)}%)`);

--- a/services/mediators/satoshi-inscription/src/types.ts
+++ b/services/mediators/satoshi-inscription/src/types.ts
@@ -39,6 +39,7 @@ export interface AccountKeys {
 
 export interface MediatorDb {
     height: number;
+    hash?: string;
     time: string;
     blockCount: number;
     blocksScanned: number;

--- a/services/mediators/satoshi-inscription/src/types/bitcoin-core/index.d.ts
+++ b/services/mediators/satoshi-inscription/src/types/bitcoin-core/index.d.ts
@@ -75,6 +75,15 @@ export interface Block {
 
 export type BlockHex = string;
 
+export interface BlockHeader {
+    hash?: string;
+    confirmations?: number;
+    height?: number;
+    time?: number;
+    nTx?: number;
+    previousblockhash?: string;
+}
+
 export interface BlockTxVerbose {
     txid: string;
     vin: Vin[];
@@ -373,6 +382,7 @@ export default class BtcClient {
     getTransaction(txid: string, include_watchonly?: boolean, verbose?: boolean): Promise<GetTransactionResult>;
     getBlockHash(height: number): Promise<string>;
     getBlock(blockHash: string, verbosity?: number): Promise<BlockHex | Block | BlockVerbose>;
+    getBlockHeader(blockHash: string, verbose?: boolean): Promise<BlockHeader>;
     getBlockCount(): Promise<number>;
     createWallet(walletName: string): Promise<any>;
     getWalletInfo(): Promise<WalletInfo>;

--- a/services/mediators/satoshi/src/db/abstract-db.ts
+++ b/services/mediators/satoshi/src/db/abstract-db.ts
@@ -20,6 +20,7 @@ export default abstract class AbstractDB implements MediatorDbInterface {
     protected defaultDb(): MediatorDb {
         return {
             height: 0,
+            hash: '',
             time: '',
             blockCount: 0,
             blocksScanned: 0,

--- a/services/mediators/satoshi/src/satoshi-mediator.ts
+++ b/services/mediators/satoshi/src/satoshi-mediator.ts
@@ -1,4 +1,4 @@
-import BtcClient, {Block, BlockVerbose, FundRawTransactionOptions, MempoolEntry} from 'bitcoin-core';
+import BtcClient, {Block, BlockVerbose, BlockHeader, FundRawTransactionOptions, MempoolEntry} from 'bitcoin-core';
 import GatekeeperClient from '@mdip/gatekeeper/client';
 import KeymasterClient from '@mdip/keymaster/client';
 import JsonFile from './db/jsonfile.js';
@@ -45,6 +45,100 @@ async function loadDb(): Promise<MediatorDb> {
     return db || newDb;
 }
 
+async function getBlockTxCount(hash: string, header?: BlockHeader): Promise<number> {
+    if (typeof header?.nTx === 'number') {
+        return header.nTx;
+    }
+
+    const block = await btcClient.getBlock(hash, BlockVerbosity.JSON) as Block;
+    return Array.isArray(block.tx) ? block.tx.length : 0;
+}
+
+async function resolveScanStart(blockCount: number): Promise<number> {
+    const db = await loadDb();
+
+    if (!db.hash) {
+        return db.height ? db.height + 1 : config.startBlock;
+    }
+
+    let header: BlockHeader | undefined;
+    try {
+        header = await btcClient.getBlockHeader(db.hash) as BlockHeader;
+    } catch { }
+
+    if ((header?.confirmations ?? 0) > 0) {
+        return db.height + 1;
+    }
+
+    console.log(`Reorg detected at height ${db.height}, rewinding to a confirmed block...`);
+
+    let height = db.height;
+    let hash = db.hash;
+    let txnsToSubtract = 0;
+
+    while (hash && height >= config.startBlock) {
+        let currentHeader: BlockHeader;
+        try {
+            currentHeader = await btcClient.getBlockHeader(hash) as BlockHeader;
+        } catch {
+            break;
+        }
+
+        if ((currentHeader.confirmations ?? 0) > 0) {
+            const resolvedHeight = currentHeader.height ?? height;
+            const resolvedTime = currentHeader.time ? new Date(currentHeader.time * 1000).toISOString() : '';
+            const resolvedHash = hash;
+            const resolvedBlocksPending = blockCount - resolvedHeight;
+            const resolvedTxnsToSubtract = txnsToSubtract;
+            await jsonPersister.updateDb((data) => {
+                data.height = resolvedHeight;
+                data.hash = resolvedHash;
+                data.time = resolvedTime;
+                data.blocksScanned = Math.max(0, resolvedHeight - config.startBlock + 1);
+                data.txnsScanned = Math.max(0, data.txnsScanned - resolvedTxnsToSubtract);
+                data.blockCount = blockCount;
+                data.blocksPending = resolvedBlocksPending;
+            });
+            return resolvedHeight + 1;
+        }
+
+        txnsToSubtract += await getBlockTxCount(hash, currentHeader);
+
+        if (!currentHeader.previousblockhash) {
+            break;
+        }
+
+        hash = currentHeader.previousblockhash;
+        height = (currentHeader.height ?? height) - 1;
+    }
+
+    const fallbackHeight = config.startBlock;
+    let fallbackHash = '';
+    let fallbackTime = '';
+
+    try {
+        fallbackHash = await btcClient.getBlockHash(fallbackHeight);
+        const fallbackHeader = await btcClient.getBlockHeader(fallbackHash) as BlockHeader;
+        fallbackTime = fallbackHeader.time ? new Date(fallbackHeader.time * 1000).toISOString() : '';
+    } catch {
+        fallbackHash = '';
+    }
+
+    await jsonPersister.updateDb((data) => {
+        data.height = fallbackHeight;
+        if (fallbackHash) {
+            data.hash = fallbackHash;
+        }
+        data.time = fallbackTime;
+        data.blocksScanned = 0;
+        data.txnsScanned = 0;
+        data.blockCount = blockCount;
+        data.blocksPending = blockCount - fallbackHeight;
+    });
+
+    return fallbackHeight + 1;
+}
+
 async function fetchBlock(height: number, blockCount: number): Promise<void> {
     try {
         const blockHash = await btcClient.getBlockHash(height);
@@ -81,6 +175,7 @@ async function fetchBlock(height: number, blockCount: number): Promise<void> {
 
         await jsonPersister.updateDb((db) => {
             db.height = height;
+            db.hash = blockHash;
             db.time = timestamp;
             db.blocksScanned = height - config.startBlock + 1;
             db.txnsScanned += block.tx.length;
@@ -95,16 +190,11 @@ async function fetchBlock(height: number, blockCount: number): Promise<void> {
 }
 
 async function scanBlocks(): Promise<void> {
-    let start = config.startBlock;
     let blockCount = await btcClient.getBlockCount();
 
     console.log(`current block height: ${blockCount}`);
 
-    const db = await loadDb();
-
-    if (db.height) {
-        start = db.height + 1;
-    }
+    let start = await resolveScanStart(blockCount);
 
     for (let height = start; height <= blockCount; height++) {
         console.log(`${height}/${blockCount} blocks (${(100 * height / blockCount).toFixed(2)}%)`);

--- a/services/mediators/satoshi/src/types.ts
+++ b/services/mediators/satoshi/src/types.ts
@@ -18,6 +18,7 @@ export interface RegisteredItem {
 
 export interface MediatorDb {
     height: number;
+    hash?: string;
     time: string;
     blockCount: number;
     blocksScanned: number;

--- a/services/mediators/satoshi/src/types/bitcoin-core/index.d.ts
+++ b/services/mediators/satoshi/src/types/bitcoin-core/index.d.ts
@@ -75,6 +75,15 @@ export interface Block {
 
 export type BlockHex = string;
 
+export interface BlockHeader {
+    hash?: string;
+    confirmations?: number;
+    height?: number;
+    time?: number;
+    nTx?: number;
+    previousblockhash?: string;
+}
+
 export interface BlockTxVerbose {
     txid: string;
     vin: Vin[];
@@ -373,6 +382,7 @@ export default class BtcClient {
     getTransaction(txid: string, include_watchonly?: boolean, verbose?: boolean): Promise<GetTransactionResult>;
     getBlockHash(height: number): Promise<string>;
     getBlock(blockHash: string, verbosity?: number): Promise<BlockHex | Block | BlockVerbose>;
+    getBlockHeader(blockHash: string, verbose?: boolean): Promise<BlockHeader>;
     getBlockCount(): Promise<number>;
     createWallet(walletName: string): Promise<any>;
     getWalletInfo(): Promise<WalletInfo>;


### PR DESCRIPTION
- Satoshi mediators only track blocks by height, this means they will not switch chains in a reorg. This PR adds tracking blocks by hash. If the mediator finds its blocks are now unconfirmed it will rollback until it gets on to the confirmed chain and then crawl forwards again.
- Resolves: https://github.com/KeychainMDIP/kc/issues/1148