### PR TITLE
fix: support mounted .env files in container deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ A Keychain MDIP node includes several interoperating microservices. If you follo
 
 Customize your node in the kc/.env file. Environment variables are documented for each service in the READMEs linked in the Overview above.
 
+When running the services outside `./start-node`, the supported configuration methods are:
+
+- inject environment variables directly with Docker Compose or Kubernetes
+- mount a shared `.env` file at `/app/.env` inside the container
+- mount a `.env` file anywhere and set `KC_ENV_FILE` to that path
+
+This matches local startup and avoids custom entrypoint wrappers just to source env files.
+
 ```
 KC_UID=1000                                        # Docker host UID
 KC_GID=1002                                        # Docker host GID

--- a/doc/02-server/deployment/index.mdx
+++ b/doc/02-server/deployment/index.mdx
@@ -219,6 +219,8 @@ Another important file controlling the behavior of an MDIP node is the `kc/docke
 
 Operators wanting to operate MDIP in a Kubernetes or similar virtualized environment will find the environment variable dependencies for each MDIP component in the `kc/docker-compose.yml` file.
 
+MDIP services support the same configuration model in container orchestration environments without custom wrapper scripts. Operators can either inject environment variables directly, mount a shared `.env` file at `/app/.env`, or mount a file elsewhere and set `KC_ENV_FILE` to the mounted path.
+
 #### Gatekeeper Service
 
 Below is the MDIP `gatekeeper` definition.
