### PR TITLE
feat: add credential tab to explorer

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -35,6 +35,7 @@ const config = {
         '^\\.\\/sync-mapping\\.js$': '<rootDir>/services/mediators/hyperswarm/src/sync-mapping.ts',
         '^\\.\\/sync-persistence\\.js$': '<rootDir>/services/mediators/hyperswarm/src/sync-persistence.ts',
         '^\\.\\/abstract-json\\.js$': '<rootDir>/packages/gatekeeper/src/db/abstract-json.ts',
+        '^\\.\\/published-credentials\\.js$': '<rootDir>/services/search-server/src/published-credentials.ts',
         '^\\.\\/cipher-base\\.js$': '<rootDir>/packages/cipher/src/cipher-base.ts',
         '^\\.\\/encryption\\.js$': '<rootDir>/packages/keymaster/src/encryption.ts',
     },

--- a/services/explorer/src/App.tsx
+++ b/services/explorer/src/App.tsx
@@ -1,6 +1,7 @@
-import React, {useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import JsonViewer from "./components/JsonViewer.js";
 import Events from "./components/Events.js";
+import Credentials from "./components/Credentials.js";
 import GatekeeperClient from '@mdip/gatekeeper/client';
 import { createTheme, ThemeProvider } from "@mui/material/styles";
 import {
@@ -54,14 +55,14 @@ function App() {
         navigate(`/search?did=${encodeURIComponent(did)}`);
     }
 
-    const setError = (error: any) => {
+    const setError = useCallback((error: any) => {
         const errorMessage = error.error || error.message || String(error);
         setSnackbar({
             open: true,
             message: errorMessage,
             severity: "error",
         });
-    };
+    }, []);
 
     const theme = useMemo(() => createTheme({
         palette: {
@@ -201,54 +202,66 @@ function App() {
                         </Alert>
                     </Snackbar>
 
-                    {isReady &&
-                        <Box>
-                            <Header
-                                handleThemeToggle={handleThemeToggle}
-                                darkMode={darkMode}
+                    <Box>
+                        <Header
+                            handleThemeToggle={handleThemeToggle}
+                            darkMode={darkMode}
+                        />
+                        <Routes>
+                            <Route
+                                path="/"
+                                element={<Navigate to="/search" replace />}
                             />
-                            <Routes>
-                                <Route
-                                    path="/"
-                                    element={<Navigate to="/search" replace />}
-                                />
-                                <Route
-                                    path="/search"
-                                    element={
-                                        <JsonViewer
-                                            gatekeeper={gatekeeper}
-                                            setError={setError}
-                                        />
-                                    }
-                                />
-                                <Route
-                                    path="/events"
-                                    element={
-                                        <Events
-                                            events={events}
-                                            eventCount={eventCount}
-                                            page={page}
-                                            dateFrom={dateFrom}
-                                            dateTo={dateTo}
-                                            registry={registry}
-                                            totalPages={totalPages}
-                                            setEventCount={setEventCount}
-                                            setPage={setPage}
-                                            setRegistry={setRegistry}
-                                            setDateFrom={setDateFrom}
-                                            setDateTo={setDateTo}
-                                            onDidClick={handleViewDid}
-                                            setError={setError}
-                                        />
-                                    }
-                                />
-                                <Route
-                                    path="*"
-                                    element={<Typography>404 Not Found</Typography>}
-                                />
-                            </Routes>
-                        </Box>
-                    }
+                            <Route
+                                path="/search"
+                                element={isReady ? (
+                                    <JsonViewer
+                                        gatekeeper={gatekeeper}
+                                        setError={setError}
+                                    />
+                                ) : (
+                                    <Typography sx={{ mt: 3 }}>Waiting for Gatekeeper...</Typography>
+                                )}
+                            />
+                            <Route
+                                path="/events"
+                                element={isReady ? (
+                                    <Events
+                                        events={events}
+                                        eventCount={eventCount}
+                                        page={page}
+                                        dateFrom={dateFrom}
+                                        dateTo={dateTo}
+                                        registry={registry}
+                                        totalPages={totalPages}
+                                        setEventCount={setEventCount}
+                                        setPage={setPage}
+                                        setRegistry={setRegistry}
+                                        setDateFrom={setDateFrom}
+                                        setDateTo={setDateTo}
+                                        onDidClick={handleViewDid}
+                                        setError={setError}
+                                    />
+                                ) : (
+                                    <Typography sx={{ mt: 3 }}>Waiting for Gatekeeper...</Typography>
+                                )}
+                            />
+                            <Route
+                                path="/credentials"
+                                element={
+                                    <Credentials
+                                        gatekeeper={gatekeeper}
+                                        isReady={isReady}
+                                        setError={setError}
+                                    />
+                                }
+                            />
+                            <Route
+                                path="*"
+                                element={<Typography>404 Not Found</Typography>}
+                            />
+                        </Routes>
+                    </Box>
                 </Box>
             </Box>
         </ThemeProvider>

--- a/services/explorer/src/components/Credentials.tsx
+++ b/services/explorer/src/components/Credentials.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
 import axios from "axios";
 import JsonView from "@uiw/react-json-view";
@@ -237,10 +237,10 @@ function Credentials(
         [credentials, selectedDetailDid]
     );
 
-    function updateParams(
+    const updateParams = useCallback((
         updates: Record<string, string | null | undefined>,
         options?: { replace?: boolean }
-    ) {
+    ) => {
         const next = new URLSearchParams(searchParams);
 
         for (const [key, value] of Object.entries(updates)) {
@@ -253,7 +253,7 @@ function Credentials(
         }
 
         setSearchParams(next, options);
-    }
+    }, [searchParams, setSearchParams]);
 
     function handleSelectSchema(nextSchemaDid: string) {
         updateParams({
@@ -363,7 +363,7 @@ function Credentials(
         return () => {
             ignore = true;
         };
-    }, [schemaDid, page, pageSize, setError]);
+    }, [page, pageSize, schemaDid, setError, updateParams]);
 
     useEffect(() => {
         const maxPage = Math.max(0, Math.ceil(schemaCounts.length / schemaPageSize) - 1);
@@ -379,7 +379,7 @@ function Credentials(
                 schemaDid: detailRecord.schemaDid,
             }, { replace: true });
         }
-    }, [detailRecord, schemaDid, selectedDetailDid]);
+    }, [detailRecord, schemaDid, selectedDetailDid, updateParams]);
 
     useEffect(() => {
         let ignore = false;

--- a/services/explorer/src/components/Credentials.tsx
+++ b/services/explorer/src/components/Credentials.tsx
@@ -39,6 +39,16 @@ interface PublishedCredentialRow {
     updatedAt: string;
 }
 
+function getDidPrefix(did: string): string {
+    const parts = did.split(":");
+
+    if (parts.length < 2) {
+        return did;
+    }
+
+    return `${parts[0]}:${parts[1]}`;
+}
+
 function parsePositiveInteger(value: string | null, fallback: number): number {
     const parsed = Number.parseInt(value ?? "", 10);
 
@@ -186,6 +196,47 @@ function DidRow(
     );
 }
 
+function SummaryCard(
+    {
+        label,
+        value,
+        minWidth = 280,
+    }: {
+        label: string;
+        value: number;
+        minWidth?: number;
+    }
+) {
+    return (
+        <Box
+            sx={{
+                border: "1px solid",
+                borderColor: "divider",
+                borderRadius: 1,
+                p: 2,
+                minWidth,
+                flex: `1 1 ${minWidth}px`,
+            }}
+        >
+            <Box sx={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 2, whiteSpace: "nowrap" }}>
+                <Typography
+                    sx={{
+                        fontSize: "0.95rem",
+                        fontWeight: 500,
+                        letterSpacing: "0.08em",
+                        textTransform: "uppercase",
+                    }}
+                >
+                    {label}
+                </Typography>
+                <Typography variant="h4" sx={{ fontSize: "2.1rem", lineHeight: 1 }}>
+                    {value}
+                </Typography>
+            </Box>
+        </Box>
+    );
+}
+
 function Credentials(
     {
         gatekeeper,
@@ -210,12 +261,28 @@ function Credentials(
 
     const schemaDid = searchParams.get("schemaDid") ?? "";
     const selectedDetailDid = searchParams.get("detailDid") ?? "";
+    const schemaPrefix = searchParams.get("schemaPrefix") ?? "";
     const pageSize = parsePositiveInteger(searchParams.get("pageSize"), 25);
     const page = parseNonNegativeInteger(searchParams.get("page"), 0);
 
-    const totalPublished = useMemo(
-        () => schemaCounts.reduce((sum, row) => sum + row.count, 0),
+    const availableSchemaPrefixes = useMemo(
+        () => Array.from(new Set(schemaCounts.map(row => getDidPrefix(row.schemaDid)))).sort(),
         [schemaCounts]
+    );
+
+    const hasMultipleSchemaPrefixes = availableSchemaPrefixes.length > 1;
+
+    const filteredSchemaCounts = useMemo(() => {
+        if (!schemaPrefix) {
+            return schemaCounts;
+        }
+
+        return schemaCounts.filter(row => getDidPrefix(row.schemaDid) === schemaPrefix);
+    }, [schemaCounts, schemaPrefix]);
+
+    const totalPublished = useMemo(
+        () => filteredSchemaCounts.reduce((sum, row) => sum + row.count, 0),
+        [filteredSchemaCounts]
     );
 
     const selectedSchemaCount = useMemo(
@@ -224,13 +291,13 @@ function Credentials(
     );
 
     const totalPages = Math.max(1, Math.ceil(credentialTotal / pageSize));
-    const schemaTotalPages = Math.max(1, Math.ceil(schemaCounts.length / schemaPageSize));
+    const schemaTotalPages = Math.max(1, Math.ceil(filteredSchemaCounts.length / schemaPageSize));
     const pagedSchemaCounts = useMemo(() => {
         const from = schemaPage * schemaPageSize;
         const to = from + schemaPageSize;
 
-        return schemaCounts.slice(from, to);
-    }, [schemaCounts, schemaPage, schemaPageSize]);
+        return filteredSchemaCounts.slice(from, to);
+    }, [filteredSchemaCounts, schemaPage, schemaPageSize]);
 
     const listDetailRecord = useMemo(
         () => credentials.find(row => row.credentialDid === selectedDetailDid) ?? null,
@@ -288,6 +355,13 @@ function Credentials(
             pageSize: value.toString(),
             page: "0",
         });
+    }
+
+    function handleSchemaPrefixChange(value: string) {
+        updateParams({
+            schemaPrefix: value || null,
+        });
+        setSchemaPage(0);
     }
 
     function handleSchemaPageSizeChange(value: number) {
@@ -366,12 +440,20 @@ function Credentials(
     }, [page, pageSize, schemaDid, setError, updateParams]);
 
     useEffect(() => {
-        const maxPage = Math.max(0, Math.ceil(schemaCounts.length / schemaPageSize) - 1);
+        const maxPage = Math.max(0, Math.ceil(filteredSchemaCounts.length / schemaPageSize) - 1);
 
         if (schemaPage > maxPage) {
             setSchemaPage(maxPage);
         }
-    }, [schemaCounts.length, schemaPage, schemaPageSize]);
+    }, [filteredSchemaCounts.length, schemaPage, schemaPageSize]);
+
+    useEffect(() => {
+        if (schemaPrefix && !availableSchemaPrefixes.includes(schemaPrefix)) {
+            updateParams({
+                schemaPrefix: null,
+            }, { replace: true });
+        }
+    }, [availableSchemaPrefixes, schemaPrefix, updateParams]);
 
     useEffect(() => {
         if (selectedDetailDid && detailRecord && !schemaDid) {
@@ -545,17 +627,28 @@ function Credentials(
             ) : !schemaDid ? (
                 <>
                     <Box sx={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", mb: 2, gap: 2, flexWrap: "wrap" }}>
-                        <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
-                            <Box sx={{ border: "1px solid", borderColor: "divider", borderRadius: 1, p: 2, minWidth: 220 }}>
-                                <Typography variant="overline">Total Published</Typography>
-                                <Typography variant="h4">{totalPublished}</Typography>
-                            </Box>
-                            <Box sx={{ border: "1px solid", borderColor: "divider", borderRadius: 1, p: 2, minWidth: 220 }}>
-                                <Typography variant="overline">Schemas In Use</Typography>
-                                <Typography variant="h4">{schemaCounts.length}</Typography>
-                            </Box>
+                        <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap", flex: "1 1 620px" }}>
+                            <SummaryCard label="Total Published" value={totalPublished} />
+                            <SummaryCard label="Schemas In Use" value={filteredSchemaCounts.length} />
                         </Box>
                         <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap", ml: "auto" }}>
+                            {hasMultipleSchemaPrefixes && (
+                                <FormControl size="small" sx={{ minWidth: 140 }}>
+                                    <Select
+                                        value={schemaPrefix}
+                                        displayEmpty
+                                        onChange={(event) => handleSchemaPrefixChange(event.target.value as string)}
+                                    >
+                                        <MenuItem value="">All</MenuItem>
+                                        {availableSchemaPrefixes.map((prefix) => (
+                                            <MenuItem key={prefix} value={prefix}>
+                                                {prefix}
+                                            </MenuItem>
+                                        ))}
+                                    </Select>
+                                </FormControl>
+                            )}
+
                             <FormControl size="small" sx={{ minWidth: 120 }}>
                                 <Select
                                     value={schemaPageSize}
@@ -593,7 +686,7 @@ function Credentials(
                         </Box>
                     </Box>
 
-                    {schemaCounts.length === 0 ? (
+                    {filteredSchemaCounts.length === 0 ? (
                         <Typography>No published credentials found.</Typography>
                     ) : (
                         <TableContainer sx={{ border: "1px solid", borderColor: "divider", borderRadius: 1 }}>
@@ -648,10 +741,7 @@ function Credentials(
                     </Box>
 
                     <Box sx={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 2, mb: 2, flexWrap: "wrap" }}>
-                        <Box sx={{ border: "1px solid", borderColor: "divider", borderRadius: 1, p: 2, minWidth: 220 }}>
-                            <Typography variant="overline">Published Credentials</Typography>
-                            <Typography variant="h4">{selectedSchemaCount}</Typography>
-                        </Box>
+                        <SummaryCard label="Published Credentials" value={selectedSchemaCount} minWidth={320} />
                         <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap", ml: "auto" }}>
                             <FormControl size="small" sx={{ minWidth: 100 }}>
                                 <Select

--- a/services/explorer/src/components/Credentials.tsx
+++ b/services/explorer/src/components/Credentials.tsx
@@ -1,0 +1,730 @@
+import React, { useEffect, useMemo, useState } from "react";
+import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
+import axios from "axios";
+import JsonView from "@uiw/react-json-view";
+import { GatekeeperInterface } from "@mdip/gatekeeper/types";
+import {
+    Box,
+    Button,
+    FormControl,
+    MenuItem,
+    Select,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    Typography,
+} from "@mui/material";
+import { Link as RouterLink, useSearchParams } from "react-router-dom";
+
+const searchServerURL = import.meta.env.VITE_SEARCH_SERVER || "http://localhost:4002";
+const VERSION = "/api/v1";
+const pageSizeOptions = [25, 50, 100];
+const schemaPageSizeOptions = [25, 50, 100];
+
+interface SchemaMetric {
+    schemaDid: string;
+    count: number;
+}
+
+interface PublishedCredentialRow {
+    holderDid: string;
+    credentialDid: string;
+    schemaDid: string;
+    issuerDid: string;
+    subjectDid: string;
+    revealed: boolean;
+    updatedAt: string;
+}
+
+function parsePositiveInteger(value: string | null, fallback: number): number {
+    const parsed = Number.parseInt(value ?? "", 10);
+
+    if (Number.isInteger(parsed) && parsed > 0) {
+        return parsed;
+    }
+
+    return fallback;
+}
+
+function parseNonNegativeInteger(value: string | null, fallback: number): number {
+    const parsed = Number.parseInt(value ?? "", 10);
+
+    if (Number.isInteger(parsed) && parsed >= 0) {
+        return parsed;
+    }
+
+    return fallback;
+}
+
+function formatTimestamp(value: string): string {
+    const date = new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+
+    return `${date.toISOString().replace("T", " ").slice(0, 16)}Z`;
+}
+
+function mapPublishedCredentialRow(row: any): PublishedCredentialRow {
+    return {
+        holderDid: row.holderDid,
+        credentialDid: row.credentialDid,
+        schemaDid: row.schemaDid,
+        issuerDid: row.issuerDid,
+        subjectDid: row.subjectDid,
+        revealed: row.revealed === true,
+        updatedAt: row.updatedAt,
+    };
+}
+
+function ClickableDid(
+    {
+        did,
+        onClick,
+        maxWidth = 520,
+    }: {
+        did: string;
+        onClick: () => void;
+        maxWidth?: number | string;
+    }
+) {
+    return (
+        <Typography
+            title={did}
+            onClick={(event) => {
+                event.stopPropagation();
+                onClick();
+            }}
+            sx={{
+                fontFamily: "Courier, monospace",
+                textDecoration: "underline",
+                color: "primary.main",
+                cursor: "pointer",
+                maxWidth,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+            }}
+        >
+            {did}
+        </Typography>
+    );
+}
+
+function JsonViewerDidLink({ did }: { did: string }) {
+    return (
+        <Typography
+            component={RouterLink}
+            to={`/search?did=${encodeURIComponent(did)}`}
+            title={did}
+            sx={{
+                display: "block",
+                fontFamily: "Courier, monospace",
+                textDecoration: "underline",
+                color: "primary.main",
+                cursor: "pointer",
+                wordBreak: "break-all",
+            }}
+        >
+            {did}
+        </Typography>
+    );
+}
+
+function getManifestEntryFromDoc(
+    {
+        doc,
+        credentialDid,
+    }: {
+        doc: Record<string, unknown>;
+        credentialDid: string;
+    }
+): Record<string, unknown> | null {
+    const didDocumentData = doc.didDocumentData;
+
+    if (!didDocumentData || typeof didDocumentData !== "object" || Array.isArray(didDocumentData)) {
+        return null;
+    }
+
+    const manifest = (didDocumentData as Record<string, unknown>).manifest;
+
+    if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) {
+        return null;
+    }
+
+    const entry = (manifest as Record<string, unknown>)[credentialDid];
+
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        return null;
+    }
+
+    return entry as Record<string, unknown>;
+}
+
+function DidRow(
+    {
+        label,
+        did,
+    }: {
+        label: string;
+        did: string;
+    }
+) {
+    return (
+        <Box sx={{ display: "flex", alignItems: "baseline", gap: 2, flexWrap: "wrap" }}>
+            <Typography variant="overline" sx={{ minWidth: 88 }}>
+                {label}
+            </Typography>
+            <Box sx={{ minWidth: 0, flex: "1 1 0" }}>
+                <JsonViewerDidLink did={did} />
+            </Box>
+        </Box>
+    );
+}
+
+function Credentials(
+    {
+        gatekeeper,
+        isReady,
+        setError,
+    }: {
+        gatekeeper: GatekeeperInterface;
+        isReady: boolean;
+        setError: (error: any) => void;
+    }
+) {
+    const [searchParams, setSearchParams] = useSearchParams();
+    const [schemaCounts, setSchemaCounts] = useState<SchemaMetric[]>([]);
+    const [credentials, setCredentials] = useState<PublishedCredentialRow[]>([]);
+    const [credentialTotal, setCredentialTotal] = useState<number>(0);
+    const [schemaPageSize, setSchemaPageSize] = useState<number>(25);
+    const [schemaPage, setSchemaPage] = useState<number>(0);
+    const [detailRecord, setDetailRecord] = useState<PublishedCredentialRow | null>(null);
+    const [detailDoc, setDetailDoc] = useState<Record<string, unknown> | null>(null);
+    const [isDetailLoading, setIsDetailLoading] = useState<boolean>(false);
+    const [detailError, setDetailError] = useState<string | null>(null);
+
+    const schemaDid = searchParams.get("schemaDid") ?? "";
+    const selectedDetailDid = searchParams.get("detailDid") ?? "";
+    const pageSize = parsePositiveInteger(searchParams.get("pageSize"), 25);
+    const page = parseNonNegativeInteger(searchParams.get("page"), 0);
+
+    const totalPublished = useMemo(
+        () => schemaCounts.reduce((sum, row) => sum + row.count, 0),
+        [schemaCounts]
+    );
+
+    const selectedSchemaCount = useMemo(
+        () => schemaCounts.find(row => row.schemaDid === schemaDid)?.count ?? 0,
+        [schemaCounts, schemaDid]
+    );
+
+    const totalPages = Math.max(1, Math.ceil(credentialTotal / pageSize));
+    const schemaTotalPages = Math.max(1, Math.ceil(schemaCounts.length / schemaPageSize));
+    const pagedSchemaCounts = useMemo(() => {
+        const from = schemaPage * schemaPageSize;
+        const to = from + schemaPageSize;
+
+        return schemaCounts.slice(from, to);
+    }, [schemaCounts, schemaPage, schemaPageSize]);
+
+    const listDetailRecord = useMemo(
+        () => credentials.find(row => row.credentialDid === selectedDetailDid) ?? null,
+        [credentials, selectedDetailDid]
+    );
+
+    function updateParams(
+        updates: Record<string, string | null | undefined>,
+        options?: { replace?: boolean }
+    ) {
+        const next = new URLSearchParams(searchParams);
+
+        for (const [key, value] of Object.entries(updates)) {
+            if (!value) {
+                next.delete(key);
+            }
+            else {
+                next.set(key, value);
+            }
+        }
+
+        setSearchParams(next, options);
+    }
+
+    function handleSelectSchema(nextSchemaDid: string) {
+        updateParams({
+            schemaDid: nextSchemaDid,
+            detailDid: null,
+            page: "0",
+        });
+    }
+
+    function handleBackToSchemas() {
+        updateParams({
+            schemaDid: null,
+            detailDid: null,
+            page: "0",
+        });
+    }
+
+    function handleOpenDidDetail(did: string) {
+        updateParams({
+            detailDid: did,
+        });
+    }
+
+    function handleBackFromDetail() {
+        updateParams({
+            detailDid: null,
+        }, { replace: true });
+    }
+
+    function handlePageSizeChange(value: number) {
+        updateParams({
+            pageSize: value.toString(),
+            page: "0",
+        });
+    }
+
+    function handleSchemaPageSizeChange(value: number) {
+        setSchemaPageSize(value);
+        setSchemaPage(0);
+    }
+
+    useEffect(() => {
+        let ignore = false;
+
+        async function fetchSchemaCounts() {
+            try {
+                const response = await axios.get(`${searchServerURL}${VERSION}/metrics/schemas/published`);
+
+                if (!ignore) {
+                    setSchemaCounts(response.data.schemas ?? []);
+                }
+            }
+            catch (error: any) {
+                if (!ignore) {
+                    setError(error);
+                }
+            }
+        }
+
+        fetchSchemaCounts();
+
+        return () => {
+            ignore = true;
+        };
+    }, [setError]);
+
+    useEffect(() => {
+        let ignore = false;
+
+        async function fetchCredentials() {
+            if (!schemaDid) {
+                setCredentials([]);
+                setCredentialTotal(0);
+                return;
+            }
+
+            try {
+                const response = await axios.get(`${searchServerURL}${VERSION}/metrics/credentials/published`, {
+                    params: {
+                        schemaDid,
+                        limit: pageSize,
+                        offset: page * pageSize,
+                    }
+                });
+
+                const total = response.data.total ?? 0;
+
+                if (!ignore) {
+                    if (total > 0 && page * pageSize >= total && page > 0) {
+                        updateParams({ page: "0" });
+                        return;
+                    }
+
+                    setCredentialTotal(total);
+                    setCredentials((response.data.credentials ?? []).map(mapPublishedCredentialRow));
+                }
+            }
+            catch (error: any) {
+                if (!ignore) {
+                    setError(error);
+                }
+            }
+        }
+
+        fetchCredentials();
+
+        return () => {
+            ignore = true;
+        };
+    }, [schemaDid, page, pageSize, setError]);
+
+    useEffect(() => {
+        const maxPage = Math.max(0, Math.ceil(schemaCounts.length / schemaPageSize) - 1);
+
+        if (schemaPage > maxPage) {
+            setSchemaPage(maxPage);
+        }
+    }, [schemaCounts.length, schemaPage, schemaPageSize]);
+
+    useEffect(() => {
+        if (selectedDetailDid && detailRecord && !schemaDid) {
+            updateParams({
+                schemaDid: detailRecord.schemaDid,
+            }, { replace: true });
+        }
+    }, [detailRecord, schemaDid, selectedDetailDid]);
+
+    useEffect(() => {
+        let ignore = false;
+
+        async function fetchDetail() {
+            if (!selectedDetailDid) {
+                setDetailRecord(null);
+                setDetailDoc(null);
+                setDetailError(null);
+                setIsDetailLoading(false);
+                return;
+            }
+
+            if (!isReady) {
+                setDetailRecord(null);
+                setDetailDoc(null);
+                setDetailError("Waiting for Gatekeeper...");
+                setIsDetailLoading(false);
+                return;
+            }
+
+            setIsDetailLoading(true);
+            setDetailError(null);
+
+            try {
+                let nextDetailRecord = listDetailRecord;
+
+                if (!nextDetailRecord && selectedDetailDid !== schemaDid) {
+                    const response = await axios.get(`${searchServerURL}${VERSION}/metrics/credentials/published`, {
+                        params: {
+                            credentialDid: selectedDetailDid,
+                            schemaDid: schemaDid || undefined,
+                            limit: 1,
+                            offset: 0,
+                        }
+                    });
+
+                    const fetchedRow = response.data.credentials?.[0];
+                    if (fetchedRow) {
+                        nextDetailRecord = mapPublishedCredentialRow(fetchedRow);
+                    }
+                }
+
+                if (!ignore) {
+                    setDetailRecord(nextDetailRecord);
+                }
+
+                if (nextDetailRecord) {
+                    const subjectDoc = await gatekeeper.resolveDID(nextDetailRecord.subjectDid) as Record<string, unknown>;
+                    const manifestEntry = getManifestEntryFromDoc({
+                        doc: subjectDoc,
+                        credentialDid: nextDetailRecord.credentialDid,
+                    });
+
+                    if (!ignore) {
+                        if (!manifestEntry) {
+                            setDetailDoc(null);
+                            setDetailError("Published credential manifest entry not found.");
+                        }
+                        else {
+                            setDetailDoc(manifestEntry);
+                        }
+                    }
+
+                    return;
+                }
+
+                const response = await gatekeeper.resolveDID(selectedDetailDid) as Record<string, unknown>;
+
+                if (!ignore) {
+                    setDetailDoc(response);
+                }
+            }
+            catch (error: any) {
+                if (!ignore) {
+                    setDetailRecord(null);
+                    setDetailDoc(null);
+
+                    if (error?.response?.status === 404 || error?.message === "Not found") {
+                        setDetailError("DID document not found.");
+                    }
+                    else {
+                        setDetailError("Unable to load DID document.");
+                        setError(error);
+                    }
+                }
+            }
+            finally {
+                if (!ignore) {
+                    setIsDetailLoading(false);
+                }
+            }
+        }
+
+        fetchDetail();
+
+        return () => {
+            ignore = true;
+        };
+    }, [gatekeeper, isReady, listDetailRecord, schemaDid, selectedDetailDid, setError]);
+
+    return (
+        <Box sx={{ ml: 1, mt: 2, minWidth: 860 }}>
+            {selectedDetailDid ? (
+                <>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap", mb: 2 }}>
+                        <Button
+                            variant="outlined"
+                            onClick={handleBackFromDetail}
+                            startIcon={<ArrowBackIosNewIcon fontSize="small" />}
+                        >
+                            Back
+                        </Button>
+                        {!detailRecord && (
+                            <>
+                                <Typography variant="overline" sx={{ whiteSpace: "nowrap" }}>
+                                    {schemaDid && selectedDetailDid === schemaDid ? "Schema" : "DID"}
+                                </Typography>
+                                <Typography
+                                    title={selectedDetailDid}
+                                    sx={{
+                                        fontFamily: "Courier, monospace",
+                                        wordBreak: "break-all",
+                                    }}
+                                >
+                                    {selectedDetailDid}
+                                </Typography>
+                            </>
+                        )}
+                    </Box>
+
+                    {detailRecord && (
+                        <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5, mb: 3 }}>
+                            <DidRow label="Credential" did={detailRecord.credentialDid} />
+                            <DidRow label="Subject" did={detailRecord.subjectDid} />
+                            <DidRow label="Issuer" did={detailRecord.issuerDid} />
+                            <Box sx={{ display: "flex", alignItems: "baseline", gap: 2, flexWrap: "wrap" }}>
+                                <Typography variant="overline" sx={{ minWidth: 88 }}>
+                                    Revealed
+                                </Typography>
+                                <Typography>{String(detailRecord.revealed)}</Typography>
+                            </Box>
+                        </Box>
+                    )}
+
+                    {isDetailLoading ? (
+                        <Typography>Loading DID document...</Typography>
+                    ) : detailError ? (
+                        <Typography>{detailError}</Typography>
+                    ) : detailDoc ? (
+                        <Box sx={{ overflowX: "auto" }}>
+                            <JsonView
+                                value={detailDoc}
+                                collapsed={false}
+                                shouldExpandNodeInitially={() => true}
+                                shortenTextAfterLength={0}
+                            />
+                        </Box>
+                    ) : (
+                        <Typography>No DID document found.</Typography>
+                    )}
+                </>
+            ) : !schemaDid ? (
+                <>
+                    <Box sx={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", mb: 2, gap: 2, flexWrap: "wrap" }}>
+                        <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+                            <Box sx={{ border: "1px solid", borderColor: "divider", borderRadius: 1, p: 2, minWidth: 220 }}>
+                                <Typography variant="overline">Total Published</Typography>
+                                <Typography variant="h4">{totalPublished}</Typography>
+                            </Box>
+                            <Box sx={{ border: "1px solid", borderColor: "divider", borderRadius: 1, p: 2, minWidth: 220 }}>
+                                <Typography variant="overline">Schemas In Use</Typography>
+                                <Typography variant="h4">{schemaCounts.length}</Typography>
+                            </Box>
+                        </Box>
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap", ml: "auto" }}>
+                            <FormControl size="small" sx={{ minWidth: 120 }}>
+                                <Select
+                                    value={schemaPageSize}
+                                    onChange={(event) => handleSchemaPageSizeChange(event.target.value as number)}
+                                >
+                                    {schemaPageSizeOptions.map((option) => (
+                                        <MenuItem key={option} value={option}>
+                                            {option}
+                                        </MenuItem>
+                                    ))}
+                                </Select>
+                            </FormControl>
+
+                            <Box display="flex" alignItems="center" gap={1}>
+                                <Button
+                                    variant="outlined"
+                                    size="small"
+                                    disabled={schemaPage === 0}
+                                    onClick={() => setSchemaPage(schemaPage - 1)}
+                                >
+                                    Prev
+                                </Button>
+                                <Typography>
+                                    Page {schemaPage + 1} / {schemaTotalPages === 0 ? 1 : schemaTotalPages}
+                                </Typography>
+                                <Button
+                                    variant="outlined"
+                                    size="small"
+                                    disabled={schemaPage + 1 >= schemaTotalPages}
+                                    onClick={() => setSchemaPage(schemaPage + 1)}
+                                >
+                                    Next
+                                </Button>
+                            </Box>
+                        </Box>
+                    </Box>
+
+                    {schemaCounts.length === 0 ? (
+                        <Typography>No published credentials found.</Typography>
+                    ) : (
+                        <TableContainer sx={{ border: "1px solid", borderColor: "divider", borderRadius: 1 }}>
+                            <Table size="small">
+                                <TableHead>
+                                    <TableRow>
+                                        <TableCell>Schema</TableCell>
+                                        <TableCell width={140}>Published</TableCell>
+                                    </TableRow>
+                                </TableHead>
+                                <TableBody>
+                                    {pagedSchemaCounts.map((row) => (
+                                        <TableRow
+                                            key={row.schemaDid}
+                                            hover
+                                            onClick={() => handleSelectSchema(row.schemaDid)}
+                                            sx={{ cursor: "pointer" }}
+                                        >
+                                            <TableCell>
+                                                <ClickableDid did={row.schemaDid} onClick={() => handleSelectSchema(row.schemaDid)} />
+                                            </TableCell>
+                                            <TableCell>{row.count}</TableCell>
+                                        </TableRow>
+                                    ))}
+                                </TableBody>
+                            </Table>
+                        </TableContainer>
+                    )}
+                </>
+            ) : (
+                <>
+                    <Box sx={{ display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 2, mb: 2 }}>
+                        <Button
+                            variant="outlined"
+                            onClick={handleBackToSchemas}
+                            startIcon={<ArrowBackIosNewIcon fontSize="small" />}
+                        >
+                            Back
+                        </Button>
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap", minWidth: 0, width: "100%" }}>
+                            <Typography variant="overline" sx={{ whiteSpace: "nowrap", minWidth: 88 }}>
+                                Schema
+                            </Typography>
+                            <Box sx={{ minWidth: 0, flex: "1 1 0" }}>
+                                <ClickableDid
+                                    did={schemaDid}
+                                    onClick={() => handleOpenDidDetail(schemaDid)}
+                                    maxWidth="100%"
+                                />
+                            </Box>
+                        </Box>
+                    </Box>
+
+                    <Box sx={{ display: "flex", alignItems: "flex-end", justifyContent: "space-between", gap: 2, mb: 2, flexWrap: "wrap" }}>
+                        <Box sx={{ border: "1px solid", borderColor: "divider", borderRadius: 1, p: 2, minWidth: 220 }}>
+                            <Typography variant="overline">Published Credentials</Typography>
+                            <Typography variant="h4">{selectedSchemaCount}</Typography>
+                        </Box>
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap", ml: "auto" }}>
+                            <FormControl size="small" sx={{ minWidth: 100 }}>
+                                <Select
+                                    value={pageSize}
+                                    onChange={(event) => handlePageSizeChange(event.target.value as number)}
+                                >
+                                    {pageSizeOptions.map((option) => (
+                                        <MenuItem key={option} value={option}>
+                                            {option}
+                                        </MenuItem>
+                                    ))}
+                                </Select>
+                            </FormControl>
+                            <Box display="flex" alignItems="center" gap={1}>
+                                <Button
+                                    variant="outlined"
+                                    size="small"
+                                    disabled={page === 0}
+                                    onClick={() => updateParams({ page: String(page - 1) })}
+                                >
+                                    Prev
+                                </Button>
+                                <Typography>
+                                    Page {Math.min(page + 1, totalPages)} / {totalPages}
+                                </Typography>
+                                <Button
+                                    variant="outlined"
+                                    size="small"
+                                    disabled={page + 1 >= totalPages}
+                                    onClick={() => updateParams({ page: String(page + 1) })}
+                                >
+                                    Next
+                                </Button>
+                            </Box>
+                        </Box>
+                    </Box>
+
+                    {credentials.length === 0 ? (
+                        <Typography>No published credentials found for this schema.</Typography>
+                    ) : (
+                        <TableContainer sx={{ border: "1px solid", borderColor: "divider", borderRadius: 1 }}>
+                            <Table size="small">
+                                <TableHead>
+                                    <TableRow>
+                                        <TableCell>Credential</TableCell>
+                                        <TableCell width={190}>Published</TableCell>
+                                    </TableRow>
+                                </TableHead>
+                                <TableBody>
+                                    {credentials.map((row) => (
+                                        <TableRow
+                                            key={row.credentialDid}
+                                            hover
+                                            onClick={() => handleOpenDidDetail(row.credentialDid)}
+                                            sx={{ cursor: "pointer" }}
+                                        >
+                                            <TableCell>
+                                                <ClickableDid
+                                                    did={row.credentialDid}
+                                                    onClick={() => handleOpenDidDetail(row.credentialDid)}
+                                                />
+                                            </TableCell>
+                                            <TableCell>{formatTimestamp(row.updatedAt)}</TableCell>
+                                        </TableRow>
+                                    ))}
+                                </TableBody>
+                            </Table>
+                        </TableContainer>
+                    )}
+                </>
+            )}
+        </Box>
+    );
+}
+
+export default React.memo(Credentials);

--- a/services/explorer/src/components/Credentials.tsx
+++ b/services/explorer/src/components/Credentials.tsx
@@ -18,6 +18,7 @@ import {
     Typography,
 } from "@mui/material";
 import { Link as RouterLink, useSearchParams } from "react-router-dom";
+import { fetchCachedDid } from "../shared/utilities.js";
 
 const searchServerURL = import.meta.env.VITE_SEARCH_SERVER || "http://localhost:4002";
 const VERSION = "/api/v1";
@@ -510,11 +511,21 @@ function Credentials(
                 }
 
                 if (nextDetailRecord) {
-                    const subjectDoc = await gatekeeper.resolveDID(nextDetailRecord.subjectDid) as Record<string, unknown>;
-                    const manifestEntry = getManifestEntryFromDoc({
-                        doc: subjectDoc,
-                        credentialDid: nextDetailRecord.credentialDid,
-                    });
+                    const cachedSubjectDoc = await fetchCachedDid(nextDetailRecord.subjectDid);
+                    let manifestEntry = cachedSubjectDoc
+                        ? getManifestEntryFromDoc({
+                            doc: cachedSubjectDoc,
+                            credentialDid: nextDetailRecord.credentialDid,
+                        })
+                        : null;
+
+                    if (!manifestEntry) {
+                        const subjectDoc = await gatekeeper.resolveDID(nextDetailRecord.subjectDid) as Record<string, unknown>;
+                        manifestEntry = getManifestEntryFromDoc({
+                            doc: subjectDoc,
+                            credentialDid: nextDetailRecord.credentialDid,
+                        });
+                    }
 
                     if (!ignore) {
                         if (!manifestEntry) {
@@ -529,7 +540,8 @@ function Credentials(
                     return;
                 }
 
-                const response = await gatekeeper.resolveDID(selectedDetailDid) as Record<string, unknown>;
+                const cachedDoc = await fetchCachedDid(selectedDetailDid);
+                const response = cachedDoc ?? await gatekeeper.resolveDID(selectedDetailDid) as Record<string, unknown>;
 
                 if (!ignore) {
                     setDetailDoc(response);

--- a/services/explorer/src/components/Events.tsx
+++ b/services/explorer/src/components/Events.tsx
@@ -183,7 +183,7 @@ function Events(
                                     <Typography
                                         sx={{
                                             textDecoration: "underline",
-                                            color: "blue",
+                                            color: "primary.main",
                                             cursor: "pointer",
                                             maxWidth: 500,
                                             overflow: "hidden",

--- a/services/explorer/src/components/Header.tsx
+++ b/services/explorer/src/components/Header.tsx
@@ -18,7 +18,14 @@ const Header = (
     const navigate = useNavigate();
     const location = useLocation();
 
-    const currentTab = location.pathname.startsWith("/events") ? "events" : "search";
+    let currentTab = "search";
+
+    if (location.pathname.startsWith("/events")) {
+        currentTab = "events";
+    }
+    else if (location.pathname.startsWith("/credentials")) {
+        currentTab = "credentials";
+    }
 
     const handleTabChange = (event: React.SyntheticEvent, newValue: string) => {
         navigate("/" + newValue);
@@ -42,7 +49,12 @@ const Header = (
                     component="img"
                     src={iconInverted}
                     alt="MDIP"
-                    sx={{ width: 32, height: 32 }}
+                    sx={{
+                        width: 32,
+                        height: 32,
+                        filter: darkMode ? "invert(1)" : "none",
+                        transition: "filter 150ms ease-in-out",
+                    }}
                 />
             </Box>
 
@@ -54,6 +66,7 @@ const Header = (
             >
                 <Tab label="Search" value="search" />
                 <Tab label="Events" value="events" />
+                <Tab label="Credentials" value="credentials" />
             </Tabs>
 
             <Box sx={{ ml: "auto", display: "flex", alignItems: "center" }}>

--- a/services/explorer/src/components/JsonViewer.tsx
+++ b/services/explorer/src/components/JsonViewer.tsx
@@ -272,7 +272,7 @@ function JsonViewer(
                                         sx={{
                                             fontFamily: "Courier, monospace",
                                             textDecoration: "underline",
-                                            color: "blue",
+                                            color: "primary.main",
                                             cursor: "pointer",
                                             maxWidth: 700,
                                             overflow: "hidden",
@@ -454,4 +454,3 @@ function JsonViewer(
 }
 
 export default JsonViewer;
-

--- a/services/explorer/src/components/JsonViewer.tsx
+++ b/services/explorer/src/components/JsonViewer.tsx
@@ -20,7 +20,7 @@ import {
     MdipDocument
 } from "@mdip/gatekeeper/types";
 import ContentCopy from "@mui/icons-material/ContentCopy";
-import { handleCopyDID } from '../shared/utilities.js';
+import { fetchCachedDid, handleCopyDID } from '../shared/utilities.js';
 import axios from "axios";
 import { useSearchParams } from "react-router-dom";
 
@@ -67,7 +67,8 @@ function JsonViewer(
             setAliasDocs(undefined);
             setFormDid(did);
 
-            const docs = await gatekeeper.resolveDID(did);
+            const cachedDocs = await fetchCachedDid(did);
+            const docs = (cachedDocs ?? await gatekeeper.resolveDID(did)) as MdipDocument;
             if (!docs.didDocumentMetadata) {
                 setError("Invalid DID");
                 return;

--- a/services/explorer/src/shared/utilities.ts
+++ b/services/explorer/src/shared/utilities.ts
@@ -1,4 +1,8 @@
 import { CSSProperties } from "react";
+import axios from "axios";
+
+const searchServerURL = import.meta.env.VITE_SEARCH_SERVER || "http://localhost:4002";
+const VERSION = "/api/v1";
 
 export function getTypeStyle(type: string): CSSProperties {
     const base = { fontWeight: "bold" as const };
@@ -18,4 +22,17 @@ export function handleCopyDID(did: string, setError: (error: any) => void) {
     navigator.clipboard.writeText(did).catch((err) => {
         setError(err);
     });
+}
+
+export async function fetchCachedDid(did: string): Promise<Record<string, unknown> | null> {
+    try {
+        const response = await axios.get(`${searchServerURL}${VERSION}/did/${encodeURIComponent(did)}`);
+        return response.data as Record<string, unknown>;
+    } catch (error: any) {
+        if (error?.response?.status === 404) {
+            return null;
+        }
+
+        throw error;
+    }
 }

--- a/services/search-server/README.md
+++ b/services/search-server/README.md
@@ -67,6 +67,32 @@ KC_LOG_LEVEL=info
 - **Returns**:
     - 200 OK + [] (empty array) if nothing matches, otherwise an array of DID strings.
 
+### Published credential metrics
+
+`search-server` also derives metrics for publicly published credentials by reading
+subject DID manifests. These metrics only cover credentials that have been
+published into a subject DID document; privately held or merely issued
+credentials are not included.
+
+### `GET /api/v1/metrics/schemas/published`
+- **Description**: Returns counts of published credentials grouped by schema DID.
+- **Returns**:
+    - `200 OK` + `{ "schemas": [{ "schemaDid": "...", "count": 42 }] }`
+
+### `GET /api/v1/metrics/credentials/published`
+- **Description**: Returns published credential rows with optional filtering and pagination.
+- **Query Params**:
+    - `credentialDid` (optional)
+    - `schemaDid` (optional)
+    - `issuerDid` (optional)
+    - `subjectDid` (optional)
+    - `limit` (optional, default `50`)
+    - `offset` (optional, default `0`)
+- **Notes**:
+    - `updatedAt` is derived from the credential manifest entry's `signature.signed` when available, with a fallback to the subject DID document timestamp.
+- **Returns**:
+    - `200 OK` + `{ "total": 123, "credentials": [{ "credentialDid": "...", "schemaDid": "...", "issuerDid": "...", "subjectDid": "...", "holderDid": "...", "updatedAt": "..." }] }`
+
 ## Contributing
 
 Feel free to open issues or submit pull requests for improvements and new features.

--- a/services/search-server/src/DidIndexer.ts
+++ b/services/search-server/src/DidIndexer.ts
@@ -1,6 +1,7 @@
 import GatekeeperClient from "@mdip/gatekeeper/client";
 import type { DIDsDb } from "./types.js";
 import { childLogger } from "@mdip/common/logger";
+import { extractPublishedCredentials } from "./published-credentials.js";
 
 export interface DidIndexerOptions {
     intervalMs: number;
@@ -60,6 +61,7 @@ export default class DidIndexer {
             for (const did of dids) {
                 const doc = await this.gatekeeper.resolveDID(did);
                 await this.db.storeDID(did, doc);
+                await this.db.replacePublishedCredentials(did, extractPublishedCredentials(did, doc));
             }
 
             await this.db.saveUpdatedAfter(now);

--- a/services/search-server/src/db/json-memory.ts
+++ b/services/search-server/src/db/json-memory.ts
@@ -1,10 +1,17 @@
-import { DIDsDb } from "../types.js";
+import {
+    DIDsDb,
+    PublishedCredentialListOptions,
+    PublishedCredentialListResult,
+    PublishedCredentialRecord,
+    PublishedCredentialSchemaCount,
+} from "../types.js";
 
 type JSONObject = Record<string, unknown>;
 
 export default class DIDsDbMemory implements DIDsDb {
     private docs = new Map<string, JSONObject>();
     private config = new Map<string, string>();
+    private publishedCredentials = new Map<string, PublishedCredentialRecord[]>();
     private static readonly ARRAY_WILDCARD_END = /\[\*]$/;
     private static readonly ARRAY_WILDCARD_MID = /\[\*]\./;
 
@@ -23,9 +30,66 @@ export default class DIDsDbMemory implements DIDsDb {
         this.docs.set(did, JSON.parse(JSON.stringify(doc)) as JSONObject);
     }
 
+    async replacePublishedCredentials(holderDid: string, records: PublishedCredentialRecord[]): Promise<void> {
+        const uniqueRecords = new Map<string, PublishedCredentialRecord>();
+
+        for (const record of records) {
+            uniqueRecords.set(
+                `${record.holderDid}\u0000${record.credentialDid}`,
+                { ...record }
+            );
+        }
+
+        this.publishedCredentials.set(holderDid, Array.from(uniqueRecords.values()));
+    }
+
     async getDID(did: string): Promise<object | null> {
         const v = this.docs.get(did);
         return v ? JSON.parse(JSON.stringify(v)) : null;
+    }
+
+    async getPublishedCredentialCountsBySchema(): Promise<PublishedCredentialSchemaCount[]> {
+        const counts = new Map<string, number>();
+
+        for (const record of this.flattenPublishedCredentials()) {
+            counts.set(record.schemaDid, (counts.get(record.schemaDid) ?? 0) + 1);
+        }
+
+        return Array.from(counts.entries())
+            .map(([schemaDid, count]) => ({ schemaDid, count }))
+            .sort((a, b) => b.count - a.count || a.schemaDid.localeCompare(b.schemaDid));
+    }
+
+    async listPublishedCredentials(
+        options: PublishedCredentialListOptions = {}
+    ): Promise<PublishedCredentialListResult> {
+        const {
+            credentialDid,
+            schemaDid,
+            issuerDid,
+            subjectDid,
+            revealed,
+            limit = 50,
+            offset = 0,
+        } = options;
+
+        const filtered = this.flattenPublishedCredentials()
+            .filter(record => !credentialDid || record.credentialDid === credentialDid)
+            .filter(record => !schemaDid || record.schemaDid === schemaDid)
+            .filter(record => !issuerDid || record.issuerDid === issuerDid)
+            .filter(record => !subjectDid || record.subjectDid === subjectDid)
+            .filter(record => typeof revealed !== 'boolean' || record.revealed === revealed)
+            .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt) || a.credentialDid.localeCompare(b.credentialDid));
+
+        const normalizedLimit = Math.max(0, limit);
+        const normalizedOffset = Math.max(0, offset);
+
+        return {
+            total: filtered.length,
+            credentials: filtered
+                .slice(normalizedOffset, normalizedOffset + normalizedLimit)
+                .map(record => ({ ...record })),
+        };
     }
 
     async searchDocs(q: string): Promise<string[]> {
@@ -99,6 +163,13 @@ export default class DIDsDbMemory implements DIDsDb {
     async wipeDb(): Promise<void> {
         this.docs.clear();
         this.config.clear();
+        this.publishedCredentials.clear();
+    }
+
+    private flattenPublishedCredentials(): PublishedCredentialRecord[] {
+        return Array.from(this.publishedCredentials.values()).flatMap(records =>
+            records.map(record => ({ ...record }))
+        );
     }
 
     private getPath(root: unknown, path: string): unknown {

--- a/services/search-server/src/db/postgres.ts
+++ b/services/search-server/src/db/postgres.ts
@@ -29,8 +29,11 @@ export default class Postgres implements DIDsDb {
     private static readonly ARRAY_WILDCARD_END = /\[\*]$/;
     private static readonly ARRAY_WILDCARD_MID = /\[\*]\./;
 
-    static async create(url: string): Promise<DIDsDb> {
-        const db = new Postgres(url);
+    static async create<T extends DIDsDb>(
+        this: new (url: string) => T,
+        url: string
+    ): Promise<T> {
+        const db = new this(url);
         await db.connect();
         return db;
     }
@@ -44,7 +47,7 @@ export default class Postgres implements DIDsDb {
             return;
         }
 
-        this.pool = new Pool({ connectionString: this.url });
+        this.pool = this.createPool();
 
         await this.pool.query(`
             CREATE TABLE IF NOT EXISTS did_docs (
@@ -425,6 +428,10 @@ export default class Postgres implements DIDsDb {
         }
 
         return this.pool;
+    }
+
+    protected createPool(): Pool {
+        return new Pool({ connectionString: this.url });
     }
 
     private toJsonLiterals(values: unknown[]): string[] {

--- a/services/search-server/src/db/postgres.ts
+++ b/services/search-server/src/db/postgres.ts
@@ -1,5 +1,11 @@
 import { Pool } from 'pg';
-import { DIDsDb } from '../types.js';
+import {
+    DIDsDb,
+    PublishedCredentialListOptions,
+    PublishedCredentialListResult,
+    PublishedCredentialRecord,
+    PublishedCredentialSchemaCount,
+} from '../types.js';
 
 interface ConfigRow {
     value: string;
@@ -11,6 +17,10 @@ interface DocRow {
 
 interface DidRow {
     did: string;
+}
+
+interface CountRow {
+    total: number;
 }
 
 export default class Postgres implements DIDsDb {
@@ -42,10 +52,40 @@ export default class Postgres implements DIDsDb {
                 doc JSONB NOT NULL
             );
 
+            CREATE TABLE IF NOT EXISTS published_credentials (
+                holder_did TEXT NOT NULL,
+                credential_did TEXT NOT NULL,
+                schema_did TEXT NOT NULL,
+                issuer_did TEXT NOT NULL,
+                subject_did TEXT NOT NULL,
+                revealed BOOLEAN,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (holder_did, credential_did)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_published_credentials_schema
+                ON published_credentials (schema_did);
+
+            CREATE INDEX IF NOT EXISTS idx_published_credentials_schema_issuer
+                ON published_credentials (schema_did, issuer_did);
+
+            CREATE INDEX IF NOT EXISTS idx_published_credentials_schema_subject
+                ON published_credentials (schema_did, subject_did);
+
             CREATE TABLE IF NOT EXISTS config (
                 key TEXT PRIMARY KEY,
                 value TEXT NOT NULL
             );
+        `);
+
+        await this.pool.query(`
+            ALTER TABLE published_credentials
+            ADD COLUMN IF NOT EXISTS revealed BOOLEAN
+        `);
+
+        await this.pool.query(`
+            CREATE INDEX IF NOT EXISTS idx_published_credentials_schema_revealed
+                ON published_credentials (schema_did, revealed)
         `);
     }
 
@@ -88,6 +128,57 @@ export default class Postgres implements DIDsDb {
         );
     }
 
+    async replacePublishedCredentials(holderDid: string, records: PublishedCredentialRecord[]): Promise<void> {
+        const pool = this.getPool();
+        const client = await pool.connect();
+
+        try {
+            await client.query('BEGIN');
+            await client.query(
+                'DELETE FROM published_credentials WHERE holder_did = $1',
+                [holderDid]
+            );
+
+            for (const record of records) {
+                await client.query(
+                    `INSERT INTO published_credentials (
+                        holder_did,
+                        credential_did,
+                        schema_did,
+                        issuer_did,
+                        subject_did,
+                        revealed,
+                        updated_at
+                    ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+                    ON CONFLICT (holder_did, credential_did) DO UPDATE SET
+                        schema_did = EXCLUDED.schema_did,
+                        issuer_did = EXCLUDED.issuer_did,
+                        subject_did = EXCLUDED.subject_did,
+                        revealed = EXCLUDED.revealed,
+                        updated_at = EXCLUDED.updated_at`,
+                    [
+                        record.holderDid,
+                        record.credentialDid,
+                        record.schemaDid,
+                        record.issuerDid,
+                        record.subjectDid,
+                        record.revealed,
+                        record.updatedAt,
+                    ]
+                );
+            }
+
+            await client.query('COMMIT');
+        }
+        catch (error) {
+            await client.query('ROLLBACK');
+            throw error;
+        }
+        finally {
+            client.release();
+        }
+    }
+
     async getDID(did: string): Promise<object | null> {
         const pool = this.getPool();
         const result = await pool.query<DocRow>(
@@ -105,6 +196,94 @@ export default class Postgres implements DIDsDb {
         }
 
         return doc;
+    }
+
+    async getPublishedCredentialCountsBySchema(): Promise<PublishedCredentialSchemaCount[]> {
+        const pool = this.getPool();
+        const result = await pool.query<PublishedCredentialSchemaCount>(
+            `SELECT schema_did AS "schemaDid", COUNT(*)::int AS count
+             FROM published_credentials
+             GROUP BY schema_did
+             ORDER BY count DESC, "schemaDid" ASC`
+        );
+
+        return result.rows;
+    }
+
+    async listPublishedCredentials(
+        options: PublishedCredentialListOptions = {}
+    ): Promise<PublishedCredentialListResult> {
+        const pool = this.getPool();
+        const {
+            credentialDid,
+            schemaDid,
+            issuerDid,
+            subjectDid,
+            revealed,
+            limit = 50,
+            offset = 0,
+        } = options;
+
+        const clauses: string[] = [];
+        const params: unknown[] = [];
+        let index = 1;
+
+        if (credentialDid) {
+            clauses.push(`credential_did = $${index++}`);
+            params.push(credentialDid);
+        }
+
+        if (schemaDid) {
+            clauses.push(`schema_did = $${index++}`);
+            params.push(schemaDid);
+        }
+
+        if (issuerDid) {
+            clauses.push(`issuer_did = $${index++}`);
+            params.push(issuerDid);
+        }
+
+        if (subjectDid) {
+            clauses.push(`subject_did = $${index++}`);
+            params.push(subjectDid);
+        }
+
+        if (typeof revealed === 'boolean') {
+            clauses.push(`revealed = $${index++}`);
+            params.push(revealed);
+        }
+
+        const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
+        const totalResult = await pool.query<CountRow>(
+            `SELECT COUNT(*)::int AS total
+             FROM published_credentials
+             ${where}`,
+            params
+        );
+
+        const pageParams = [...params, Math.max(0, limit), Math.max(0, offset)];
+        const limitParam = `$${pageParams.length - 1}`;
+        const offsetParam = `$${pageParams.length}`;
+        const result = await pool.query<PublishedCredentialRecord>(
+            `SELECT
+                holder_did AS "holderDid",
+                credential_did AS "credentialDid",
+                schema_did AS "schemaDid",
+                issuer_did AS "issuerDid",
+                subject_did AS "subjectDid",
+                revealed AS "revealed",
+                updated_at AS "updatedAt"
+             FROM published_credentials
+             ${where}
+             ORDER BY updated_at DESC, credential_did ASC
+             LIMIT ${limitParam} OFFSET ${offsetParam}`,
+            pageParams
+        );
+
+        return {
+            total: totalResult.rows[0]?.total ?? 0,
+            credentials: result.rows,
+        };
     }
 
     async searchDocs(q: string): Promise<string[]> {
@@ -236,6 +415,7 @@ export default class Postgres implements DIDsDb {
     async wipeDb(): Promise<void> {
         const pool = this.getPool();
         await pool.query('DELETE FROM did_docs');
+        await pool.query('DELETE FROM published_credentials');
         await pool.query('DELETE FROM config');
     }
 

--- a/services/search-server/src/db/postgres.ts
+++ b/services/search-server/src/db/postgres.ts
@@ -458,7 +458,9 @@ export default class Postgres implements DIDsDb {
         while (match) {
             if (match[1]) {
                 tokens.push(match[1]);
-            } else if (match[2]) {
+            }
+
+            if (match[2]) {
                 tokens.push(match[2]);
             }
             match = re.exec(normalized);

--- a/services/search-server/src/db/sqlite.ts
+++ b/services/search-server/src/db/sqlite.ts
@@ -1,6 +1,12 @@
 import sqlite3 from 'sqlite3';
 import { open, Database } from 'sqlite';
-import { DIDsDb } from "../types.js";
+import {
+    DIDsDb,
+    PublishedCredentialListOptions,
+    PublishedCredentialListResult,
+    PublishedCredentialRecord,
+    PublishedCredentialSchemaCount,
+} from "../types.js";
 
 export default class Sqlite implements DIDsDb {
     private readonly dbFile: string;
@@ -34,10 +40,47 @@ export default class Sqlite implements DIDsDb {
                                                     doc TEXT NOT NULL
             );
 
+            CREATE TABLE IF NOT EXISTS published_credentials (
+                holder_did TEXT NOT NULL,
+                credential_did TEXT NOT NULL,
+                schema_did TEXT NOT NULL,
+                issuer_did TEXT NOT NULL,
+                subject_did TEXT NOT NULL,
+                revealed INTEGER,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (holder_did, credential_did)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_published_credentials_schema
+                ON published_credentials (schema_did);
+
+            CREATE INDEX IF NOT EXISTS idx_published_credentials_schema_issuer
+                ON published_credentials (schema_did, issuer_did);
+
+            CREATE INDEX IF NOT EXISTS idx_published_credentials_schema_subject
+                ON published_credentials (schema_did, subject_did);
+
             CREATE TABLE IF NOT EXISTS config (
                                                   key TEXT PRIMARY KEY,
                                                   value TEXT NOT NULL
             );
+        `);
+
+        const columns = await this.db.all<{ name: string }[]>(
+            `PRAGMA table_info('published_credentials')`
+        );
+        const hasRevealed = columns.some(column => column.name === 'revealed');
+
+        if (!hasRevealed) {
+            await this.db.exec(`
+                ALTER TABLE published_credentials
+                ADD COLUMN revealed INTEGER
+            `);
+        }
+
+        await this.db.exec(`
+            CREATE INDEX IF NOT EXISTS idx_published_credentials_schema_revealed
+                ON published_credentials (schema_did, revealed)
         `);
     }
 
@@ -81,6 +124,55 @@ export default class Sqlite implements DIDsDb {
         `, [did, docString]);
     }
 
+    async replacePublishedCredentials(holderDid: string, records: PublishedCredentialRecord[]): Promise<void> {
+        if (!this.db) {
+            throw new Error('DB not connected');
+        }
+
+        await this.db.exec('BEGIN');
+
+        try {
+            await this.db.run(
+                'DELETE FROM published_credentials WHERE holder_did = ?',
+                [holderDid]
+            );
+
+            for (const record of records) {
+                await this.db.run(`
+                    INSERT INTO published_credentials (
+                        holder_did,
+                        credential_did,
+                        schema_did,
+                        issuer_did,
+                        subject_did,
+                        revealed,
+                        updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(holder_did, credential_did) DO UPDATE SET
+                        schema_did = excluded.schema_did,
+                        issuer_did = excluded.issuer_did,
+                        subject_did = excluded.subject_did,
+                        revealed = excluded.revealed,
+                        updated_at = excluded.updated_at
+                `, [
+                    record.holderDid,
+                    record.credentialDid,
+                    record.schemaDid,
+                    record.issuerDid,
+                    record.subjectDid,
+                    record.revealed ? 1 : 0,
+                    record.updatedAt,
+                ]);
+            }
+
+            await this.db.exec('COMMIT');
+        }
+        catch (error) {
+            await this.db.exec('ROLLBACK');
+            throw error;
+        }
+    }
+
     async getDID(did: string): Promise<object | null> {
         if (!this.db) {
             throw new Error('DB not connected');
@@ -90,6 +182,114 @@ export default class Sqlite implements DIDsDb {
             return null;
         }
         return JSON.parse(row.doc);
+    }
+
+    async getPublishedCredentialCountsBySchema(): Promise<PublishedCredentialSchemaCount[]> {
+        if (!this.db) {
+            throw new Error('DB not connected');
+        }
+
+        const rows = await this.db.all<PublishedCredentialSchemaCount[]>(`
+            SELECT schema_did AS schemaDid, COUNT(*) AS count
+            FROM published_credentials
+            GROUP BY schema_did
+            ORDER BY count DESC, schemaDid ASC
+        `);
+
+        return rows.map(row => ({
+            schemaDid: row.schemaDid,
+            count: Number(row.count),
+        }));
+    }
+
+    async listPublishedCredentials(
+        options: PublishedCredentialListOptions = {}
+    ): Promise<PublishedCredentialListResult> {
+        if (!this.db) {
+            throw new Error('DB not connected');
+        }
+
+        const {
+            credentialDid,
+            schemaDid,
+            issuerDid,
+            subjectDid,
+            revealed,
+            limit = 50,
+            offset = 0,
+        } = options;
+
+        const clauses: string[] = [];
+        const params: unknown[] = [];
+
+        if (credentialDid) {
+            clauses.push('credential_did = ?');
+            params.push(credentialDid);
+        }
+
+        if (schemaDid) {
+            clauses.push('schema_did = ?');
+            params.push(schemaDid);
+        }
+
+        if (issuerDid) {
+            clauses.push('issuer_did = ?');
+            params.push(issuerDid);
+        }
+
+        if (subjectDid) {
+            clauses.push('subject_did = ?');
+            params.push(subjectDid);
+        }
+
+        if (typeof revealed === 'boolean') {
+            clauses.push('revealed = ?');
+            params.push(revealed ? 1 : 0);
+        }
+
+        const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
+
+        const totalRow = await this.db.get<{ total: number | string }>(
+            `SELECT COUNT(*) AS total FROM published_credentials ${where}`,
+            params
+        );
+
+        const rows = await this.db.all<{
+            holderDid: string;
+            credentialDid: string;
+            schemaDid: string;
+            issuerDid: string;
+            subjectDid: string;
+            revealed: number | null;
+            updatedAt: string;
+        }[]>(
+            `SELECT
+                holder_did AS holderDid,
+                credential_did AS credentialDid,
+                schema_did AS schemaDid,
+                issuer_did AS issuerDid,
+                subject_did AS subjectDid,
+                revealed AS revealed,
+                updated_at AS updatedAt
+             FROM published_credentials
+             ${where}
+             ORDER BY updated_at DESC, credential_did ASC
+             LIMIT ? OFFSET ?`,
+            [...params, Math.max(0, limit), Math.max(0, offset)]
+        );
+
+        return {
+            total: Number(totalRow?.total ?? 0),
+            credentials: rows.map(row => ({
+                holderDid: row.holderDid,
+                credentialDid: row.credentialDid,
+                schemaDid: row.schemaDid,
+                issuerDid: row.issuerDid,
+                subjectDid: row.subjectDid,
+                revealed: row.revealed === 1,
+                updatedAt: row.updatedAt,
+            })),
+        };
     }
 
     async searchDocs(q: string): Promise<string[]> {
@@ -193,6 +393,7 @@ export default class Sqlite implements DIDsDb {
         }
         await this.db.exec(`
             DELETE FROM did_docs;
+            DELETE FROM published_credentials;
             DELETE FROM config;
         `);
     }

--- a/services/search-server/src/index.ts
+++ b/services/search-server/src/index.ts
@@ -188,7 +188,7 @@ async function main() {
     app.use(express.json({ limit: config.jsonLimit }));
 
     let didDb: DIDsDb;
-    log.info(`Search Server persisting to (${config.db})`);
+    log.info(`Search Server persisting to ${config.db}`);
 
     if (config.db === 'sqlite') {
         didDb = await DIDsSQLite.create();

--- a/services/search-server/src/index.ts
+++ b/services/search-server/src/index.ts
@@ -188,6 +188,7 @@ async function main() {
     app.use(express.json({ limit: config.jsonLimit }));
 
     let didDb: DIDsDb;
+    log.info(`Search Server persisting to (${config.db})`);
 
     if (config.db === 'sqlite') {
         didDb = await DIDsSQLite.create();

--- a/services/search-server/src/index.ts
+++ b/services/search-server/src/index.ts
@@ -94,6 +94,33 @@ function shouldSkipRateLimitPath(req: express.Request, skipPaths: string[]): boo
         pathOnly === skipPath || pathOnly.startsWith(`${skipPath}/`));
 }
 
+function parseNonNegativeInteger(value: unknown, fallback: number): number {
+    const parsed = Number.parseInt(String(value ?? ''), 10);
+
+    if (Number.isInteger(parsed) && parsed >= 0) {
+        return parsed;
+    }
+
+    return fallback;
+}
+
+function parseOptionalBoolean(value: unknown): boolean | undefined {
+    if (typeof value !== 'string') {
+        return undefined;
+    }
+
+    const normalized = value.trim().toLowerCase();
+    if (normalized === 'true') {
+        return true;
+    }
+
+    if (normalized === 'false') {
+        return false;
+    }
+
+    return undefined;
+}
+
 async function main() {
     const app = express();
     const v1router = express.Router();
@@ -235,6 +262,42 @@ async function main() {
         } catch (err) {
             log.error({ error: err }, '/query error');
             res.status(500).json({ error: String(err) });
+        }
+    });
+
+    v1router.get("/metrics/schemas/published", async (req, res) => {
+        try {
+            const schemas = await didDb.getPublishedCredentialCountsBySchema();
+            res.json({ schemas });
+        } catch (error) {
+            log.error({ error }, '/metrics/schemas/published error');
+            res.status(500).json({ error: String(error) });
+        }
+    });
+
+    v1router.get("/metrics/credentials/published", async (req, res) => {
+        try {
+            const credentialDid = req.query.credentialDid?.toString();
+            const schemaDid = req.query.schemaDid?.toString();
+            const issuerDid = req.query.issuerDid?.toString();
+            const subjectDid = req.query.subjectDid?.toString();
+            const revealed = parseOptionalBoolean(req.query.revealed);
+            const limit = parseNonNegativeInteger(req.query.limit, 50);
+            const offset = parseNonNegativeInteger(req.query.offset, 0);
+            const result = await didDb.listPublishedCredentials({
+                credentialDid,
+                schemaDid,
+                issuerDid,
+                subjectDid,
+                revealed,
+                limit,
+                offset,
+            });
+
+            res.json(result);
+        } catch (error) {
+            log.error({ error }, '/metrics/credentials/published error');
+            res.status(500).json({ error: String(error) });
         }
     });
 

--- a/services/search-server/src/published-credentials.ts
+++ b/services/search-server/src/published-credentials.ts
@@ -1,0 +1,95 @@
+import { PublishedCredentialRecord } from "./types.js";
+
+interface MaybeVc {
+    type?: unknown;
+    issuer?: unknown;
+    credential?: unknown;
+    signature?: {
+        signed?: unknown;
+    };
+    credentialSubject?: {
+        id?: unknown;
+    };
+}
+
+interface MaybeMdipDocument {
+    didDocument?: {
+        id?: unknown;
+    };
+    didDocumentData?: {
+        manifest?: unknown;
+    };
+    didDocumentMetadata?: {
+        updated?: unknown;
+        created?: unknown;
+    };
+}
+
+function isDid(value: unknown): value is string {
+    return typeof value === 'string' && value.startsWith('did:');
+}
+
+function getFallbackUpdatedAt(doc: MaybeMdipDocument): string {
+    const updatedAt = doc.didDocumentMetadata?.updated ?? doc.didDocumentMetadata?.created;
+
+    return typeof updatedAt === 'string' ? updatedAt : '';
+}
+
+function getPublishedAt(vc: MaybeVc, doc: MaybeMdipDocument): string {
+    const signedAt = vc.signature?.signed;
+
+    if (typeof signedAt === 'string') {
+        return signedAt;
+    }
+
+    return getFallbackUpdatedAt(doc);
+}
+
+export function extractPublishedCredentials(
+    defaultHolderDid: string,
+    doc: object
+): PublishedCredentialRecord[] {
+    const mdipDoc = doc as MaybeMdipDocument;
+    const holderDid = isDid(mdipDoc.didDocument?.id)
+        ? mdipDoc.didDocument.id
+        : defaultHolderDid;
+
+    const manifest = mdipDoc.didDocumentData?.manifest;
+    if (!manifest || typeof manifest !== 'object' || Array.isArray(manifest)) {
+        return [];
+    }
+
+    const rows: PublishedCredentialRecord[] = [];
+
+    for (const [credentialDid, value] of Object.entries(manifest as Record<string, unknown>)) {
+        if (!isDid(credentialDid) || !value || typeof value !== 'object' || Array.isArray(value)) {
+            continue;
+        }
+
+        const vc = value as MaybeVc;
+        const type = Array.isArray(vc.type) ? vc.type : [];
+        const schemaDid = type[1];
+        const issuerDid = vc.issuer;
+        const subjectDid = vc.credentialSubject?.id;
+
+        if (type[0] !== 'VerifiableCredential' ||
+            !isDid(schemaDid) ||
+            !isDid(issuerDid) ||
+            !isDid(subjectDid) ||
+            subjectDid !== holderDid) {
+            continue;
+        }
+
+        rows.push({
+            holderDid,
+            credentialDid,
+            schemaDid,
+            issuerDid,
+            subjectDid,
+            revealed: vc.credential !== null && vc.credential !== undefined,
+            updatedAt: getPublishedAt(vc, mdipDoc),
+        });
+    }
+
+    return rows;
+}

--- a/services/search-server/src/types.ts
+++ b/services/search-server/src/types.ts
@@ -1,3 +1,33 @@
+export interface PublishedCredentialRecord {
+    holderDid: string;
+    credentialDid: string;
+    schemaDid: string;
+    issuerDid: string;
+    subjectDid: string;
+    revealed: boolean;
+    updatedAt: string;
+}
+
+export interface PublishedCredentialSchemaCount {
+    schemaDid: string;
+    count: number;
+}
+
+export interface PublishedCredentialListOptions {
+    credentialDid?: string;
+    schemaDid?: string;
+    issuerDid?: string;
+    subjectDid?: string;
+    revealed?: boolean;
+    limit?: number;
+    offset?: number;
+}
+
+export interface PublishedCredentialListResult {
+    total: number;
+    credentials: PublishedCredentialRecord[];
+}
+
 export interface DIDsDb {
     connect(): Promise<void>;
     disconnect(): Promise<void>;
@@ -6,7 +36,10 @@ export interface DIDsDb {
     saveUpdatedAfter(timestamp: string): Promise<void>;
 
     storeDID(did: string, doc: object): Promise<void>;
+    replacePublishedCredentials(holderDid: string, records: PublishedCredentialRecord[]): Promise<void>;
     getDID(did: string): Promise<object | null>;
+    getPublishedCredentialCountsBySchema(): Promise<PublishedCredentialSchemaCount[]>;
+    listPublishedCredentials(options?: PublishedCredentialListOptions): Promise<PublishedCredentialListResult>;
     searchDocs(q: string): Promise<string[]>;
     queryDocs(where: Record<string, unknown>): Promise<string[]>;
     wipeDb(): Promise<void>;

--- a/tests/search-server/published-credentials.test.ts
+++ b/tests/search-server/published-credentials.test.ts
@@ -1204,13 +1204,54 @@ describe('postgres adapter with mocked pool', () => {
         expect((db as any).normalizePath('$')).toBe('');
         expect((db as any).normalizePath('$.profile.name')).toBe('profile.name');
         expect((db as any).normalizePath('$profile.name')).toBe('profile.name');
+        expect((db as any).normalizePath('profile.name')).toBe('profile.name');
         expect((db as any).toPathTokens('$')).toStrictEqual([]);
         expect((db as any).toPathTokens('$.items[0].name')).toStrictEqual(['items', '0', 'name']);
+        expect((db as any).toPathTokens('[0]')).toStrictEqual(['0']);
         expect((db as any).toJsonLiterals([undefined, Symbol('x'), 'text'])).toStrictEqual([
             'null',
             'null',
             '"text"',
         ]);
+    });
+
+    it('uses default list filters and falls back total to zero when the count query is empty', async () => {
+        const poolQuery = jest.fn(async (sql: string, params?: unknown[]) => {
+            const text = String(sql);
+
+            if (text.includes('COUNT(*)::int AS total')) {
+                return { rowCount: 0, rows: [] };
+            }
+
+            if (text.includes('holder_did AS "holderDid"')) {
+                return { rowCount: 0, rows: [] };
+            }
+
+            return { rowCount: 0, rows: [] };
+        });
+        const mockPool = {
+            query: poolQuery,
+            end: jest.fn().mockResolvedValue(undefined),
+        };
+        const Postgres = await loadPostgresModule();
+        const db = new Postgres('postgresql://example');
+        (db as any).pool = mockPool;
+
+        expect(await db.listPublishedCredentials()).toStrictEqual({
+            total: 0,
+            credentials: [],
+        });
+
+        const totalCall = poolQuery.mock.calls.find(([sql]) =>
+            String(sql).includes('COUNT(*)::int AS total')
+        );
+        const rowsCall = poolQuery.mock.calls.find(([sql]) =>
+            String(sql).includes('holder_did AS "holderDid"')
+        );
+
+        expect(totalCall?.[0]).not.toContain('WHERE');
+        expect(totalCall?.[1]).toStrictEqual([]);
+        expect(rowsCall?.[1]).toStrictEqual([50, 0]);
     });
 
     it('constructs a real pool instance in createPool without connecting', async () => {

--- a/tests/search-server/published-credentials.test.ts
+++ b/tests/search-server/published-credentials.test.ts
@@ -1151,10 +1151,10 @@ describe('postgres adapter with mocked pool', () => {
         };
 
         class TestPostgres extends Postgres {
-            static mockPool = mockPool;
+            static readonly sharedPool = mockPool;
 
             protected createPool(): any {
-                return TestPostgres.mockPool;
+                return TestPostgres.sharedPool;
             }
         }
 

--- a/tests/search-server/published-credentials.test.ts
+++ b/tests/search-server/published-credentials.test.ts
@@ -2,6 +2,8 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { jest } from '@jest/globals';
+import sqlite3 from 'sqlite3';
+import { open } from 'sqlite';
 import { setLogger } from '../../packages/common/src/logger.ts';
 import DIDsDbMemory from '../../services/search-server/src/db/json-memory.ts';
 import Sqlite from '../../services/search-server/src/db/sqlite.ts';
@@ -142,6 +144,19 @@ beforeEach(() => {
     setLogger(logger as any);
 });
 
+function createLogger() {
+    const logger = {
+        child: jest.fn(),
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    };
+
+    logger.child.mockReturnValue(logger);
+    return logger;
+}
+
 describe('extractPublishedCredentials', () => {
     it('extracts normalized rows from a valid manifest using signature.signed as the published timestamp', () => {
         const holderDid = 'did:test:subject-1';
@@ -243,6 +258,53 @@ describe('extractPublishedCredentials', () => {
         expect(rows.map(row => ({ schemaDid: row.schemaDid, revealed: row.revealed }))).toStrictEqual([
             { schemaDid: 'did:test:schema-1', revealed: false },
             { schemaDid: 'did:test:schema-1', revealed: true },
+        ]);
+    });
+
+    it('returns an empty list when the manifest is missing or invalid', () => {
+        expect(extractPublishedCredentials('did:test:subject-1', {})).toStrictEqual([]);
+        expect(extractPublishedCredentials('did:test:subject-1', {
+            didDocumentData: {
+                manifest: [],
+            },
+        })).toStrictEqual([]);
+    });
+
+    it('falls back to the default holder DID and created timestamp when needed', () => {
+        const defaultHolderDid = 'did:test:subject-1';
+        const credentialDid = 'did:test:credential-1';
+        const schemaDid = 'did:test:schema-1';
+        const issuerDid = 'did:test:issuer-1';
+        const createdAt = '2026-03-31T09:59:00.000Z';
+
+        expect(extractPublishedCredentials(defaultHolderDid, {
+            didDocument: {
+                id: 'not-a-did',
+            },
+            didDocumentData: {
+                manifest: {
+                    [credentialDid]: {
+                        type: ['VerifiableCredential', schemaDid],
+                        issuer: issuerDid,
+                        credentialSubject: {
+                            id: defaultHolderDid,
+                        },
+                    },
+                },
+            },
+            didDocumentMetadata: {
+                created: createdAt,
+            },
+        })).toStrictEqual<PublishedCredentialRecord[]>([
+            {
+                holderDid: defaultHolderDid,
+                credentialDid,
+                schemaDid,
+                issuerDid,
+                subjectDid: defaultHolderDid,
+                revealed: false,
+                updatedAt: createdAt,
+            },
         ]);
     });
 });
@@ -694,6 +756,25 @@ describe('memory adapter query edge cases', () => {
 
         await db.disconnect();
     });
+
+    it('exposes getPath edge cases through direct calls', () => {
+        const db = new DIDsDbMemory() as any;
+        const root = {
+            profile: {
+                nested: [
+                    {
+                        value: 'found',
+                    },
+                ],
+            },
+        };
+
+        expect(db.getPath(root, '')).toBeUndefined();
+        expect(db.getPath(root, '$')).toBe(root);
+        expect(db.getPath(root, '$.profile.missing.value')).toBeUndefined();
+        expect(db.getPath({ profile: 'text' }, '$.profile.value')).toBeUndefined();
+        expect(db.getPath(root, '$.profile.nested.0.value')).toBe('found');
+    });
 });
 
 describe('sqlite adapter disconnected behavior', () => {
@@ -719,6 +800,347 @@ describe('sqlite adapter disconnected behavior', () => {
             await db.disconnect();
             fs.rmSync(tempDir, { recursive: true, force: true });
         }
+    });
+
+    it('connects idempotently and migrates legacy schemas without a revealed column', async () => {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'search-server-sqlite-legacy-'));
+        const dbFile = path.join(tempDir, 'legacy.db');
+        const rawDb = await open({
+            filename: dbFile,
+            driver: sqlite3.Database,
+        });
+
+        try {
+            await rawDb.exec(`
+                CREATE TABLE did_docs (
+                    did TEXT PRIMARY KEY,
+                    doc TEXT NOT NULL
+                );
+
+                CREATE TABLE published_credentials (
+                    holder_did TEXT NOT NULL,
+                    credential_did TEXT NOT NULL,
+                    schema_did TEXT NOT NULL,
+                    issuer_did TEXT NOT NULL,
+                    subject_did TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    PRIMARY KEY (holder_did, credential_did)
+                );
+
+                CREATE TABLE config (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL
+                );
+            `);
+        }
+        finally {
+            await rawDb.close();
+        }
+
+        const db = new Sqlite('legacy.db', tempDir);
+
+        try {
+            await db.connect();
+            await db.connect();
+
+            const internalDb = (db as any).db;
+            const columns = await internalDb.all(`PRAGMA table_info('published_credentials')`);
+
+            expect(columns.some((column: { name: string }) => column.name === 'revealed')).toBe(true);
+        }
+        finally {
+            await db.disconnect();
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('rolls back failed replacements and supports subject/revealed filters', async () => {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'search-server-sqlite-rollback-'));
+        const db = await Sqlite.create('rollback.db', tempDir) as Sqlite;
+
+        try {
+            await db.replacePublishedCredentials('did:test:subject-1', [
+                {
+                    holderDid: 'did:test:subject-1',
+                    credentialDid: 'did:test:credential-1',
+                    schemaDid: 'did:test:schema-1',
+                    issuerDid: 'did:test:issuer-1',
+                    subjectDid: 'did:test:subject-1',
+                    revealed: true,
+                    updatedAt: '2026-03-31T11:05:00.000Z',
+                },
+            ]);
+
+            expect(await db.listPublishedCredentials({
+                subjectDid: 'did:test:subject-1',
+                revealed: true,
+                limit: 10,
+                offset: 0,
+            })).toStrictEqual({
+                total: 1,
+                credentials: [
+                    {
+                        holderDid: 'did:test:subject-1',
+                        credentialDid: 'did:test:credential-1',
+                        schemaDid: 'did:test:schema-1',
+                        issuerDid: 'did:test:issuer-1',
+                        subjectDid: 'did:test:subject-1',
+                        revealed: true,
+                        updatedAt: '2026-03-31T11:05:00.000Z',
+                    },
+                ],
+            });
+
+            await expect(db.replacePublishedCredentials('did:test:subject-1', [
+                {
+                    holderDid: 'did:test:subject-1',
+                    credentialDid: 'did:test:credential-2',
+                    schemaDid: null as any,
+                    issuerDid: 'did:test:issuer-2',
+                    subjectDid: 'did:test:subject-1',
+                    revealed: false,
+                    updatedAt: '2026-03-31T11:06:00.000Z',
+                },
+            ] as any)).rejects.toBeTruthy();
+
+            expect(await db.listPublishedCredentials({
+                subjectDid: 'did:test:subject-1',
+                revealed: true,
+                limit: 10,
+                offset: 0,
+            })).toStrictEqual({
+                total: 1,
+                credentials: [
+                    {
+                        holderDid: 'did:test:subject-1',
+                        credentialDid: 'did:test:credential-1',
+                        schemaDid: 'did:test:schema-1',
+                        issuerDid: 'did:test:issuer-1',
+                        subjectDid: 'did:test:subject-1',
+                        revealed: true,
+                        updatedAt: '2026-03-31T11:05:00.000Z',
+                    },
+                ],
+            });
+        }
+        finally {
+            await db.disconnect();
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+});
+
+describe('postgres adapter with mocked pool', () => {
+    async function loadPostgresModule() {
+        jest.resetModules();
+        const module = await import('../../services/search-server/src/db/postgres.ts');
+        return module.default;
+    }
+
+    it('covers connect, read/write helpers, query variants, and wipe behavior', async () => {
+        let configReads = 0;
+        let didReads = 0;
+        const poolQuery = jest.fn(async (sql: string, params?: unknown[]) => {
+            const text = String(sql);
+
+            if (text.includes('CREATE TABLE IF NOT EXISTS did_docs')) {
+                return { rowCount: 0, rows: [] };
+            }
+            if (text.includes('ALTER TABLE published_credentials')) {
+                return { rowCount: 0, rows: [] };
+            }
+            if (text.includes('CREATE INDEX IF NOT EXISTS idx_published_credentials_schema_revealed')) {
+                return { rowCount: 0, rows: [] };
+            }
+            if (text.includes('SELECT value FROM config WHERE key = $1 LIMIT 1')) {
+                configReads += 1;
+                if (configReads === 1) {
+                    return { rowCount: 0, rows: [] };
+                }
+
+                return { rowCount: 1, rows: [{ value: '2026-04-02T09:00:00.000Z' }] };
+            }
+            if (text.includes(`INSERT INTO config (key, value) VALUES ('updated_after', $1)`)) {
+                return { rowCount: 1, rows: [] };
+            }
+            if (text.includes('INSERT INTO did_docs (did, doc) VALUES ($1, $2::jsonb)')) {
+                return { rowCount: 1, rows: [] };
+            }
+            if (text.includes('SELECT doc FROM did_docs WHERE did = $1 LIMIT 1')) {
+                didReads += 1;
+                if (didReads === 1) {
+                    return { rowCount: 1, rows: [{ doc: '{"stored":true}' }] };
+                }
+                if (didReads === 2) {
+                    return { rowCount: 1, rows: [{ doc: { stored: 'object' } }] };
+                }
+
+                return { rowCount: 0, rows: [] };
+            }
+            if (text.includes('COUNT(*)::int AS count')) {
+                return { rowCount: 1, rows: [{ schemaDid: 'did:test:schema-1', count: 2 }] };
+            }
+            if (text.includes('COUNT(*)::int AS total')) {
+                return { rowCount: 1, rows: [{ total: 1 }] };
+            }
+            if (text.includes('holder_did AS "holderDid"')) {
+                return {
+                    rowCount: 1,
+                    rows: [{
+                        holderDid: 'did:test:subject-1',
+                        credentialDid: 'did:test:credential-1',
+                        schemaDid: 'did:test:schema-1',
+                        issuerDid: 'did:test:issuer-1',
+                        subjectDid: 'did:test:subject-1',
+                        revealed: true,
+                        updatedAt: '2026-04-02T09:05:00.000Z',
+                    }],
+                };
+            }
+            if (text.includes("WHERE doc::text LIKE '%' || $1 || '%'")) {
+                return { rowCount: 1, rows: [{ did: 'did:test:search-1' }] };
+            }
+            if (text.includes('JOIN LATERAL jsonb_array_elements') && text.includes('elem.value = expected.value::jsonb')) {
+                return { rowCount: 1, rows: [{ did: 'did:test:array-tail' }] };
+            }
+            if (text.includes('JOIN LATERAL jsonb_array_elements') && text.includes('elem.value #> $2::text[] = expected.value::jsonb')) {
+                return { rowCount: 1, rows: [{ did: 'did:test:array-mid' }] };
+            }
+            if (text.includes('JOIN LATERAL jsonb_each') && text.includes('member.key = ANY($2::text[])')) {
+                return { rowCount: 1, rows: [{ did: 'did:test:key-wildcard' }] };
+            }
+            if (text.includes('JOIN LATERAL jsonb_each') && text.includes('member.value #> $2::text[] = expected.value::jsonb')) {
+                return { rowCount: 1, rows: [{ did: 'did:test:value-wildcard' }] };
+            }
+            if (text.includes('WHERE EXISTS (') && text.includes('did_docs.doc #> $1::text[] = expected.value::jsonb')) {
+                return { rowCount: 1, rows: [{ did: 'did:test:plain-path' }] };
+            }
+            if (text === 'DELETE FROM did_docs' || text === 'DELETE FROM published_credentials' || text === 'DELETE FROM config') {
+                return { rowCount: 1, rows: [] };
+            }
+
+            return { rowCount: 0, rows: [] };
+        });
+        const mockClient = {
+            query: jest.fn(),
+            release: jest.fn(),
+        };
+        const mockPool = {
+            query: poolQuery,
+            connect: jest.fn().mockResolvedValue(mockClient),
+            end: jest.fn().mockResolvedValue(undefined),
+        };
+        const Postgres = await loadPostgresModule();
+        const db = new Postgres('postgresql://example');
+        (db as any).pool = mockPool;
+
+        expect(await db.loadUpdatedAfter()).toBeNull();
+        expect(await db.saveUpdatedAfter('2026-04-02T09:00:00.000Z')).toBeUndefined();
+        expect(await db.loadUpdatedAfter()).toBe('2026-04-02T09:00:00.000Z');
+        expect(await db.storeDID('did:test:doc-1', { stored: true })).toBeUndefined();
+        expect(await db.getDID('did:test:doc-1')).toStrictEqual({ stored: true });
+        expect(await db.getDID('did:test:doc-2')).toStrictEqual({ stored: 'object' });
+        expect(await db.getDID('did:test:doc-3')).toBeNull();
+        expect(await db.getPublishedCredentialCountsBySchema()).toStrictEqual([
+            { schemaDid: 'did:test:schema-1', count: 2 },
+        ]);
+        expect(await db.listPublishedCredentials({
+            credentialDid: 'did:test:credential-1',
+            schemaDid: 'did:test:schema-1',
+            issuerDid: 'did:test:issuer-1',
+            subjectDid: 'did:test:subject-1',
+            revealed: true,
+            limit: 5,
+            offset: 10,
+        })).toStrictEqual({
+            total: 1,
+            credentials: [{
+                holderDid: 'did:test:subject-1',
+                credentialDid: 'did:test:credential-1',
+                schemaDid: 'did:test:schema-1',
+                issuerDid: 'did:test:issuer-1',
+                subjectDid: 'did:test:subject-1',
+                revealed: true,
+                updatedAt: '2026-04-02T09:05:00.000Z',
+            }],
+        });
+        expect(await db.searchDocs('search')).toStrictEqual(['did:test:search-1']);
+
+        expect(await db.queryDocs({})).toStrictEqual([]);
+        await expect(db.queryDocs({ '$.didDocument.id': {} } as any)).rejects.toThrow('Only {$in:[…]} supported');
+        expect(await db.queryDocs({ '$.didDocument.id': { $in: [] } })).toStrictEqual([]);
+        expect(await db.queryDocs({ '$.didDocumentData.tags[*]': { $in: ['tag', undefined] } })).toStrictEqual(['did:test:array-tail']);
+        expect(await db.queryDocs({ '$.didDocumentData.nested[*].kind': { $in: ['shared'] } })).toStrictEqual(['did:test:array-mid']);
+        expect(await db.queryDocs({ '$.didDocumentData.manifest.*': { $in: ['cred'] } })).toStrictEqual(['did:test:key-wildcard']);
+        expect(await db.queryDocs({ '$.didDocumentData.manifest.*.issuer': { $in: ['issuer'] } })).toStrictEqual(['did:test:value-wildcard']);
+        expect(await db.queryDocs({ '$.didDocument.id': { $in: ['did:test:plain-path'] } })).toStrictEqual(['did:test:plain-path']);
+
+        await db.wipeDb();
+        await db.disconnect();
+        await db.disconnect();
+
+        expect(mockPool.end).toHaveBeenCalledTimes(1);
+
+        const arrayTailCall = poolQuery.mock.calls.find(([sql]) =>
+            String(sql).includes('elem.value = expected.value::jsonb')
+        );
+        const defaultPathCall = poolQuery.mock.calls.find(([sql]) =>
+            String(sql).includes('did_docs.doc #> $1::text[] = expected.value::jsonb')
+        );
+
+        expect(arrayTailCall?.[1]).toStrictEqual([
+            ['didDocumentData', 'tags'],
+            ['"tag"', 'null'],
+        ]);
+        expect(defaultPathCall?.[1]).toStrictEqual([
+            ['didDocument', 'id'],
+            ['"did:test:plain-path"'],
+        ]);
+    });
+
+    it('throws when disconnected and rolls back failed replacements', async () => {
+        const clientError = new Error('insert failed');
+        const mockClient = {
+            query: jest.fn()
+                .mockResolvedValueOnce(undefined)
+                .mockResolvedValueOnce(undefined)
+                .mockRejectedValueOnce(clientError)
+                .mockResolvedValueOnce(undefined),
+            release: jest.fn(),
+        };
+        const mockPool = {
+            query: jest.fn().mockResolvedValue({ rowCount: 0, rows: [] }),
+            connect: jest.fn().mockResolvedValue(mockClient),
+            end: jest.fn().mockResolvedValue(undefined),
+        };
+        const Postgres = await loadPostgresModule();
+        const disconnectedDb = new Postgres('postgresql://example');
+
+        await expect(disconnectedDb.loadUpdatedAfter()).rejects.toThrow('Postgres DB not connected');
+
+        const db = new Postgres('postgresql://example');
+        (db as any).pool = mockPool;
+
+        await expect(db.replacePublishedCredentials('did:test:subject-1', [
+            {
+                holderDid: 'did:test:subject-1',
+                credentialDid: 'did:test:credential-1',
+                schemaDid: 'did:test:schema-1',
+                issuerDid: 'did:test:issuer-1',
+                subjectDid: 'did:test:subject-1',
+                revealed: false,
+                updatedAt: '2026-04-02T09:05:00.000Z',
+            },
+        ])).rejects.toThrow(clientError);
+
+        expect(mockClient.query).toHaveBeenNthCalledWith(1, 'BEGIN');
+        expect(mockClient.query).toHaveBeenNthCalledWith(
+            2,
+            'DELETE FROM published_credentials WHERE holder_did = $1',
+            ['did:test:subject-1']
+        );
+        expect(mockClient.query).toHaveBeenNthCalledWith(4, 'ROLLBACK');
+        expect(mockClient.release).toHaveBeenCalledTimes(1);
     });
 });
 
@@ -759,5 +1181,120 @@ describe('DidIndexer published credential indexing', () => {
                 },
             ],
         });
+    });
+
+    it('skips refresh work when gatekeeper is not ready', async () => {
+        const db = {
+            loadUpdatedAfter: jest.fn(),
+            storeDID: jest.fn(),
+            replacePublishedCredentials: jest.fn(),
+            saveUpdatedAfter: jest.fn(),
+        };
+        const gatekeeper = {
+            isReady: jest.fn().mockResolvedValue(false),
+        };
+        const indexer = new DidIndexer(gatekeeper as any, db as any, { intervalMs: 60_000 });
+
+        await (indexer as any).refreshIndex();
+
+        expect(db.loadUpdatedAfter).not.toHaveBeenCalled();
+        expect(db.saveUpdatedAfter).not.toHaveBeenCalled();
+    });
+
+    it('skips overlapping refresh calls while one is already in progress', async () => {
+        let resolveGetDIDs: ((value: string[]) => void) | null = null;
+        const getDIDsPromise = new Promise<string[]>((resolve) => {
+            resolveGetDIDs = resolve;
+        });
+        const db = {
+            loadUpdatedAfter: jest.fn().mockResolvedValue(null),
+            storeDID: jest.fn(),
+            replacePublishedCredentials: jest.fn(),
+            saveUpdatedAfter: jest.fn(),
+        };
+        const gatekeeper = {
+            isReady: jest.fn().mockResolvedValue(true),
+            getDIDs: jest.fn().mockReturnValue(getDIDsPromise),
+            resolveDID: jest.fn(),
+        };
+        const indexer = new DidIndexer(gatekeeper as any, db as any, { intervalMs: 60_000 });
+
+        const firstRefresh = (indexer as any).refreshIndex();
+        await Promise.resolve();
+        await (indexer as any).refreshIndex();
+
+        expect(gatekeeper.getDIDs).toHaveBeenCalledTimes(1);
+
+        resolveGetDIDs!([]);
+        await firstRefresh;
+    });
+
+    it('logs refresh errors and resets state for later runs', async () => {
+        const logger = createLogger();
+        setLogger(logger as any);
+
+        const db = {
+            loadUpdatedAfter: jest.fn().mockResolvedValue(null),
+            storeDID: jest.fn(),
+            replacePublishedCredentials: jest.fn(),
+            saveUpdatedAfter: jest.fn(),
+        };
+        const error = new Error('boom');
+        const gatekeeper = {
+            isReady: jest.fn().mockResolvedValue(true),
+            getDIDs: jest.fn().mockRejectedValueOnce(error).mockResolvedValueOnce([]),
+            resolveDID: jest.fn(),
+        };
+        const indexer = new DidIndexer(gatekeeper as any, db as any, { intervalMs: 60_000 });
+
+        await (indexer as any).refreshIndex();
+        await (indexer as any).refreshIndex();
+
+        expect(logger.error).toHaveBeenCalledWith({ error }, 'Error in refreshIndex');
+        expect(db.saveUpdatedAfter).toHaveBeenCalledTimes(1);
+    });
+
+    it('logs rejected interval refreshes from the timer callback', async () => {
+        const logger = createLogger();
+        setLogger(logger as any);
+
+        const db = {
+            loadUpdatedAfter: jest.fn().mockResolvedValue(null),
+            storeDID: jest.fn(),
+            replacePublishedCredentials: jest.fn(),
+            saveUpdatedAfter: jest.fn(),
+        };
+        const gatekeeper = {
+            isReady: jest.fn().mockResolvedValue(true),
+            getDIDs: jest.fn().mockResolvedValue([]),
+            resolveDID: jest.fn(),
+        };
+        const setIntervalSpy = jest.spyOn(global, 'setInterval');
+        const clearIntervalSpy = jest.spyOn(global, 'clearInterval').mockImplementation(() => undefined as any);
+        let intervalCallback: (() => Promise<void>) | undefined;
+
+        setIntervalSpy.mockImplementation(((callback: () => Promise<void>) => {
+            intervalCallback = callback;
+            return {} as NodeJS.Timeout;
+        }) as any);
+
+        try {
+            const indexer = new DidIndexer(gatekeeper as any, db as any, { intervalMs: 60_000 });
+            await indexer.startIndexing();
+            (indexer as any).refreshIndex = jest.fn().mockRejectedValue(new Error('timer boom'));
+
+            await intervalCallback!();
+
+            expect(logger.error).toHaveBeenCalledWith(
+                { error: expect.any(Error) },
+                'refreshIndex error'
+            );
+
+            indexer.stopIndexing();
+        }
+        finally {
+            setIntervalSpy.mockRestore();
+            clearIntervalSpy.mockRestore();
+        }
     });
 });

--- a/tests/search-server/published-credentials.test.ts
+++ b/tests/search-server/published-credentials.test.ts
@@ -1,0 +1,551 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { jest } from '@jest/globals';
+import { setLogger } from '../../packages/common/src/logger.ts';
+import DIDsDbMemory from '../../services/search-server/src/db/json-memory.ts';
+import Sqlite from '../../services/search-server/src/db/sqlite.ts';
+import DidIndexer from '../../services/search-server/src/DidIndexer.ts';
+import { extractPublishedCredentials } from '../../services/search-server/src/published-credentials.ts';
+import type {
+    PublishedCredentialRecord,
+    PublishedCredentialSchemaCount,
+} from '../../services/search-server/src/types.ts';
+
+function createPublishedCredential(
+    schemaDid: string,
+    issuerDid: string,
+    subjectDid: string,
+    options: { reveal?: boolean; signed?: string } = {}
+) {
+    const {
+        reveal = false,
+        signed = '2026-03-31T10:30:00.000Z',
+    } = options;
+
+    return {
+        "@context": [
+            "https://www.w3.org/ns/credentials/v2",
+            "https://www.w3.org/ns/credentials/examples/v2"
+        ],
+        type: ['VerifiableCredential', schemaDid],
+        issuer: issuerDid,
+        validFrom: '2026-03-31T10:00:00.000Z',
+        credentialSubject: {
+            id: subjectDid,
+        },
+        signature: {
+            signed,
+        },
+        credential: reveal ? { score: 100 } : null,
+    };
+}
+
+function createSubjectDoc(
+    holderDid: string,
+    manifest: Record<string, unknown>,
+    updatedAt = '2026-03-31T11:00:00.000Z'
+) {
+    return {
+        didDocument: {
+            id: holderDid,
+        },
+        didDocumentData: {
+            manifest,
+        },
+        didDocumentMetadata: {
+            updated: updatedAt,
+        },
+    };
+}
+
+beforeEach(() => {
+    const logger = {
+        child: jest.fn(),
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    };
+
+    logger.child.mockReturnValue(logger);
+    setLogger(logger as any);
+});
+
+describe('extractPublishedCredentials', () => {
+    it('extracts normalized rows from a valid manifest using signature.signed as the published timestamp', () => {
+        const holderDid = 'did:test:subject-1';
+        const schemaDid = 'did:test:schema-1';
+        const issuerDid = 'did:test:issuer-1';
+        const credentialDid = 'did:test:credential-1';
+        const signedAt = '2026-03-31T10:41:22.000Z';
+        const doc = createSubjectDoc(holderDid, {
+            [credentialDid]: createPublishedCredential(schemaDid, issuerDid, holderDid, {
+                signed: signedAt,
+            }),
+        });
+
+        expect(extractPublishedCredentials(holderDid, doc)).toStrictEqual<PublishedCredentialRecord[]>([
+            {
+                holderDid,
+                credentialDid,
+                schemaDid,
+                issuerDid,
+                subjectDid: holderDid,
+                revealed: false,
+                updatedAt: signedAt,
+            },
+        ]);
+    });
+
+    it('falls back to the subject DID document timestamp when signature.signed is missing', () => {
+        const holderDid = 'did:test:subject-1';
+        const credentialDid = 'did:test:credential-1';
+        const doc = createSubjectDoc(holderDid, {
+            [credentialDid]: {
+                "@context": [
+                    "https://www.w3.org/ns/credentials/v2",
+                    "https://www.w3.org/ns/credentials/examples/v2"
+                ],
+                type: ['VerifiableCredential', 'did:test:schema-1'],
+                issuer: 'did:test:issuer-1',
+                credentialSubject: {
+                    id: holderDid,
+                },
+                credential: null,
+            },
+        }, '2026-03-31T11:00:00.000Z');
+
+        expect(extractPublishedCredentials(holderDid, doc)).toStrictEqual<PublishedCredentialRecord[]>([
+            {
+                holderDid,
+                credentialDid,
+                schemaDid: 'did:test:schema-1',
+                issuerDid: 'did:test:issuer-1',
+                subjectDid: holderDid,
+                revealed: false,
+                updatedAt: '2026-03-31T11:00:00.000Z',
+            },
+        ]);
+    });
+
+    it('ignores malformed or mismatched manifest entries', () => {
+        const holderDid = 'did:test:subject-1';
+        const doc = createSubjectDoc(holderDid, {
+            'did:test:not-vc': {
+                type: ['NotVC', 'did:test:schema-1'],
+                issuer: 'did:test:issuer-1',
+                credentialSubject: { id: holderDid },
+            },
+            'did:test:mismatch': createPublishedCredential(
+                'did:test:schema-2',
+                'did:test:issuer-2',
+                'did:test:someone-else'
+            ),
+            'not-a-did': createPublishedCredential(
+                'did:test:schema-3',
+                'did:test:issuer-3',
+                holderDid
+            ),
+        });
+
+        expect(extractPublishedCredentials(holderDid, doc)).toStrictEqual([]);
+    });
+
+    it('counts reveal=false and reveal=true manifests equally', () => {
+        const holderDid = 'did:test:subject-1';
+        const doc = createSubjectDoc(holderDid, {
+            'did:test:credential-1': createPublishedCredential(
+                'did:test:schema-1',
+                'did:test:issuer-1',
+                holderDid
+            ),
+            'did:test:credential-2': createPublishedCredential(
+                'did:test:schema-1',
+                'did:test:issuer-2',
+                holderDid,
+                { reveal: true }
+            ),
+        });
+
+        const rows = extractPublishedCredentials(holderDid, doc);
+        expect(rows).toHaveLength(2);
+        expect(rows.map(row => ({ schemaDid: row.schemaDid, revealed: row.revealed }))).toStrictEqual([
+            { schemaDid: 'did:test:schema-1', revealed: false },
+            { schemaDid: 'did:test:schema-1', revealed: true },
+        ]);
+    });
+});
+
+describe('published credential aggregation', () => {
+    it('deduplicates duplicate published credential rows when replacing holder rows', async () => {
+        const db = new DIDsDbMemory();
+
+        await db.replacePublishedCredentials('did:test:subject-1', [
+            {
+                holderDid: 'did:test:subject-1',
+                credentialDid: 'did:test:credential-1',
+                schemaDid: 'did:test:schema-1',
+                issuerDid: 'did:test:issuer-1',
+                subjectDid: 'did:test:subject-1',
+                revealed: false,
+                updatedAt: '2026-03-31T11:05:00.000Z',
+            },
+            {
+                holderDid: 'did:test:subject-1',
+                credentialDid: 'did:test:credential-1',
+                schemaDid: 'did:test:schema-1',
+                issuerDid: 'did:test:issuer-1',
+                subjectDid: 'did:test:subject-1',
+                revealed: false,
+                updatedAt: '2026-03-31T11:05:00.000Z',
+            },
+        ]);
+
+        expect(await db.listPublishedCredentials({
+            schemaDid: 'did:test:schema-1',
+            limit: 10,
+            offset: 0,
+        })).toStrictEqual({
+            total: 1,
+            credentials: [
+                {
+                    holderDid: 'did:test:subject-1',
+                    credentialDid: 'did:test:credential-1',
+                    schemaDid: 'did:test:schema-1',
+                    issuerDid: 'did:test:issuer-1',
+                    subjectDid: 'did:test:subject-1',
+                    revealed: false,
+                    updatedAt: '2026-03-31T11:05:00.000Z',
+                },
+            ],
+        });
+    });
+
+    it('aggregates counts in memory and supports replacing holder rows', async () => {
+        const db = new DIDsDbMemory();
+        const subject1Doc = createSubjectDoc('did:test:subject-1', {
+            'did:test:credential-1': createPublishedCredential(
+                'did:test:schema-1',
+                'did:test:issuer-1',
+                'did:test:subject-1',
+                { reveal: true }
+            ),
+            'did:test:credential-2': createPublishedCredential(
+                'did:test:schema-1',
+                'did:test:issuer-2',
+                'did:test:subject-1'
+            ),
+        }, '2026-03-31T11:05:00.000Z');
+        const subject2Doc = createSubjectDoc('did:test:subject-2', {
+            'did:test:credential-3': createPublishedCredential(
+                'did:test:schema-2',
+                'did:test:issuer-1',
+                'did:test:subject-2'
+            ),
+        }, '2026-03-31T11:10:00.000Z');
+
+        await db.storeDID('did:test:subject-1', subject1Doc);
+        await db.storeDID('did:test:subject-2', subject2Doc);
+
+        await db.replacePublishedCredentials('did:test:subject-1', [
+            {
+                holderDid: 'did:test:subject-1',
+                credentialDid: 'did:test:credential-1',
+                schemaDid: 'did:test:schema-1',
+                issuerDid: 'did:test:issuer-1',
+                subjectDid: 'did:test:subject-1',
+                revealed: true,
+                updatedAt: '2026-03-31T11:05:00.000Z',
+            },
+            {
+                holderDid: 'did:test:subject-1',
+                credentialDid: 'did:test:credential-2',
+                schemaDid: 'did:test:schema-1',
+                issuerDid: 'did:test:issuer-2',
+                subjectDid: 'did:test:subject-1',
+                revealed: false,
+                updatedAt: '2026-03-31T11:05:00.000Z',
+            },
+        ]);
+
+        await db.replacePublishedCredentials('did:test:subject-2', [
+            {
+                holderDid: 'did:test:subject-2',
+                credentialDid: 'did:test:credential-3',
+                schemaDid: 'did:test:schema-2',
+                issuerDid: 'did:test:issuer-1',
+                subjectDid: 'did:test:subject-2',
+                revealed: false,
+                updatedAt: '2026-03-31T11:10:00.000Z',
+            },
+        ]);
+
+        expect(await db.getPublishedCredentialCountsBySchema()).toStrictEqual<PublishedCredentialSchemaCount[]>([
+            { schemaDid: 'did:test:schema-1', count: 2 },
+            { schemaDid: 'did:test:schema-2', count: 1 },
+        ]);
+
+        expect(await db.listPublishedCredentials({
+            schemaDid: 'did:test:schema-1',
+            limit: 1,
+            offset: 0,
+        })).toStrictEqual({
+            total: 2,
+            credentials: [
+                {
+                    holderDid: 'did:test:subject-1',
+                    credentialDid: 'did:test:credential-1',
+                    schemaDid: 'did:test:schema-1',
+                    issuerDid: 'did:test:issuer-1',
+                    subjectDid: 'did:test:subject-1',
+                    revealed: true,
+                    updatedAt: '2026-03-31T11:05:00.000Z',
+                },
+            ],
+        });
+
+        expect(await db.listPublishedCredentials({
+            schemaDid: 'did:test:schema-1',
+            revealed: false,
+            limit: 10,
+            offset: 0,
+        })).toStrictEqual({
+            total: 1,
+            credentials: [
+                {
+                    holderDid: 'did:test:subject-1',
+                    credentialDid: 'did:test:credential-2',
+                    schemaDid: 'did:test:schema-1',
+                    issuerDid: 'did:test:issuer-2',
+                    subjectDid: 'did:test:subject-1',
+                    revealed: false,
+                    updatedAt: '2026-03-31T11:05:00.000Z',
+                },
+            ],
+        });
+
+        expect(await db.listPublishedCredentials({
+            credentialDid: 'did:test:credential-3',
+            limit: 10,
+            offset: 0,
+        })).toStrictEqual({
+            total: 1,
+            credentials: [
+                {
+                    holderDid: 'did:test:subject-2',
+                    credentialDid: 'did:test:credential-3',
+                    schemaDid: 'did:test:schema-2',
+                    issuerDid: 'did:test:issuer-1',
+                    subjectDid: 'did:test:subject-2',
+                    revealed: false,
+                    updatedAt: '2026-03-31T11:10:00.000Z',
+                },
+            ],
+        });
+
+        await db.replacePublishedCredentials('did:test:subject-1', []);
+
+        expect(await db.getPublishedCredentialCountsBySchema()).toStrictEqual([
+            { schemaDid: 'did:test:schema-2', count: 1 },
+        ]);
+    });
+
+    it('aggregates counts in sqlite', async () => {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'search-server-sqlite-'));
+        const db = await Sqlite.create('metrics.db', tempDir) as Sqlite;
+
+        try {
+            const subject1Doc = createSubjectDoc('did:test:subject-1', {
+                'did:test:credential-1': createPublishedCredential(
+                    'did:test:schema-1',
+                    'did:test:issuer-1',
+                    'did:test:subject-1',
+                    { reveal: true }
+                ),
+                'did:test:credential-2': createPublishedCredential(
+                    'did:test:schema-1',
+                    'did:test:issuer-2',
+                    'did:test:subject-1'
+                ),
+            }, '2026-03-31T11:05:00.000Z');
+            const subject2Doc = createSubjectDoc('did:test:subject-2', {
+                'did:test:credential-3': createPublishedCredential(
+                    'did:test:schema-2',
+                    'did:test:issuer-1',
+                    'did:test:subject-2'
+                ),
+            }, '2026-03-31T11:10:00.000Z');
+
+            await db.storeDID('did:test:subject-1', subject1Doc);
+            await db.storeDID('did:test:subject-2', subject2Doc);
+
+            await db.replacePublishedCredentials('did:test:subject-1', [
+                {
+                    holderDid: 'did:test:subject-1',
+                    credentialDid: 'did:test:credential-1',
+                    schemaDid: 'did:test:schema-1',
+                    issuerDid: 'did:test:issuer-1',
+                    subjectDid: 'did:test:subject-1',
+                    revealed: true,
+                    updatedAt: '2026-03-31T11:05:00.000Z',
+                },
+                {
+                    holderDid: 'did:test:subject-1',
+                    credentialDid: 'did:test:credential-2',
+                    schemaDid: 'did:test:schema-1',
+                    issuerDid: 'did:test:issuer-2',
+                    subjectDid: 'did:test:subject-1',
+                    revealed: false,
+                    updatedAt: '2026-03-31T11:05:00.000Z',
+                },
+            ]);
+
+            await db.replacePublishedCredentials('did:test:subject-2', [
+                {
+                    holderDid: 'did:test:subject-2',
+                    credentialDid: 'did:test:credential-3',
+                    schemaDid: 'did:test:schema-2',
+                    issuerDid: 'did:test:issuer-1',
+                    subjectDid: 'did:test:subject-2',
+                    revealed: false,
+                    updatedAt: '2026-03-31T11:10:00.000Z',
+                },
+            ]);
+
+            expect(await db.getPublishedCredentialCountsBySchema()).toStrictEqual([
+                { schemaDid: 'did:test:schema-1', count: 2 },
+                { schemaDid: 'did:test:schema-2', count: 1 },
+            ]);
+
+            expect(await db.listPublishedCredentials({
+                schemaDid: 'did:test:schema-1',
+                issuerDid: 'did:test:issuer-2',
+                limit: 10,
+                offset: 0,
+            })).toStrictEqual({
+                total: 1,
+                credentials: [
+                    {
+                        holderDid: 'did:test:subject-1',
+                        credentialDid: 'did:test:credential-2',
+                        schemaDid: 'did:test:schema-1',
+                        issuerDid: 'did:test:issuer-2',
+                        subjectDid: 'did:test:subject-1',
+                        revealed: false,
+                        updatedAt: '2026-03-31T11:05:00.000Z',
+                    },
+                ],
+            });
+
+            expect(await db.listPublishedCredentials({
+                credentialDid: 'did:test:credential-3',
+                limit: 10,
+                offset: 0,
+            })).toStrictEqual({
+                total: 1,
+                credentials: [
+                    {
+                        holderDid: 'did:test:subject-2',
+                        credentialDid: 'did:test:credential-3',
+                        schemaDid: 'did:test:schema-2',
+                        issuerDid: 'did:test:issuer-1',
+                        subjectDid: 'did:test:subject-2',
+                        revealed: false,
+                        updatedAt: '2026-03-31T11:10:00.000Z',
+                    },
+                ],
+            });
+
+            await db.replacePublishedCredentials('did:test:subject-2', [
+                {
+                    holderDid: 'did:test:subject-2',
+                    credentialDid: 'did:test:credential-3',
+                    schemaDid: 'did:test:schema-2',
+                    issuerDid: 'did:test:issuer-1',
+                    subjectDid: 'did:test:subject-2',
+                    revealed: false,
+                    updatedAt: '2026-03-31T11:10:00.000Z',
+                },
+                {
+                    holderDid: 'did:test:subject-2',
+                    credentialDid: 'did:test:credential-3',
+                    schemaDid: 'did:test:schema-2',
+                    issuerDid: 'did:test:issuer-1',
+                    subjectDid: 'did:test:subject-2',
+                    revealed: false,
+                    updatedAt: '2026-03-31T11:10:00.000Z',
+                },
+            ]);
+
+            expect(await db.listPublishedCredentials({
+                schemaDid: 'did:test:schema-2',
+                limit: 10,
+                offset: 0,
+            })).toStrictEqual({
+                total: 1,
+                credentials: [
+                    {
+                        holderDid: 'did:test:subject-2',
+                        credentialDid: 'did:test:credential-3',
+                        schemaDid: 'did:test:schema-2',
+                        issuerDid: 'did:test:issuer-1',
+                        subjectDid: 'did:test:subject-2',
+                        revealed: false,
+                        updatedAt: '2026-03-31T11:10:00.000Z',
+                    },
+                ],
+            });
+
+            await db.replacePublishedCredentials('did:test:subject-1', []);
+
+            expect(await db.getPublishedCredentialCountsBySchema()).toStrictEqual([
+                { schemaDid: 'did:test:schema-2', count: 1 },
+            ]);
+        }
+        finally {
+            await db.disconnect();
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+});
+
+describe('DidIndexer published credential indexing', () => {
+    it('stores published credential rows during refresh', async () => {
+        const db = new DIDsDbMemory();
+        const holderDid = 'did:test:subject-1';
+        const schemaDid = 'did:test:schema-1';
+        const issuerDid = 'did:test:issuer-1';
+        const credentialDid = 'did:test:credential-1';
+        const doc = createSubjectDoc(holderDid, {
+            [credentialDid]: createPublishedCredential(schemaDid, issuerDid, holderDid),
+        });
+        const gatekeeper = {
+            isReady: jest.fn().mockResolvedValue(true),
+            getDIDs: jest.fn().mockResolvedValue([holderDid]),
+            resolveDID: jest.fn().mockResolvedValue(doc),
+        };
+        const indexer = new DidIndexer(gatekeeper as any, db, { intervalMs: 60_000 });
+
+        await indexer.startIndexing();
+        indexer.stopIndexing();
+
+        expect(await db.getPublishedCredentialCountsBySchema()).toStrictEqual([
+            { schemaDid, count: 1 },
+        ]);
+        expect(await db.listPublishedCredentials({ schemaDid, limit: 10, offset: 0 })).toStrictEqual({
+            total: 1,
+            credentials: [
+                {
+                    holderDid,
+                    credentialDid,
+                    schemaDid,
+                    issuerDid,
+                    subjectDid: holderDid,
+                    revealed: false,
+                    updatedAt: '2026-03-31T10:30:00.000Z',
+                },
+            ],
+        });
+    });
+});

--- a/tests/search-server/published-credentials.test.ts
+++ b/tests/search-server/published-credentials.test.ts
@@ -8,6 +8,7 @@ import Sqlite from '../../services/search-server/src/db/sqlite.ts';
 import DidIndexer from '../../services/search-server/src/DidIndexer.ts';
 import { extractPublishedCredentials } from '../../services/search-server/src/published-credentials.ts';
 import type {
+    DIDsDb,
     PublishedCredentialRecord,
     PublishedCredentialSchemaCount,
 } from '../../services/search-server/src/types.ts';
@@ -58,6 +59,75 @@ function createSubjectDoc(
         },
     };
 }
+
+function createQueryableDoc(
+    did: string,
+    {
+        name,
+        tags,
+        nestedKinds,
+        manifest,
+        coordinates,
+    }: {
+        name: string;
+        tags: string[];
+        nestedKinds: string[];
+        manifest: Record<string, { issuer: string }>;
+        coordinates: string[];
+    }
+) {
+    return {
+        didDocument: {
+            id: did,
+        },
+        didDocumentData: {
+            profile: {
+                name,
+            },
+            tags,
+            nested: nestedKinds.map(kind => ({ kind })),
+            coordinates,
+            manifest,
+        },
+    };
+}
+
+type DbHarness = {
+    db: DIDsDb;
+    cleanup: () => Promise<void>;
+};
+
+const adapterFactories = [
+    {
+        name: 'memory',
+        create: async (): Promise<DbHarness> => {
+            const db = new DIDsDbMemory();
+            await db.connect();
+
+            return {
+                db,
+                cleanup: async () => {
+                    await db.disconnect();
+                },
+            };
+        },
+    },
+    {
+        name: 'sqlite',
+        create: async (): Promise<DbHarness> => {
+            const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'search-server-query-'));
+            const db = await Sqlite.create('query.db', tempDir);
+
+            return {
+                db,
+                cleanup: async () => {
+                    await db.disconnect();
+                    fs.rmSync(tempDir, { recursive: true, force: true });
+                },
+            };
+        },
+    },
+] as const;
 
 beforeEach(() => {
     const logger = {
@@ -502,6 +572,148 @@ describe('published credential aggregation', () => {
             expect(await db.getPublishedCredentialCountsBySchema()).toStrictEqual([
                 { schemaDid: 'did:test:schema-2', count: 1 },
             ]);
+        }
+        finally {
+            await db.disconnect();
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+});
+
+describe.each(adapterFactories)('$name query and utility behavior', ({ create }) => {
+    it('round-trips config and docs, supports search and query variants, and wipes all state', async () => {
+        const { db, cleanup } = await create();
+
+        try {
+            const did1 = 'did:test:query-1';
+            const did2 = 'did:test:query-2';
+            const doc1 = createQueryableDoc(did1, {
+                name: 'Needle Alpha',
+                tags: ['alpha', 'shared'],
+                nestedKinds: ['first', 'shared'],
+                coordinates: ['zero', 'one'],
+                manifest: {
+                    'did:test:credential-a': { issuer: 'did:test:issuer-1' },
+                    'did:test:credential-b': { issuer: 'did:test:issuer-2' },
+                },
+            });
+            const doc2 = createQueryableDoc(did2, {
+                name: 'Haystack Beta',
+                tags: ['beta'],
+                nestedKinds: ['second'],
+                coordinates: ['left', 'right'],
+                manifest: {
+                    'did:test:credential-c': { issuer: 'did:test:issuer-3' },
+                },
+            });
+
+            expect(await db.loadUpdatedAfter()).toBeNull();
+
+            await db.saveUpdatedAfter('2026-04-01T12:34:00.000Z');
+            expect(await db.loadUpdatedAfter()).toBe('2026-04-01T12:34:00.000Z');
+
+            await db.storeDID(did1, doc1);
+            await db.storeDID(did2, doc2);
+
+            const storedDoc = await db.getDID(did1) as Record<string, any>;
+            expect(storedDoc).toStrictEqual(doc1);
+            storedDoc.didDocumentData.profile.name = 'Mutated';
+            expect((await db.getDID(did1) as any).didDocumentData.profile.name).toBe('Needle Alpha');
+            expect(await db.getDID('did:test:missing')).toBeNull();
+
+            await db.replacePublishedCredentials(did1, [
+                {
+                    holderDid: did1,
+                    credentialDid: 'did:test:credential-a',
+                    schemaDid: 'did:test:schema-a',
+                    issuerDid: 'did:test:issuer-1',
+                    subjectDid: did1,
+                    revealed: true,
+                    updatedAt: '2026-04-01T12:35:00.000Z',
+                },
+            ]);
+
+            expect(await db.searchDocs('Needle')).toStrictEqual([did1]);
+            expect(await db.queryDocs({
+                '$.didDocument.id': { $in: [did1] },
+            })).toStrictEqual([did1]);
+            expect(await db.queryDocs({
+                'didDocumentData.tags[*]': { $in: ['shared'] },
+            })).toStrictEqual([did1]);
+            expect(await db.queryDocs({
+                'didDocumentData.nested[*].kind': { $in: ['shared'] },
+            })).toStrictEqual([did1]);
+            expect(await db.queryDocs({
+                'didDocumentData.manifest.*': { $in: ['did:test:credential-b'] },
+            })).toStrictEqual([did1]);
+            expect(await db.queryDocs({
+                'didDocumentData.manifest.*.issuer': { $in: ['did:test:issuer-3'] },
+            })).toStrictEqual([did2]);
+
+            await expect(db.queryDocs({
+                'didDocument.id': {},
+            } as any)).rejects.toThrow('Only {$in:[…]} supported');
+
+            await db.wipeDb();
+
+            expect(await db.loadUpdatedAfter()).toBeNull();
+            expect(await db.searchDocs('Needle')).toStrictEqual([]);
+            expect(await db.getDID(did1)).toBeNull();
+            expect(await db.getPublishedCredentialCountsBySchema()).toStrictEqual([]);
+            expect(await db.listPublishedCredentials({ limit: 10, offset: 0 })).toStrictEqual({
+                total: 0,
+                credentials: [],
+            });
+        }
+        finally {
+            await cleanup();
+        }
+    });
+});
+
+describe('memory adapter query edge cases', () => {
+    it('returns no matches for an empty where clause and supports numeric array path segments', async () => {
+        const db = new DIDsDbMemory();
+        const did = 'did:test:memory-query-1';
+
+        await db.connect();
+        await db.storeDID(did, createQueryableDoc(did, {
+            name: 'Indexed Value',
+            tags: ['memory'],
+            nestedKinds: ['only'],
+            coordinates: ['zero', 'one'],
+            manifest: {
+                'did:test:credential-memory': { issuer: 'did:test:issuer-memory' },
+            },
+        }));
+
+        expect(await db.queryDocs({})).toStrictEqual([]);
+        expect(await db.queryDocs({
+            '$.didDocumentData.coordinates.1': { $in: ['one'] },
+        })).toStrictEqual([did]);
+
+        await db.disconnect();
+    });
+});
+
+describe('sqlite adapter disconnected behavior', () => {
+    it('throws consistent errors when used before connect', async () => {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'search-server-sqlite-disconnected-'));
+        const db = new Sqlite('disconnected.db', tempDir);
+
+        try {
+            await expect(db.loadUpdatedAfter()).rejects.toThrow('DB not connected');
+            await expect(db.saveUpdatedAfter('2026-04-01T12:00:00.000Z')).rejects.toThrow('DB not connected');
+            await expect(db.storeDID('did:test:doc', {})).rejects.toThrow('DB not connected');
+            await expect(db.replacePublishedCredentials('did:test:doc', [])).rejects.toThrow('DB not connected');
+            await expect(db.getDID('did:test:doc')).rejects.toThrow('DB not connected');
+            await expect(db.getPublishedCredentialCountsBySchema()).rejects.toThrow('DB not connected');
+            await expect(db.listPublishedCredentials()).rejects.toThrow('DB not connected');
+            await expect(db.searchDocs('doc')).rejects.toThrow('DB not connected');
+            await expect(db.queryDocs({
+                'didDocument.id': { $in: ['did:test:doc'] },
+            })).rejects.toThrow('DB not connected');
+            await expect(db.wipeDb()).rejects.toThrow('DB not connected');
         }
         finally {
             await db.disconnect();

--- a/tests/search-server/published-credentials.test.ts
+++ b/tests/search-server/published-credentials.test.ts
@@ -1142,6 +1142,85 @@ describe('postgres adapter with mocked pool', () => {
         expect(mockClient.query).toHaveBeenNthCalledWith(4, 'ROLLBACK');
         expect(mockClient.release).toHaveBeenCalledTimes(1);
     });
+
+    it('covers static create plus real connect and disconnect branches with spied pool methods', async () => {
+        const Postgres = await loadPostgresModule();
+        const mockPool = {
+            query: jest.fn().mockResolvedValue({ rowCount: 0, rows: [] }),
+            end: jest.fn().mockResolvedValue(undefined),
+        };
+
+        class TestPostgres extends Postgres {
+            static mockPool = mockPool;
+
+            protected createPool(): any {
+                return TestPostgres.mockPool;
+            }
+        }
+
+        const db = await TestPostgres.create('postgresql://example');
+
+        await (db as any).connect();
+        await db.disconnect();
+        await db.disconnect();
+
+        expect(mockPool.query).toHaveBeenCalledTimes(3);
+        expect(mockPool.end).toHaveBeenCalledTimes(1);
+
+        const disconnectedDb = new TestPostgres('postgresql://example');
+        await disconnectedDb.disconnect();
+    });
+
+    it('commits successful replacements and covers path helper fallbacks', async () => {
+        const mockClient = {
+            query: jest.fn().mockResolvedValue(undefined),
+            release: jest.fn(),
+        };
+        const mockPool = {
+            query: jest.fn().mockResolvedValue({ rowCount: 0, rows: [] }),
+            connect: jest.fn().mockResolvedValue(mockClient),
+            end: jest.fn().mockResolvedValue(undefined),
+        };
+        const Postgres = await loadPostgresModule();
+        const db = new Postgres('postgresql://example');
+        (db as any).pool = mockPool;
+
+        await db.replacePublishedCredentials('did:test:subject-1', [
+            {
+                holderDid: 'did:test:subject-1',
+                credentialDid: 'did:test:credential-1',
+                schemaDid: 'did:test:schema-1',
+                issuerDid: 'did:test:issuer-1',
+                subjectDid: 'did:test:subject-1',
+                revealed: true,
+                updatedAt: '2026-04-02T09:05:00.000Z',
+            },
+        ]);
+
+        expect(mockClient.query).toHaveBeenNthCalledWith(1, 'BEGIN');
+        expect(mockClient.query).toHaveBeenNthCalledWith(4, 'COMMIT');
+        expect(mockClient.release).toHaveBeenCalledTimes(1);
+
+        expect((db as any).normalizePath('$')).toBe('');
+        expect((db as any).normalizePath('$.profile.name')).toBe('profile.name');
+        expect((db as any).normalizePath('$profile.name')).toBe('profile.name');
+        expect((db as any).toPathTokens('$')).toStrictEqual([]);
+        expect((db as any).toPathTokens('$.items[0].name')).toStrictEqual(['items', '0', 'name']);
+        expect((db as any).toJsonLiterals([undefined, Symbol('x'), 'text'])).toStrictEqual([
+            'null',
+            'null',
+            '"text"',
+        ]);
+    });
+
+    it('constructs a real pool instance in createPool without connecting', async () => {
+        const Postgres = await loadPostgresModule();
+        const db = new Postgres('postgresql://example');
+        const pool = (db as any).createPool();
+
+        expect(pool).toBeTruthy();
+        await pool.end();
+    });
 });
 
 describe('DidIndexer published credential indexing', () => {


### PR DESCRIPTION
## Summary
- add published credential indexing to `search-server` by deriving rows from subject DID manifests during refresh
- add published credential storage and query support across SQLite, Postgres, and in-memory adapters
- add public metrics endpoints for schema counts and published credential listing, including direct lookup by `credentialDid`
- add a new explorer `Credentials` tab with schema browsing, credential browsing, and full-page credential detail views
- show credential detail from the subject manifest entry so revealed vs redacted publication is visible
- use `signature.signed` as the published timestamp when available, with fallback to the subject DID document timestamp

## Search-Server Changes
- add `published_credentials` as a derived index populated from public subject manifests
- add typed published credential records and list/count query interfaces
- expose:
  - `GET /api/v1/metrics/schemas/published`
  - `GET /api/v1/metrics/credentials/published`
- support filtering published credential rows by:
  - `credentialDid`
  - `schemaDid`
  - `issuerDid`
  - `subjectDid`
  - `revealed`

## Explorer Changes
- add `/credentials` route and header tab
- add schema list view with published counts
- add schema-scoped credential list view with pagination
- add full-page credential detail view with back navigation
- show `Credential`, `Subject`, `Issuer`, and `Revealed` metadata above the JSON viewer

## Notes
- existing `search-server` databases need a rebuild/reindex to populate `published_credentials` rows for already indexed DIDs
- the published credential dashboard only covers credentials made visible via publication