@@ -753,4 +755,3 @@ server {
         allow all;
     }
 ```
-

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,6 +14,7 @@ const config = {
     moduleNameMapper: {
         '^@mdip/cipher/node$': '<rootDir>/packages/cipher/src/cipher-node.ts',
         '^@mdip/cipher/types': '<rootDir>/packages/cipher/src/types.ts',
+        '^@mdip/common/env$': '<rootDir>/packages/common/src/env.ts',
         '^@mdip/common/errors$': '<rootDir>/packages/common/src/errors.ts',
         '^@mdip/common/utils$': '<rootDir>/packages/common/src/utils.ts',
         '^@mdip/common/logger': '<rootDir>/packages/common/src/logger.ts',

--- a/package-lock.json
+++ b/package-lock.json
@@ -29281,6 +29281,7 @@
       "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
+        "dotenv": "^17.3.1",
         "pino": "^10.3.1",
         "pino-pretty": "^13.1.3"
       },
@@ -29288,6 +29289,18 @@
         "@rollup/plugin-commonjs": "^29.0.1",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "rollup": "^4.59.0"
+      }
+    },
+    "packages/common/node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "packages/gatekeeper": {

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -18,6 +18,11 @@
       "require": "./dist/cjs/index.cjs",
       "types": "./dist/types/index.d.ts"
     },
+    "./env": {
+      "import": "./dist/esm/env.js",
+      "require": "./dist/cjs/env.cjs",
+      "types": "./dist/types/env.d.ts"
+    },
     "./utils": {
       "import": "./dist/esm/utils.js",
       "require": "./dist/cjs/utils.cjs",
@@ -36,6 +41,9 @@
   },
   "typesVersions": {
     "*": {
+      "env": [
+        "./dist/types/env.d.ts"
+      ],
       "utils": [
         "./dist/types/utils.d.ts"
       ],
@@ -57,6 +65,7 @@
   "author": "David McFadzean <davidmc@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "dotenv": "^17.3.1",
     "pino": "^10.3.1",
     "pino-pretty": "^13.1.3"
   },

--- a/packages/common/rollup.cjs.config.js
+++ b/packages/common/rollup.cjs.config.js
@@ -10,6 +10,7 @@ const external = [
 
 const config = {
     input: {
+        env: 'dist/esm/env.js',
         'index': 'dist/esm/index.js',
         utils: 'dist/esm/utils.js',
         errors: 'dist/esm/errors.js',

--- a/packages/common/src/env.ts
+++ b/packages/common/src/env.ts
@@ -1,0 +1,124 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import dotenv from 'dotenv';
+
+const DEFAULT_ENV_FILENAME = '.env';
+const DEFAULT_ENV_FILE_VAR = 'KC_ENV_FILE';
+
+export interface LoadEnvOptions {
+    cwd?: string;
+    envFileVar?: string;
+    filenames?: string[];
+}
+
+function hasPackageJson(dir: string): boolean {
+    return fs.existsSync(path.join(dir, 'package.json'));
+}
+
+function hasWorkspaceRootMarker(dir: string): boolean {
+    if (fs.existsSync(path.join(dir, '.git')) || fs.existsSync(path.join(dir, 'docker-compose.yml'))) {
+        return true;
+    }
+
+    const packageJsonPath = path.join(dir, 'package.json');
+
+    if (!fs.existsSync(packageJsonPath)) {
+        return false;
+    }
+
+    try {
+        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as { workspaces?: unknown };
+        return Array.isArray(packageJson.workspaces) || Boolean(packageJson.workspaces);
+    } catch {
+        return false;
+    }
+}
+
+function collectSearchDirectories(startDir: string): string[] {
+    const directories: string[] = [];
+    let currentDir = path.resolve(startDir);
+    let nearestPackageIndex = -1;
+
+    while (true) {
+        directories.push(currentDir);
+
+        if (nearestPackageIndex === -1 && hasPackageJson(currentDir)) {
+            nearestPackageIndex = directories.length - 1;
+        }
+
+        if (hasWorkspaceRootMarker(currentDir)) {
+            return directories;
+        }
+
+        const parentDir = path.dirname(currentDir);
+
+        if (parentDir === currentDir) {
+            break;
+        }
+
+        currentDir = parentDir;
+    }
+
+    if (nearestPackageIndex >= 0) {
+        return directories.slice(0, nearestPackageIndex + 1);
+    }
+
+    return directories;
+}
+
+export function resolveEnvFiles(options: LoadEnvOptions = {}): string[] {
+    const cwd = options.cwd ?? process.cwd();
+    const envFileVar = options.envFileVar ?? DEFAULT_ENV_FILE_VAR;
+    const filenames = options.filenames ?? [DEFAULT_ENV_FILENAME];
+    const explicitEnvFile = process.env[envFileVar]?.trim();
+    const candidates: string[] = [];
+
+    if (explicitEnvFile) {
+        const resolvedExplicitEnvFile = path.resolve(cwd, explicitEnvFile);
+
+        if (!fs.existsSync(resolvedExplicitEnvFile)) {
+            throw new Error(`Environment file set by ${envFileVar} was not found: ${resolvedExplicitEnvFile}`);
+        }
+
+        candidates.push(resolvedExplicitEnvFile);
+    }
+
+    for (const dir of collectSearchDirectories(cwd)) {
+        for (const filename of filenames) {
+            candidates.push(path.join(dir, filename));
+        }
+    }
+
+    const uniqueFiles = new Set<string>();
+
+    return candidates.filter(candidate => {
+        const resolvedCandidate = path.resolve(candidate);
+
+        if (uniqueFiles.has(resolvedCandidate)) {
+            return false;
+        }
+
+        uniqueFiles.add(resolvedCandidate);
+
+        return fs.existsSync(resolvedCandidate) && fs.statSync(resolvedCandidate).isFile();
+    });
+}
+
+export function loadEnv(options: LoadEnvOptions = {}): string[] {
+    const loadedFiles: string[] = [];
+
+    for (const envFile of resolveEnvFiles(options)) {
+        const result = dotenv.config({
+            path: envFile,
+            override: false,
+        });
+
+        if (result.error) {
+            throw result.error;
+        }
+
+        loadedFiles.push(envFile);
+    }
+
+    return loadedFiles;
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,3 +1,4 @@
+export * from './env.js';
 export * from './errors.js';
 export * from './logger.js';
 export * from './utils.js';

--- a/services/explorer/server.js
+++ b/services/explorer/server.js
@@ -1,10 +1,10 @@
 import express from 'express';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import dotenv from 'dotenv';
+import { loadEnv } from '@mdip/common/env';
 import { childLogger } from '@mdip/common/logger';
 
-dotenv.config();
+loadEnv();
 const log = childLogger({ service: 'explorer-server' });
 
 const __filename = fileURLToPath(import.meta.url);

--- a/services/gatekeeper/server/src/config.js
+++ b/services/gatekeeper/server/src/config.js
@@ -1,6 +1,6 @@
-import dotenv from 'dotenv';
+import { loadEnv } from '@mdip/common/env';
 
-dotenv.config();
+loadEnv();
 
 const DEFAULT_RATE_LIMIT_SKIP_PATHS = ['/api/v1/ready'];
 

--- a/services/keymaster/server/src/config.js
+++ b/services/keymaster/server/src/config.js
@@ -1,6 +1,6 @@
-import dotenv from 'dotenv';
+import { loadEnv } from '@mdip/common/env';
 
-dotenv.config();
+loadEnv();
 
 const DEFAULT_RATE_LIMIT_SKIP_PATHS = ['/api/v1/ready'];
 

--- a/services/mediators/hyperswarm/src/config.js
+++ b/services/mediators/hyperswarm/src/config.js
@@ -1,6 +1,6 @@
-import dotenv from 'dotenv';
+import { loadEnv } from '@mdip/common/env';
 
-dotenv.config();
+loadEnv();
 
 function parsePositiveIntEnv(varName, defaultValue, options = {}) {
     const allowZero = options.allowZero === true;

--- a/services/mediators/satoshi-inscription/src/config.ts
+++ b/services/mediators/satoshi-inscription/src/config.ts
@@ -1,6 +1,6 @@
-import dotenv from 'dotenv';
+import { loadEnv } from '@mdip/common/env';
 
-dotenv.config();
+loadEnv();
 
 export type NetworkName = 'bitcoin' | 'testnet' | 'regtest';
 export type ChainName = 'BTC' | 'TBTC' | 'Signet' | 'TFTC';

--- a/services/mediators/satoshi/src/config.ts
+++ b/services/mediators/satoshi/src/config.ts
@@ -1,6 +1,6 @@
-import dotenv from 'dotenv';
+import { loadEnv } from '@mdip/common/env';
 
-dotenv.config();
+loadEnv();
 
 export type NetworkName = 'bitcoin' | 'testnet' | 'regtest';
 export type ChainName = 'BTC' | 'TBTC' | 'Signet' | 'TFTC';

--- a/services/search-server/src/config.ts
+++ b/services/search-server/src/config.ts
@@ -1,6 +1,6 @@
-import dotenv from "dotenv";
+import { loadEnv } from "@mdip/common/env";
 
-dotenv.config();
+loadEnv();
 
 const DEFAULT_RATE_LIMIT_SKIP_PATHS = ['/api/v1/ready'];
 

--- a/tests/common/env.test.ts
+++ b/tests/common/env.test.ts
@@ -1,0 +1,79 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { loadEnv, resolveEnvFiles } from '../../packages/common/src/env.ts';
+
+const ORIGINAL_ENV = { ...process.env };
+const ORIGINAL_CWD = process.cwd();
+
+describe('loadEnv', () => {
+    let tempDir = '';
+
+    beforeEach(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'kc-env-'));
+        process.env = { ...ORIGINAL_ENV };
+    });
+
+    afterEach(() => {
+        process.env = { ...ORIGINAL_ENV };
+        process.chdir(ORIGINAL_CWD);
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    test('loads service and workspace env files without overriding process env', () => {
+        const workspaceDir = path.join(tempDir, 'repo');
+        const serviceDir = path.join(workspaceDir, 'services', 'search-server');
+        const distDir = path.join(serviceDir, 'dist');
+
+        fs.mkdirSync(distDir, { recursive: true });
+        fs.writeFileSync(path.join(workspaceDir, 'package.json'), JSON.stringify({ workspaces: ['packages/*'] }));
+        fs.writeFileSync(path.join(workspaceDir, '.env'), 'ROOT_ONLY=root\nSHARED=root\nEXISTING=root\n');
+        fs.writeFileSync(path.join(serviceDir, '.env'), 'SERVICE_ONLY=service\nSHARED=service\n');
+
+        process.env.EXISTING = 'process';
+        process.chdir(distDir);
+
+        const loadedFiles = loadEnv();
+
+        expect(loadedFiles).toEqual([
+            path.join(serviceDir, '.env'),
+            path.join(workspaceDir, '.env'),
+        ]);
+        expect(process.env.SERVICE_ONLY).toBe('service');
+        expect(process.env.ROOT_ONLY).toBe('root');
+        expect(process.env.SHARED).toBe('service');
+        expect(process.env.EXISTING).toBe('process');
+    });
+
+    test('loads an explicit KC_ENV_FILE before discovered env files', () => {
+        const workspaceDir = path.join(tempDir, 'repo');
+        const serviceDir = path.join(workspaceDir, 'services', 'search-server');
+        const mountedDir = path.join(tempDir, 'mounted');
+        const explicitEnvFile = path.join(mountedDir, 'kc.env');
+
+        fs.mkdirSync(serviceDir, { recursive: true });
+        fs.mkdirSync(mountedDir, { recursive: true });
+        fs.writeFileSync(path.join(workspaceDir, 'package.json'), JSON.stringify({ workspaces: ['packages/*'] }));
+        fs.writeFileSync(path.join(workspaceDir, '.env'), 'ROOT_ONLY=root\n');
+        fs.writeFileSync(explicitEnvFile, 'MOUNTED_ONLY=mounted\nROOT_ONLY=mounted\n');
+
+        process.env.KC_ENV_FILE = explicitEnvFile;
+        process.chdir(serviceDir);
+
+        const loadedFiles = loadEnv();
+
+        expect(loadedFiles).toEqual([
+            explicitEnvFile,
+            path.join(workspaceDir, '.env'),
+        ]);
+        expect(process.env.MOUNTED_ONLY).toBe('mounted');
+        expect(process.env.ROOT_ONLY).toBe('mounted');
+    });
+
+    test('throws when KC_ENV_FILE points to a missing file', () => {
+        process.env.KC_ENV_FILE = path.join(tempDir, 'missing.env');
+        process.chdir(tempDir);
+
+        expect(() => resolveEnvFiles()).toThrow(`Environment file set by KC_ENV_FILE was not found: ${path.join(tempDir, 'missing.env')}`);
+    });
+});

--- a/tests/common/env.test.ts
+++ b/tests/common/env.test.ts
@@ -70,10 +70,94 @@ describe('loadEnv', () => {
         expect(process.env.ROOT_ONLY).toBe('mounted');
     });
 
+    test('deduplicates KC_ENV_FILE when it matches a discovered env file', () => {
+        const workspaceDir = path.join(tempDir, 'repo');
+        const serviceDir = path.join(workspaceDir, 'services', 'search-server');
+        const rootEnvFile = path.join(workspaceDir, '.env');
+
+        fs.mkdirSync(serviceDir, { recursive: true });
+        fs.writeFileSync(path.join(workspaceDir, 'package.json'), JSON.stringify({ workspaces: ['packages/*'] }));
+        fs.writeFileSync(rootEnvFile, 'ROOT_ONLY=root\n');
+
+        process.env.KC_ENV_FILE = rootEnvFile;
+        process.chdir(serviceDir);
+
+        expect(resolveEnvFiles()).toEqual([rootEnvFile]);
+    });
+
+    test('stops searching at the nearest package when package.json cannot be parsed', () => {
+        const workspaceDir = path.join(tempDir, 'repo');
+        const serviceDir = path.join(workspaceDir, 'services', 'search-server', 'dist');
+        const workspaceEnvFile = path.join(workspaceDir, '.env');
+        const outsideEnvFile = path.join(tempDir, '.env');
+
+        fs.mkdirSync(serviceDir, { recursive: true });
+        fs.writeFileSync(path.join(workspaceDir, 'package.json'), '{ not-valid-json');
+        fs.writeFileSync(workspaceEnvFile, 'ROOT_ONLY=root\n');
+        fs.writeFileSync(outsideEnvFile, 'OUTSIDE=outside\n');
+
+        process.chdir(serviceDir);
+
+        expect(resolveEnvFiles()).toEqual([workspaceEnvFile]);
+    });
+
+    test('stops searching when docker-compose.yml marks the workspace root', () => {
+        const workspaceDir = path.join(tempDir, 'repo');
+        const serviceDir = path.join(workspaceDir, 'services', 'search-server', 'dist');
+        const workspaceEnvFile = path.join(workspaceDir, '.env');
+        const outsideEnvFile = path.join(tempDir, '.env');
+
+        fs.mkdirSync(serviceDir, { recursive: true });
+        fs.writeFileSync(path.join(workspaceDir, 'docker-compose.yml'), 'services:\n  app:\n    image: test\n');
+        fs.writeFileSync(workspaceEnvFile, 'ROOT_ONLY=root\n');
+        fs.writeFileSync(outsideEnvFile, 'OUTSIDE=outside\n');
+
+        process.chdir(serviceDir);
+
+        expect(resolveEnvFiles()).toEqual([workspaceEnvFile]);
+    });
+
+    test('treats a truthy workspaces field as a workspace root marker', () => {
+        const workspaceDir = path.join(tempDir, 'repo');
+        const serviceDir = path.join(workspaceDir, 'services', 'search-server', 'dist');
+        const workspaceEnvFile = path.join(workspaceDir, '.env');
+        const outsideEnvFile = path.join(tempDir, '.env');
+
+        fs.mkdirSync(serviceDir, { recursive: true });
+        fs.writeFileSync(path.join(workspaceDir, 'package.json'), JSON.stringify({ workspaces: 'packages/*' }));
+        fs.writeFileSync(workspaceEnvFile, 'ROOT_ONLY=root\n');
+        fs.writeFileSync(outsideEnvFile, 'OUTSIDE=outside\n');
+
+        process.chdir(serviceDir);
+
+        expect(resolveEnvFiles()).toEqual([workspaceEnvFile]);
+    });
+
+    test('searches ancestor directories even outside a package workspace', () => {
+        const nestedDir = path.join(tempDir, 'loose', 'service', 'dist');
+        const ancestorEnvFile = path.join(tempDir, '.env');
+
+        fs.mkdirSync(nestedDir, { recursive: true });
+        fs.writeFileSync(ancestorEnvFile, 'LOOSE=1\n');
+
+        expect(resolveEnvFiles({ cwd: nestedDir })).toContain(ancestorEnvFile);
+    });
+
     test('throws when KC_ENV_FILE points to a missing file', () => {
         process.env.KC_ENV_FILE = path.join(tempDir, 'missing.env');
         process.chdir(tempDir);
 
         expect(() => resolveEnvFiles()).toThrow(`Environment file set by KC_ENV_FILE was not found: ${path.join(tempDir, 'missing.env')}`);
+    });
+
+    test('throws when dotenv reports an error while loading a file', () => {
+        const envFile = path.join(tempDir, '.env');
+
+        fs.writeFileSync(envFile, 'ROOT_ONLY=root\n');
+        fs.chmodSync(envFile, 0o000);
+
+        expect(() => loadEnv({ cwd: tempDir })).toThrow();
+
+        fs.chmodSync(envFile, 0o600);
     });
 });


### PR DESCRIPTION
## Summary

- add a shared env loader for MDIP services
- support mounted `.env` files in containers without requiring a custom `entrypoint.sh`
- support `KC_ENV_FILE` for env files mounted at non-default paths
- keep existing `./start-node` and direct environment injection behavior unchanged
- document the supported deployment patterns for Docker Compose and Kubernetes

## Problem

Local startup works because `./start-node` sources the repo root `.env` and `docker compose` injects the resolved values into each container.

In standalone container deployments such as Kubernetes, operators may mount a `.env` file into the  container, but the service does not automatically load that file unless they add a wrapper script to  source and export it first.

## Solution

This PR adds a shared env-loading utility in `@mdip/common` and updates the runtime services to use it at startup.

The loader now supports the following configuration patterns:

- direct env injection via `env` / `envFrom`
- a mounted `.env` file at `/app/.env`
- a mounted env file at any path referenced by `KC_ENV_FILE`

The loader preserves existing behavior by not overriding variables already present in `process.env`.

- Resolves: https://github.com/KeychainMDIP/kc/issues/1195
 