### PR TITLE
feat: add challenge usage receipts

### DIFF
--- a/doc/keymaster-api.json
+++ b/doc/keymaster-api.json
@@ -2056,6 +2056,16 @@
         }
       }
     },
+    "/response/receipts/build": {
+      "post": {
+        "summary": "Build challenge usage receipts for a verified response without publishing them."
+      }
+    },
+    "/response/receipts": {
+      "post": {
+        "summary": "Publish challenge usage receipts for a verified response."
+      }
+    },
     "/groups": {
       "get": {
         "summary": "List all group DIDs owned by (or associated with) a specific ID.",

--- a/packages/common/src/env.ts
+++ b/packages/common/src/env.ts
@@ -30,7 +30,8 @@ function hasWorkspaceRootMarker(dir: string): boolean {
         const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8')) as { workspaces?: unknown };
         return Array.isArray(packageJson.workspaces) || Boolean(packageJson.workspaces);
     } catch {
-        return false;
+        // Do not cross a package boundary when its package metadata cannot be trusted.
+        return true;
     }
 }
 

--- a/packages/keymaster/src/keymaster-client.ts
+++ b/packages/keymaster/src/keymaster-client.ts
@@ -4,12 +4,14 @@ import {
 } from '@mdip/gatekeeper/types';
 import {
     Challenge,
+    ChallengeReceipt,
     ChallengeResponse,
     CheckWalletResult,
     CreateAssetOptions,
     DmailItem,
     DmailMessage,
     FileAssetOptions,
+    BuildChallengeReceiptOptions,
     CreateResponseOptions,
     EncryptOptions,
     FileAsset,
@@ -23,6 +25,7 @@ import {
     KeymasterInterface,
     NoticeMessage,
     Poll,
+    PublishChallengeReceiptOptions,
     StoredWallet,
     VerifiableCredential,
     ViewPollResult,
@@ -538,6 +541,32 @@ export default class KeymasterClient implements KeymasterInterface {
         try {
             const response = await axios.post(`${this.API}/response/verify`, { response: responseDID, options });
             return response.data.verify;
+        }
+        catch (error) {
+            throwError(error);
+        }
+    }
+
+    async buildChallengeReceipts(
+        responseDID: string,
+        options?: BuildChallengeReceiptOptions
+    ): Promise<ChallengeReceipt[]> {
+        try {
+            const response = await axios.post(`${this.API}/response/receipts/build`, { response: responseDID, options });
+            return response.data.receipts;
+        }
+        catch (error) {
+            throwError(error);
+        }
+    }
+
+    async publishChallengeReceipts(
+        responseDID: string,
+        options?: PublishChallengeReceiptOptions
+    ): Promise<string[]> {
+        try {
+            const response = await axios.post(`${this.API}/response/receipts`, { response: responseDID, options });
+            return response.data.dids;
         }
         catch (error) {
             throwError(error);

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -95,8 +95,6 @@ export enum NoticeTags {
     CREDENTIAL = "credential",
 }
 
-const ChallengeResponseCommitmentType = 'mdip.challenge.response.commitment.v1';
-
 export default class Keymaster implements KeymasterInterface {
     private readonly passphrase: string;
     private gatekeeper: GatekeeperInterface;
@@ -2152,7 +2150,6 @@ export default class Keymaster implements KeymasterInterface {
 
     private createResponseCommitment(responseDID: string, responseNonce: string): string {
         return this.cipher.hashJSON({
-            type: ChallengeResponseCommitmentType,
             responseDid: responseDID,
             responseNonce,
         });

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -2227,11 +2227,7 @@ export default class Keymaster implements KeymasterInterface {
         responseDID: string,
         options: PublishChallengeReceiptOptions = {}
     ): Promise<string[]> {
-        const { registry, validUntil, name, controller, ...receiptOptions } = options;
-
-        if (controller) {
-            throw new InvalidParameterError('options.controller');
-        }
+        const { registry, validUntil, name, ...receiptOptions } = options;
 
         const receipts = await this.buildChallengeReceipts(responseDID, receiptOptions);
         if (name && receipts.length !== 1) {

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -15,11 +15,13 @@ import {
 } from '@mdip/gatekeeper/types';
 import {
     Challenge,
+    ChallengeReceipt,
     ChallengeResponse,
     CheckWalletResult,
     CreateAssetOptions,
     EncryptedMessage,
     FileAssetOptions,
+    BuildChallengeReceiptOptions,
     CreateResponseOptions,
     DmailItem,
     DmailMessage,
@@ -37,6 +39,7 @@ import {
     NoticeMessage,
     Poll,
     PollResults,
+    PublishChallengeReceiptOptions,
     PossiblySigned,
     Signature,
     StoredWallet,
@@ -91,6 +94,8 @@ export enum NoticeTags {
     POLL = "poll",
     CREDENTIAL = "credential",
 }
+
+const ChallengeResponseCommitmentType = 'mdip.challenge.response.commitment.v1';
 
 export default class Keymaster implements KeymasterInterface {
     private readonly passphrase: string;
@@ -2035,13 +2040,15 @@ export default class Keymaster implements KeymasterInterface {
         const requested = challenge.credentials?.length ?? 0;
         const fulfilled = matches.length;
         const match = (requested === fulfilled);
+        const responseNonce = this.cipher.generateRandomSalt();
 
         const response = {
             challenge: challengeDID,
             credentials: pairs,
             requested: requested,
             fulfilled: fulfilled,
-            match: match
+            match: match,
+            responseNonce
         };
 
         return await this.encryptJSON({ response }, requestor!, options);
@@ -2085,7 +2092,7 @@ export default class Keymaster implements KeymasterInterface {
             throw new InvalidParameterError('challengeDID');
         }
 
-        const vps: unknown[] = [];
+        const vps: VerifiableCredential[] = [];
 
         for (let credential of response.credentials) {
             const vcData = await this.resolveAsset(credential.vc);
@@ -2141,6 +2148,109 @@ export default class Keymaster implements KeymasterInterface {
         response.responder = responseDoc.didDocument?.controller;
 
         return response;
+    }
+
+    private createResponseCommitment(responseDID: string, responseNonce: string): string {
+        return this.cipher.hashJSON({
+            type: ChallengeResponseCommitmentType,
+            responseDid: responseDID,
+            responseNonce,
+        });
+    }
+
+    async buildChallengeReceipts(
+        responseDID: string,
+        options: BuildChallengeReceiptOptions = {}
+    ): Promise<ChallengeReceipt[]> {
+        const { verification, verifiedAt, retries, delay } = options;
+        const response = verification ?? await this.verifyResponse(responseDID, { retries, delay });
+
+        if (!response.match) {
+            throw new InvalidParameterError('verification.match');
+        }
+
+        if (!response.responseNonce) {
+            throw new InvalidParameterError('response.responseNonce');
+        }
+
+        if (verifiedAt && isNaN(new Date(verifiedAt).getTime())) {
+            throw new InvalidParameterError('options.verifiedAt');
+        }
+
+        const challengeDoc = await this.resolveDID(response.challenge);
+        const requesterDid = challengeDoc.didDocument?.controller;
+        if (!requesterDid) {
+            throw new InvalidParameterError('requesterDid');
+        }
+
+        const id = await this.fetchIdInfo();
+        if (id.did !== requesterDid) {
+            throw new InvalidParameterError('requesterDid');
+        }
+
+        const result = await this.resolveAsset(response.challenge);
+        const challenge = (result as { challenge?: Challenge } | null)?.challenge;
+        if (!challenge) {
+            throw new InvalidParameterError('challengeDID');
+        }
+
+        const expectedCredentials = challenge?.credentials?.length ?? 0;
+        if (expectedCredentials > 0 && !response.vps) {
+            throw new InvalidParameterError('verification.vps');
+        }
+
+        const timestamp = verifiedAt ?? new Date().toISOString();
+        const responseCommitment = this.createResponseCommitment(responseDID, response.responseNonce);
+        const receipts: ChallengeReceipt[] = [];
+
+        for (const vp of response.vps ?? []) {
+            if (!this.isVerifiableCredential(vp)) {
+                throw new InvalidParameterError('verification.vps');
+            }
+
+            const schemaDid = vp.type[1];
+            if (!schemaDid || !schemaDid.startsWith('did:')) {
+                throw new InvalidParameterError('verification.vps.type');
+            }
+
+            receipts.push({
+                version: 1,
+                attesterDid: vp.issuer,
+                schemaDid,
+                requesterDid,
+                verifiedAt: timestamp,
+                responseCommitment,
+            });
+        }
+
+        return receipts;
+    }
+
+    async publishChallengeReceipts(
+        responseDID: string,
+        options: PublishChallengeReceiptOptions = {}
+    ): Promise<string[]> {
+        const { registry, validUntil, name, controller, ...receiptOptions } = options;
+
+        if (controller) {
+            throw new InvalidParameterError('options.controller');
+        }
+
+        const receipts = await this.buildChallengeReceipts(responseDID, receiptOptions);
+        if (name && receipts.length !== 1) {
+            throw new InvalidParameterError('options.name');
+        }
+
+        const receiptDIDs: string[] = [];
+        for (const challengeReceipt of receipts) {
+            const receiptDID = await this.createAsset(
+                { challengeReceipt },
+                { registry, validUntil, name }
+            );
+            receiptDIDs.push(receiptDID);
+        }
+
+        return receiptDIDs;
     }
 
     async createGroup(

--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -156,7 +156,11 @@ export interface BuildChallengeReceiptOptions {
     delay?: number;
 }
 
-export interface PublishChallengeReceiptOptions extends BuildChallengeReceiptOptions, CreateAssetOptions {}
+export interface PublishChallengeReceiptOptions extends BuildChallengeReceiptOptions {
+    registry?: string;
+    validUntil?: string;
+    name?: string;
+}
 
 export interface PollResults {
     tally: Array<{

--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -128,7 +128,8 @@ export interface ChallengeResponse {
     requested: number;
     fulfilled: number;
     match: boolean;
-    vps?: unknown[];
+    responseNonce?: string;
+    vps?: VerifiableCredential[];
     responder?: string;
 }
 
@@ -138,6 +139,24 @@ export interface CreateResponseOptions {
     retries?: number;
     delay?: number;
 }
+
+export interface ChallengeReceipt {
+    version: 1;
+    attesterDid: string;
+    schemaDid: string;
+    requesterDid: string;
+    verifiedAt: string;
+    responseCommitment: string;
+}
+
+export interface BuildChallengeReceiptOptions {
+    verification?: ChallengeResponse;
+    verifiedAt?: string;
+    retries?: number;
+    delay?: number;
+}
+
+export interface PublishChallengeReceiptOptions extends BuildChallengeReceiptOptions, CreateAssetOptions {}
 
 export interface PollResults {
     tally: Array<{
@@ -384,6 +403,8 @@ export interface KeymasterInterface {
     createChallenge(challenge?: Challenge, options?: { registry?: string; validUntil?: string }): Promise<string>;
     createResponse(challengeDid: string, options?: CreateResponseOptions): Promise<string>;
     verifyResponse(responseDid: string, options?: { retries?: number; delay?: number }): Promise<ChallengeResponse>;
+    buildChallengeReceipts(responseDid: string, options?: BuildChallengeReceiptOptions): Promise<ChallengeReceipt[]>;
+    publishChallengeReceipts(responseDid: string, options?: PublishChallengeReceiptOptions): Promise<string[]>;
 
     // Polls
     pollTemplate(): Promise<Poll>;

--- a/services/gatekeeper/client/src/KeymasterUI.jsx
+++ b/services/gatekeeper/client/src/KeymasterUI.jsx
@@ -14,6 +14,7 @@ import {
     FormLabel,
     Grid,
     IconButton,
+    InputAdornment,
     MenuItem,
     Paper,
     Radio,
@@ -107,6 +108,8 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
     const [docsVersionMax, setDocsVersionMax] = useState(1);
     const [idList, setIdList] = useState(null);
     const [challenge, setChallenge] = useState(null);
+    const [challengeSchema, setChallengeSchema] = useState('');
+    const [challengeAttester, setChallengeAttester] = useState('');
     const [callback, setCallback] = useState(null);
     const [widget, setWidget] = useState(false);
     const [response, setResponse] = useState(null);
@@ -155,6 +158,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
     const [manifest, setManifest] = useState(null);
     const [checkingWallet, setCheckingWallet] = useState(false);
     const [disableSendResponse, setDisableSendResponse] = useState(true);
+    const [disableSendReceipt, setDisableSendReceipt] = useState(true);
     const [authDID, setAuthDID] = useState('');
     const [authString, setAuthString] = useState('');
     const [dmailTab, setDmailTab] = useState('');
@@ -474,9 +478,23 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
 
     async function newChallenge() {
         try {
-            const challenge = await keymaster.createChallenge();
-            setChallenge(challenge);
-            resolveChallenge(challenge);
+            const challengeData = {};
+
+            if (challengeSchema) {
+                const credential = {
+                    schema: await resolveInputDID(challengeSchema),
+                };
+
+                if (challengeAttester) {
+                    credential.issuers = [await resolveInputDID(challengeAttester)];
+                }
+
+                challengeData.credentials = [credential];
+            }
+
+            const challengeDID = await keymaster.createChallenge(challengeData);
+            setChallenge(challengeDID);
+            resolveChallenge(challengeDID);
         } catch (error) {
             showError(error);
         }
@@ -516,6 +534,23 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
         setChallenge('');
     }
 
+    async function resolveInputDID(id) {
+        const input = id.trim();
+
+        if (input.startsWith('did:')) {
+            return input;
+        }
+
+        const doc = await keymaster.resolveDID(input);
+        const did = doc.didDocument?.id;
+
+        if (!did) {
+            throw new Error(`Cannot resolve DID: ${input}`);
+        }
+
+        return did;
+    }
+
     async function decryptResponse(did) {
         try {
             const decrypted = await keymaster.decryptJSON(did);
@@ -533,10 +568,12 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
             if (verify.match) {
                 showError("Response is VALID");
                 setAccessGranted(true);
+                setDisableSendReceipt(false);
             }
             else {
                 showError("Response is NOT VALID");
                 setAccessGranted(false);
+                setDisableSendReceipt(true);
             }
         } catch (error) {
             showError(error);
@@ -546,12 +583,40 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
     async function clearResponse() {
         setResponse('');
         setAccessGranted(false);
+        setDisableSendReceipt(true);
     }
 
     async function sendResponse() {
         try {
             setDisableSendResponse(true);
             axios.post(callback, { response });
+        } catch (error) {
+            showError(error);
+        }
+    }
+
+    function updateResponse(did) {
+        setResponse(did.trim());
+        setAccessGranted(false);
+        setDisableSendReceipt(true);
+    }
+
+    async function sendReceipt() {
+        try {
+            setDisableSendReceipt(true);
+            const receiptDIDs = await keymaster.publishChallengeReceipts(response);
+            setAuthDID(response);
+            setAuthString(JSON.stringify({ receiptDIDs }, null, 4));
+
+            if (receiptDIDs.length === 0) {
+                showAlert("No receipts to send");
+            }
+            else if (receiptDIDs.length === 1) {
+                showSuccess(`Receipt sent: ${receiptDIDs[0]}`);
+            }
+            else {
+                showSuccess(`Receipts sent: ${receiptDIDs.length}`);
+            }
         } catch (error) {
             showError(error);
         }
@@ -644,9 +709,17 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
             setSelectedSchema(null);
         }
 
+        if (!schemaList.includes(challengeSchema)) {
+            setChallengeSchema('');
+        }
+
         if (!schemaList.includes(credentialSchema)) {
             setCredentialSchema('');
             setCredentialString('');
+        }
+
+        if (!agentList.includes(challengeAttester)) {
+            setChallengeAttester('');
         }
 
         setImageList(imageList);
@@ -5007,7 +5080,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
                             <Table style={{ width: '800px' }}>
                                 <TableBody>
                                     <TableRow>
-                                        <TableCell style={{ width: '20%' }}>Challenge</TableCell>
+                                        <TableCell style={{ width: '20%', verticalAlign: 'top', paddingTop: '34px' }}>Challenge</TableCell>
                                         <TableCell style={{ width: '80%' }}>
                                             <TextField
                                                 label=""
@@ -5015,15 +5088,97 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
                                                 onChange={(e) => setChallenge(e.target.value.trim())}
                                                 fullWidth
                                                 margin="normal"
-                                                inputProps={{ maxLength: 85, style: { fontFamily: 'Courier', fontSize: '0.8em' } }}
+                                                slotProps={{
+                                                    htmlInput: { maxLength: 85, style: { fontFamily: 'Courier', fontSize: '0.8em' } },
+                                                    input: {
+                                                        endAdornment: (
+                                                            <InputAdornment position="end" sx={{ mr: '-14px', height: 56, maxHeight: 'none' }}>
+                                                                <Button
+                                                                    variant="contained"
+                                                                    color="primary"
+                                                                    onClick={clearChallenge}
+                                                                    disabled={!challenge}
+                                                                    sx={{
+                                                                        borderTopLeftRadius: 0,
+                                                                        borderBottomLeftRadius: 0,
+                                                                        boxShadow: 'none',
+                                                                        height: 56,
+                                                                    }}
+                                                                >
+                                                                    Clear
+                                                                </Button>
+                                                            </InputAdornment>
+                                                        ),
+                                                    },
+                                                }}
                                             />
                                             <br />
+                                            <Box sx={{ display: 'flex', alignItems: 'stretch', mt: 1, mb: 2 }}>
+                                                <Select
+                                                    style={{ width: '300px' }}
+                                                    value={challengeSchema}
+                                                    displayEmpty
+                                                    onChange={(event) => {
+                                                        setChallengeSchema(event.target.value);
+                                                        if (!event.target.value) {
+                                                            setChallengeAttester('');
+                                                        }
+                                                    }}
+                                                    sx={{
+                                                        '& .MuiOutlinedInput-notchedOutline': {
+                                                            borderTopRightRadius: 0,
+                                                            borderBottomRightRadius: 0,
+                                                        },
+                                                    }}
+                                                >
+                                                    <MenuItem value="">
+                                                        <em>No credential schema</em>
+                                                    </MenuItem>
+                                                    {(schemaList || []).map((name, index) => (
+                                                        <MenuItem value={name} key={index}>
+                                                            {name}
+                                                        </MenuItem>
+                                                    ))}
+                                                </Select>
+                                                <Select
+                                                    style={{ width: '300px' }}
+                                                    value={challengeAttester}
+                                                    displayEmpty
+                                                    disabled={!challengeSchema}
+                                                    onChange={(event) => setChallengeAttester(event.target.value)}
+                                                    sx={{
+                                                        ml: '-1px',
+                                                        '& .MuiOutlinedInput-notchedOutline': {
+                                                            borderRadius: 0,
+                                                        },
+                                                    }}
+                                                >
+                                                    <MenuItem value="">
+                                                        <em>Any attester</em>
+                                                    </MenuItem>
+                                                    {(agentList || []).map((name, index) => (
+                                                        <MenuItem value={name} key={index}>
+                                                            {name}
+                                                        </MenuItem>
+                                                    ))}
+                                                </Select>
+                                                <Button
+                                                    variant="contained"
+                                                    color="primary"
+                                                    onClick={newChallenge}
+                                                    sx={{
+                                                        height: 56,
+                                                        ml: '-1px',
+                                                        minWidth: 110,
+                                                        borderTopLeftRadius: 0,
+                                                        borderBottomLeftRadius: 0,
+                                                        boxShadow: 3,
+                                                    }}
+                                                >
+                                                    New
+                                                </Button>
+                                            </Box>
                                             <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
-                                                <Grid item>
-                                                    <Button variant="contained" color="primary" onClick={newChallenge}>
-                                                        New
-                                                    </Button>
-                                                </Grid>
                                                 <Grid item>
                                                     <Button variant="contained" color="primary" onClick={() => resolveChallenge(challenge)} disabled={!challenge || challenge === authDID}>
                                                         Resolve
@@ -5034,24 +5189,41 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
                                                         Respond
                                                     </Button>
                                                 </Grid>
-                                                <Grid item>
-                                                    <Button variant="contained" color="primary" onClick={clearChallenge} disabled={!challenge}>
-                                                        Clear
-                                                    </Button>
-                                                </Grid>
                                             </Grid>
                                         </TableCell>
                                     </TableRow>
                                     <TableRow>
-                                        <TableCell style={{ width: '20%' }}>Response</TableCell>
+                                        <TableCell style={{ width: '20%', verticalAlign: 'top', paddingTop: '34px' }}>Response</TableCell>
                                         <TableCell style={{ width: '80%' }}>
                                             <TextField
                                                 label=""
                                                 value={response}
-                                                onChange={(e) => setResponse(e.target.value.trim())}
+                                                onChange={(e) => updateResponse(e.target.value)}
                                                 fullWidth
                                                 margin="normal"
-                                                inputProps={{ maxLength: 85, style: { fontFamily: 'Courier', fontSize: '0.8em' } }}
+                                                slotProps={{
+                                                    htmlInput: { maxLength: 85, style: { fontFamily: 'Courier', fontSize: '0.8em' } },
+                                                    input: {
+                                                        endAdornment: (
+                                                            <InputAdornment position="end" sx={{ mr: '-14px', height: 56, maxHeight: 'none' }}>
+                                                                <Button
+                                                                    variant="contained"
+                                                                    color="primary"
+                                                                    onClick={clearResponse}
+                                                                    disabled={!response}
+                                                                    sx={{
+                                                                        borderTopLeftRadius: 0,
+                                                                        borderBottomLeftRadius: 0,
+                                                                        boxShadow: 'none',
+                                                                        height: 56,
+                                                                    }}
+                                                                >
+                                                                    Clear
+                                                                </Button>
+                                                            </InputAdornment>
+                                                        ),
+                                                    },
+                                                }}
                                             />
                                             <br />
                                             <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
@@ -5067,12 +5239,12 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
                                                 </Grid>
                                                 <Grid item>
                                                     <Button variant="contained" color="primary" onClick={sendResponse} disabled={disableSendResponse}>
-                                                        Send
+                                                        Send Response
                                                     </Button>
                                                 </Grid>
                                                 <Grid item>
-                                                    <Button variant="contained" color="primary" onClick={clearResponse} disabled={!response}>
-                                                        Clear
+                                                    <Button variant="contained" color="primary" onClick={sendReceipt} disabled={disableSendReceipt}>
+                                                        Send Receipt
                                                     </Button>
                                                 </Grid>
                                             </Grid>

--- a/services/keymaster/client/src/KeymasterUI.jsx
+++ b/services/keymaster/client/src/KeymasterUI.jsx
@@ -14,6 +14,7 @@ import {
     FormLabel,
     Grid,
     IconButton,
+    InputAdornment,
     MenuItem,
     Paper,
     Radio,
@@ -107,6 +108,8 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
     const [docsVersionMax, setDocsVersionMax] = useState(1);
     const [idList, setIdList] = useState(null);
     const [challenge, setChallenge] = useState(null);
+    const [challengeSchema, setChallengeSchema] = useState('');
+    const [challengeAttester, setChallengeAttester] = useState('');
     const [callback, setCallback] = useState(null);
     const [widget, setWidget] = useState(false);
     const [response, setResponse] = useState(null);
@@ -155,6 +158,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
     const [manifest, setManifest] = useState(null);
     const [checkingWallet, setCheckingWallet] = useState(false);
     const [disableSendResponse, setDisableSendResponse] = useState(true);
+    const [disableSendReceipt, setDisableSendReceipt] = useState(true);
     const [authDID, setAuthDID] = useState('');
     const [authString, setAuthString] = useState('');
     const [dmailTab, setDmailTab] = useState('');
@@ -474,9 +478,23 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
 
     async function newChallenge() {
         try {
-            const challenge = await keymaster.createChallenge();
-            setChallenge(challenge);
-            resolveChallenge(challenge);
+            const challengeData = {};
+
+            if (challengeSchema) {
+                const credential = {
+                    schema: await resolveInputDID(challengeSchema),
+                };
+
+                if (challengeAttester) {
+                    credential.issuers = [await resolveInputDID(challengeAttester)];
+                }
+
+                challengeData.credentials = [credential];
+            }
+
+            const challengeDID = await keymaster.createChallenge(challengeData);
+            setChallenge(challengeDID);
+            resolveChallenge(challengeDID);
         } catch (error) {
             showError(error);
         }
@@ -516,6 +534,23 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
         setChallenge('');
     }
 
+    async function resolveInputDID(id) {
+        const input = id.trim();
+
+        if (input.startsWith('did:')) {
+            return input;
+        }
+
+        const doc = await keymaster.resolveDID(input);
+        const did = doc.didDocument?.id;
+
+        if (!did) {
+            throw new Error(`Cannot resolve DID: ${input}`);
+        }
+
+        return did;
+    }
+
     async function decryptResponse(did) {
         try {
             const decrypted = await keymaster.decryptJSON(did);
@@ -533,10 +568,12 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
             if (verify.match) {
                 showError("Response is VALID");
                 setAccessGranted(true);
+                setDisableSendReceipt(false);
             }
             else {
                 showError("Response is NOT VALID");
                 setAccessGranted(false);
+                setDisableSendReceipt(true);
             }
         } catch (error) {
             showError(error);
@@ -546,12 +583,40 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
     async function clearResponse() {
         setResponse('');
         setAccessGranted(false);
+        setDisableSendReceipt(true);
     }
 
     async function sendResponse() {
         try {
             setDisableSendResponse(true);
             axios.post(callback, { response });
+        } catch (error) {
+            showError(error);
+        }
+    }
+
+    function updateResponse(did) {
+        setResponse(did.trim());
+        setAccessGranted(false);
+        setDisableSendReceipt(true);
+    }
+
+    async function sendReceipt() {
+        try {
+            setDisableSendReceipt(true);
+            const receiptDIDs = await keymaster.publishChallengeReceipts(response);
+            setAuthDID(response);
+            setAuthString(JSON.stringify({ receiptDIDs }, null, 4));
+
+            if (receiptDIDs.length === 0) {
+                showAlert("No receipts to send");
+            }
+            else if (receiptDIDs.length === 1) {
+                showSuccess(`Receipt sent: ${receiptDIDs[0]}`);
+            }
+            else {
+                showSuccess(`Receipts sent: ${receiptDIDs.length}`);
+            }
         } catch (error) {
             showError(error);
         }
@@ -644,9 +709,17 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
             setSelectedSchema(null);
         }
 
+        if (!schemaList.includes(challengeSchema)) {
+            setChallengeSchema('');
+        }
+
         if (!schemaList.includes(credentialSchema)) {
             setCredentialSchema('');
             setCredentialString('');
+        }
+
+        if (!agentList.includes(challengeAttester)) {
+            setChallengeAttester('');
         }
 
         setImageList(imageList);
@@ -5007,7 +5080,7 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
                             <Table style={{ width: '800px' }}>
                                 <TableBody>
                                     <TableRow>
-                                        <TableCell style={{ width: '20%' }}>Challenge</TableCell>
+                                        <TableCell style={{ width: '20%', verticalAlign: 'top', paddingTop: '34px' }}>Challenge</TableCell>
                                         <TableCell style={{ width: '80%' }}>
                                             <TextField
                                                 label=""
@@ -5015,15 +5088,97 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
                                                 onChange={(e) => setChallenge(e.target.value.trim())}
                                                 fullWidth
                                                 margin="normal"
-                                                inputProps={{ maxLength: 85, style: { fontFamily: 'Courier', fontSize: '0.8em' } }}
+                                                slotProps={{
+                                                    htmlInput: { maxLength: 85, style: { fontFamily: 'Courier', fontSize: '0.8em' } },
+                                                    input: {
+                                                        endAdornment: (
+                                                            <InputAdornment position="end" sx={{ mr: '-14px', height: 56, maxHeight: 'none' }}>
+                                                                <Button
+                                                                    variant="contained"
+                                                                    color="primary"
+                                                                    onClick={clearChallenge}
+                                                                    disabled={!challenge}
+                                                                    sx={{
+                                                                        borderTopLeftRadius: 0,
+                                                                        borderBottomLeftRadius: 0,
+                                                                        boxShadow: 'none',
+                                                                        height: 56,
+                                                                    }}
+                                                                >
+                                                                    Clear
+                                                                </Button>
+                                                            </InputAdornment>
+                                                        ),
+                                                    },
+                                                }}
                                             />
                                             <br />
+                                            <Box sx={{ display: 'flex', alignItems: 'stretch', mt: 1, mb: 2 }}>
+                                                <Select
+                                                    style={{ width: '300px' }}
+                                                    value={challengeSchema}
+                                                    displayEmpty
+                                                    onChange={(event) => {
+                                                        setChallengeSchema(event.target.value);
+                                                        if (!event.target.value) {
+                                                            setChallengeAttester('');
+                                                        }
+                                                    }}
+                                                    sx={{
+                                                        '& .MuiOutlinedInput-notchedOutline': {
+                                                            borderTopRightRadius: 0,
+                                                            borderBottomRightRadius: 0,
+                                                        },
+                                                    }}
+                                                >
+                                                    <MenuItem value="">
+                                                        <em>No credential schema</em>
+                                                    </MenuItem>
+                                                    {(schemaList || []).map((name, index) => (
+                                                        <MenuItem value={name} key={index}>
+                                                            {name}
+                                                        </MenuItem>
+                                                    ))}
+                                                </Select>
+                                                <Select
+                                                    style={{ width: '300px' }}
+                                                    value={challengeAttester}
+                                                    displayEmpty
+                                                    disabled={!challengeSchema}
+                                                    onChange={(event) => setChallengeAttester(event.target.value)}
+                                                    sx={{
+                                                        ml: '-1px',
+                                                        '& .MuiOutlinedInput-notchedOutline': {
+                                                            borderRadius: 0,
+                                                        },
+                                                    }}
+                                                >
+                                                    <MenuItem value="">
+                                                        <em>Any attester</em>
+                                                    </MenuItem>
+                                                    {(agentList || []).map((name, index) => (
+                                                        <MenuItem value={name} key={index}>
+                                                            {name}
+                                                        </MenuItem>
+                                                    ))}
+                                                </Select>
+                                                <Button
+                                                    variant="contained"
+                                                    color="primary"
+                                                    onClick={newChallenge}
+                                                    sx={{
+                                                        height: 56,
+                                                        ml: '-1px',
+                                                        minWidth: 110,
+                                                        borderTopLeftRadius: 0,
+                                                        borderBottomLeftRadius: 0,
+                                                        boxShadow: 3,
+                                                    }}
+                                                >
+                                                    New
+                                                </Button>
+                                            </Box>
                                             <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
-                                                <Grid item>
-                                                    <Button variant="contained" color="primary" onClick={newChallenge}>
-                                                        New
-                                                    </Button>
-                                                </Grid>
                                                 <Grid item>
                                                     <Button variant="contained" color="primary" onClick={() => resolveChallenge(challenge)} disabled={!challenge || challenge === authDID}>
                                                         Resolve
@@ -5034,24 +5189,41 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
                                                         Respond
                                                     </Button>
                                                 </Grid>
-                                                <Grid item>
-                                                    <Button variant="contained" color="primary" onClick={clearChallenge} disabled={!challenge}>
-                                                        Clear
-                                                    </Button>
-                                                </Grid>
                                             </Grid>
                                         </TableCell>
                                     </TableRow>
                                     <TableRow>
-                                        <TableCell style={{ width: '20%' }}>Response</TableCell>
+                                        <TableCell style={{ width: '20%', verticalAlign: 'top', paddingTop: '34px' }}>Response</TableCell>
                                         <TableCell style={{ width: '80%' }}>
                                             <TextField
                                                 label=""
                                                 value={response}
-                                                onChange={(e) => setResponse(e.target.value.trim())}
+                                                onChange={(e) => updateResponse(e.target.value)}
                                                 fullWidth
                                                 margin="normal"
-                                                inputProps={{ maxLength: 85, style: { fontFamily: 'Courier', fontSize: '0.8em' } }}
+                                                slotProps={{
+                                                    htmlInput: { maxLength: 85, style: { fontFamily: 'Courier', fontSize: '0.8em' } },
+                                                    input: {
+                                                        endAdornment: (
+                                                            <InputAdornment position="end" sx={{ mr: '-14px', height: 56, maxHeight: 'none' }}>
+                                                                <Button
+                                                                    variant="contained"
+                                                                    color="primary"
+                                                                    onClick={clearResponse}
+                                                                    disabled={!response}
+                                                                    sx={{
+                                                                        borderTopLeftRadius: 0,
+                                                                        borderBottomLeftRadius: 0,
+                                                                        boxShadow: 'none',
+                                                                        height: 56,
+                                                                    }}
+                                                                >
+                                                                    Clear
+                                                                </Button>
+                                                            </InputAdornment>
+                                                        ),
+                                                    },
+                                                }}
                                             />
                                             <br />
                                             <Grid container direction="row" justifyContent="flex-start" alignItems="center" spacing={3}>
@@ -5067,12 +5239,12 @@ function KeymasterUI({ keymaster, title, challengeDID, onWalletUpload }) {
                                                 </Grid>
                                                 <Grid item>
                                                     <Button variant="contained" color="primary" onClick={sendResponse} disabled={disableSendResponse}>
-                                                        Send
+                                                        Send Response
                                                     </Button>
                                                 </Grid>
                                                 <Grid item>
-                                                    <Button variant="contained" color="primary" onClick={clearResponse} disabled={!response}>
-                                                        Clear
+                                                    <Button variant="contained" color="primary" onClick={sendReceipt} disabled={disableSendReceipt}>
+                                                        Send Receipt
                                                     </Button>
                                                 </Grid>
                                             </Grid>

--- a/services/keymaster/server/src/challenge-receipts-api.ts
+++ b/services/keymaster/server/src/challenge-receipts-api.ts
@@ -1,0 +1,32 @@
+import type express from 'express';
+import type { KeymasterInterface } from '@mdip/keymaster/types';
+
+type ReceiptKeymaster = Pick<KeymasterInterface, 'buildChallengeReceipts' | 'publishChallengeReceipts'>;
+
+function errorResponse(res: express.Response, error: unknown): void {
+    res.status(400).send({ error: String(error) });
+}
+
+export function buildChallengeReceiptsRoute(keymaster: ReceiptKeymaster) {
+    return async (req: express.Request, res: express.Response) => {
+        try {
+            const { response, options } = req.body;
+            const receipts = await keymaster.buildChallengeReceipts(response, options);
+            res.json({ receipts });
+        } catch (error: unknown) {
+            errorResponse(res, error);
+        }
+    };
+}
+
+export function publishChallengeReceiptsRoute(keymaster: ReceiptKeymaster) {
+    return async (req: express.Request, res: express.Response) => {
+        try {
+            const { response, options } = req.body;
+            const dids = await keymaster.publishChallengeReceipts(response, options);
+            res.json({ dids });
+        } catch (error: unknown) {
+            errorResponse(res, error);
+        }
+    };
+}

--- a/services/keymaster/server/src/keymaster-api.ts
+++ b/services/keymaster/server/src/keymaster-api.ts
@@ -18,6 +18,10 @@ import CipherNode from '@mdip/cipher/node';
 import { InvalidParameterError } from '@mdip/common/errors';
 import { childLogger } from '@mdip/common/logger';
 import config from './config.js';
+import {
+    buildChallengeReceiptsRoute,
+    publishChallengeReceiptsRoute,
+} from './challenge-receipts-api.js';
 
 const app = express();
 const v1router = express.Router();
@@ -1888,15 +1892,7 @@ v1router.post('/response/verify', async (req, res) => {
  *   post:
  *     summary: Build challenge usage receipts for a verified response without publishing them.
  */
-v1router.post('/response/receipts/build', async (req, res) => {
-    try {
-        const { response, options } = req.body;
-        const receipts = await keymaster.buildChallengeReceipts(response, options);
-        res.json({ receipts });
-    } catch (error: any) {
-        res.status(400).send({ error: error.toString() });
-    }
-});
+v1router.post('/response/receipts/build', (req, res) => buildChallengeReceiptsRoute(keymaster)(req, res));
 
 /**
  * @swagger
@@ -1904,15 +1900,7 @@ v1router.post('/response/receipts/build', async (req, res) => {
  *   post:
  *     summary: Publish challenge usage receipts for a verified response.
  */
-v1router.post('/response/receipts', async (req, res) => {
-    try {
-        const { response, options } = req.body;
-        const dids = await keymaster.publishChallengeReceipts(response, options);
-        res.json({ dids });
-    } catch (error: any) {
-        res.status(400).send({ error: error.toString() });
-    }
-});
+v1router.post('/response/receipts', (req, res) => publishChallengeReceiptsRoute(keymaster)(req, res));
 
 /**
  * @swagger

--- a/services/keymaster/server/src/keymaster-api.ts
+++ b/services/keymaster/server/src/keymaster-api.ts
@@ -1884,6 +1884,38 @@ v1router.post('/response/verify', async (req, res) => {
 
 /**
  * @swagger
+ * /response/receipts/build:
+ *   post:
+ *     summary: Build challenge usage receipts for a verified response without publishing them.
+ */
+v1router.post('/response/receipts/build', async (req, res) => {
+    try {
+        const { response, options } = req.body;
+        const receipts = await keymaster.buildChallengeReceipts(response, options);
+        res.json({ receipts });
+    } catch (error: any) {
+        res.status(400).send({ error: error.toString() });
+    }
+});
+
+/**
+ * @swagger
+ * /response/receipts:
+ *   post:
+ *     summary: Publish challenge usage receipts for a verified response.
+ */
+v1router.post('/response/receipts', async (req, res) => {
+    try {
+        const { response, options } = req.body;
+        const dids = await keymaster.publishChallengeReceipts(response, options);
+        res.json({ dids });
+    } catch (error: any) {
+        res.status(400).send({ error: error.toString() });
+    }
+});
+
+/**
+ * @swagger
  * /groups:
  *   get:
  *     summary: List all group DIDs owned by (or associated with) a specific ID.

--- a/tests/cli-tests/test_cli_reveal_credentials.expect
+++ b/tests/cli-tests/test_cli_reveal_credentials.expect
@@ -5,14 +5,21 @@ set timeout 30
 
 spawn bash kc new-wallet
 expect {
-    -re {"version"\s*:\s*1} {
-        send_user "\n✅ Wallet Reset Complete!\n"
+    eof {
+        set wallet_output $expect_out(buffer)
     }
     timeout {
         send_user "\n❌ Wallet Reset Timeout.\n";
         exit 1
     }
 }
+
+if {![regexp {"version"\s*:\s*1} $wallet_output]} {
+    send_user "\n❌ Wallet Reset Failed: wallet output did not include version 1.\n"
+    exit 1
+}
+
+send_user "\n✅ Wallet Reset Complete!\n"
 
 # Enable output logging
 log_user 1

--- a/tests/common/env.test.ts
+++ b/tests/common/env.test.ts
@@ -101,6 +101,23 @@ describe('loadEnv', () => {
         expect(resolveEnvFiles()).toEqual([workspaceEnvFile]);
     });
 
+    test('does not cross an unparseable package boundary to an outer workspace marker', () => {
+        const workspaceDir = path.join(tempDir, 'repo');
+        const serviceDir = path.join(workspaceDir, 'services', 'search-server', 'dist');
+        const workspaceEnvFile = path.join(workspaceDir, '.env');
+        const outsideEnvFile = path.join(tempDir, '.env');
+
+        fs.mkdirSync(serviceDir, { recursive: true });
+        fs.mkdirSync(path.join(tempDir, '.git'));
+        fs.writeFileSync(path.join(workspaceDir, 'package.json'), '{ not-valid-json');
+        fs.writeFileSync(workspaceEnvFile, 'ROOT_ONLY=root\n');
+        fs.writeFileSync(outsideEnvFile, 'OUTSIDE=outside\n');
+
+        process.chdir(serviceDir);
+
+        expect(resolveEnvFiles()).toEqual([workspaceEnvFile]);
+    });
+
     test('stops searching when docker-compose.yml marks the workspace root', () => {
         const workspaceDir = path.join(tempDir, 'repo');
         const serviceDir = path.join(workspaceDir, 'services', 'search-server', 'dist');

--- a/tests/keymaster/challenge-receipts-api.test.ts
+++ b/tests/keymaster/challenge-receipts-api.test.ts
@@ -1,0 +1,100 @@
+import { jest } from '@jest/globals';
+import {
+    buildChallengeReceiptsRoute,
+    publishChallengeReceiptsRoute,
+} from '../../services/keymaster/server/src/challenge-receipts-api.ts';
+
+function mockResponse() {
+    return {
+        json: jest.fn(),
+        send: jest.fn(),
+        status: jest.fn().mockReturnThis(),
+    };
+}
+
+describe('challenge receipt API routes', () => {
+    it('should build challenge receipts', async () => {
+        const receipts = [
+            {
+                version: 1,
+                attesterDid: 'did:mock:attester',
+                schemaDid: 'did:mock:schema',
+                requesterDid: 'did:mock:requester',
+                verifiedAt: '2026-01-01T00:00:00.000Z',
+                responseCommitment: 'mock-commitment',
+            },
+        ];
+        const keymaster = {
+            buildChallengeReceipts: jest.fn().mockResolvedValue(receipts as never),
+        } as any;
+        const req = {
+            body: {
+                response: 'did:mock:response',
+                options: {
+                    registry: 'local',
+                },
+            },
+        } as any;
+        const res = mockResponse() as any;
+
+        await buildChallengeReceiptsRoute(keymaster)(req, res);
+
+        expect(keymaster.buildChallengeReceipts).toHaveBeenCalledWith(req.body.response, req.body.options);
+        expect(res.json).toHaveBeenCalledWith({ receipts });
+    });
+
+    it('should return build challenge receipt errors', async () => {
+        const keymaster = {
+            buildChallengeReceipts: jest.fn().mockRejectedValue(new Error('mock build failure') as never),
+        } as any;
+        const req = {
+            body: {
+                response: 'did:mock:response',
+            },
+        } as any;
+        const res = mockResponse() as any;
+
+        await buildChallengeReceiptsRoute(keymaster)(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.send).toHaveBeenCalledWith({ error: 'Error: mock build failure' });
+    });
+
+    it('should publish challenge receipts', async () => {
+        const dids = ['did:mock:receipt'];
+        const keymaster = {
+            publishChallengeReceipts: jest.fn().mockResolvedValue(dids as never),
+        } as any;
+        const req = {
+            body: {
+                response: 'did:mock:response',
+                options: {
+                    registry: 'local',
+                },
+            },
+        } as any;
+        const res = mockResponse() as any;
+
+        await publishChallengeReceiptsRoute(keymaster)(req, res);
+
+        expect(keymaster.publishChallengeReceipts).toHaveBeenCalledWith(req.body.response, req.body.options);
+        expect(res.json).toHaveBeenCalledWith({ dids });
+    });
+
+    it('should return publish challenge receipt errors', async () => {
+        const keymaster = {
+            publishChallengeReceipts: jest.fn().mockRejectedValue(new Error('mock publish failure') as never),
+        } as any;
+        const req = {
+            body: {
+                response: 'did:mock:response',
+            },
+        } as any;
+        const res = mockResponse() as any;
+
+        await publishChallengeReceiptsRoute(keymaster)(req, res);
+
+        expect(res.status).toHaveBeenCalledWith(400);
+        expect(res.send).toHaveBeenCalledWith({ error: 'Error: mock publish failure' });
+    });
+});

--- a/tests/keymaster/client.test.ts
+++ b/tests/keymaster/client.test.ts
@@ -28,6 +28,8 @@ const Endpoints = {
     challenge: '/api/v1/challenge',
     response: '/api/v1/response',
     response_verify: '/api/v1/response/verify',
+    response_receipts: '/api/v1/response/receipts',
+    response_receipts_build: '/api/v1/response/receipts/build',
     groups: '/api/v1/groups',
     schemas: '/api/v1/schemas',
     agents: '/api/v1/agents',
@@ -1355,6 +1357,77 @@ describe('verifyResponse', () => {
 
         try {
             await keymaster.verifyResponse(mockResponse);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(ServerError.message);
+        }
+    });
+});
+
+describe('buildChallengeReceipts', () => {
+    const mockResponse = 'mockResponse';
+    const mockReceipt = {
+        version: 1,
+        attesterDid: 'did:mock:attester',
+        schemaDid: 'did:mock:schema',
+        requesterDid: 'did:mock:requester',
+        verifiedAt: '2026-01-01T00:00:00.000Z',
+        responseCommitment: 'mockCommitment',
+    };
+
+    it('should build challenge receipts', async () => {
+        nock(KeymasterURL)
+            .post(Endpoints.response_receipts_build)
+            .reply(200, { receipts: [mockReceipt] });
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const receipts = await keymaster.buildChallengeReceipts(mockResponse);
+
+        expect(receipts).toStrictEqual([mockReceipt]);
+    });
+
+    it('should throw exception on buildChallengeReceipts server error', async () => {
+        nock(KeymasterURL)
+            .post(Endpoints.response_receipts_build)
+            .reply(500, ServerError);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+
+        try {
+            await keymaster.buildChallengeReceipts(mockResponse);
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe(ServerError.message);
+        }
+    });
+});
+
+describe('publishChallengeReceipts', () => {
+    const mockResponse = 'mockResponse';
+    const mockReceiptDIDs = ['did:mock:receipt'];
+
+    it('should publish challenge receipts', async () => {
+        nock(KeymasterURL)
+            .post(Endpoints.response_receipts)
+            .reply(200, { dids: mockReceiptDIDs });
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const receiptDIDs = await keymaster.publishChallengeReceipts(mockResponse);
+
+        expect(receiptDIDs).toStrictEqual(mockReceiptDIDs);
+    });
+
+    it('should throw exception on publishChallengeReceipts server error', async () => {
+        nock(KeymasterURL)
+            .post(Endpoints.response_receipts)
+            .reply(500, ServerError);
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+
+        try {
+            await keymaster.publishChallengeReceipts(mockResponse);
             throw new ExpectedExceptionError();
         }
         catch (error: any) {

--- a/tests/keymaster/response.test.ts
+++ b/tests/keymaster/response.test.ts
@@ -1,6 +1,7 @@
 import Gatekeeper from '@mdip/gatekeeper';
 import Keymaster from '@mdip/keymaster';
 import { ChallengeReceipt, ChallengeResponse } from '@mdip/keymaster/types';
+import { jest } from '@jest/globals';
 import CipherNode from '@mdip/cipher/node';
 import DbJsonMemory from '@mdip/gatekeeper/db/json-memory';
 import WalletJsonMemory from '@mdip/keymaster/wallet/json-memory';
@@ -528,6 +529,172 @@ describe('challenge receipts', () => {
         catch (error: any) {
             expect(error.message).toBe('Invalid parameter: verification.match');
         }
+    });
+
+    it('should reject malformed receipt inputs', async () => {
+        const victor = await keymaster.createId('Victor');
+        const schemaDid = await keymaster.createSchema(mockSchema);
+        const challengeDID = await keymaster.createChallenge({
+            credentials: [
+                {
+                    schema: schemaDid,
+                },
+            ],
+        });
+        const emptyChallengeDID = await keymaster.createChallenge();
+        const verification: ChallengeResponse = {
+            challenge: challengeDID,
+            credentials: [],
+            requested: 1,
+            fulfilled: 1,
+            match: true,
+            responseNonce: 'mock-nonce',
+            vps: [],
+        };
+
+        try {
+            await keymaster.buildChallengeReceipts('did:mock:response', {
+                verification: {
+                    ...verification,
+                    responseNonce: undefined,
+                },
+            });
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe('Invalid parameter: response.responseNonce');
+        }
+
+        try {
+            await keymaster.buildChallengeReceipts('did:mock:response', {
+                verification,
+                verifiedAt: 'not-a-date',
+            });
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe('Invalid parameter: options.verifiedAt');
+        }
+
+        const resolveDID = jest.spyOn(keymaster, 'resolveDID')
+            .mockResolvedValueOnce({ didDocument: {} } as any);
+        try {
+            await keymaster.buildChallengeReceipts('did:mock:response', { verification });
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe('Invalid parameter: requesterDid');
+        }
+        resolveDID.mockRestore();
+
+        const resolveAsset = jest.spyOn(keymaster, 'resolveAsset')
+            .mockResolvedValueOnce(null);
+        try {
+            await keymaster.buildChallengeReceipts('did:mock:response', { verification });
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe('Invalid parameter: challengeDID');
+        }
+        resolveAsset.mockRestore();
+
+        try {
+            await keymaster.buildChallengeReceipts('did:mock:response', {
+                verification: {
+                    ...verification,
+                    vps: undefined,
+                },
+            });
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe('Invalid parameter: verification.vps');
+        }
+
+        try {
+            await keymaster.buildChallengeReceipts('did:mock:response', {
+                verification: {
+                    challenge: emptyChallengeDID,
+                    credentials: [],
+                    requested: 0,
+                    fulfilled: 0,
+                    match: true,
+                    responseNonce: 'mock-nonce',
+                    vps: [{} as any],
+                },
+            });
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe('Invalid parameter: verification.vps');
+        }
+
+        try {
+            await keymaster.buildChallengeReceipts('did:mock:response', {
+                verification: {
+                    challenge: emptyChallengeDID,
+                    credentials: [],
+                    requested: 0,
+                    fulfilled: 0,
+                    match: true,
+                    responseNonce: 'mock-nonce',
+                    vps: [
+                        {
+                            '@context': [],
+                            type: ['VerifiableCredential'],
+                            issuer: victor,
+                            validFrom: '2026-01-01T00:00:00.000Z',
+                            credentialSubject: {
+                                id: victor,
+                            },
+                        },
+                    ],
+                },
+            });
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe('Invalid parameter: verification.vps.type');
+        }
+    });
+
+    it('should reject invalid receipt publish options', async () => {
+        const receipt: ChallengeReceipt = {
+            version: 1,
+            attesterDid: 'did:mock:attester',
+            schemaDid: 'did:mock:schema',
+            requesterDid: 'did:mock:requester',
+            verifiedAt: '2026-01-01T00:00:00.000Z',
+            responseCommitment: 'mock-commitment',
+        };
+
+        try {
+            await keymaster.publishChallengeReceipts('did:mock:response', {
+                controller: 'did:mock:controller',
+            });
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe('Invalid parameter: options.controller');
+        }
+
+        const buildReceipts = jest.spyOn(keymaster, 'buildChallengeReceipts')
+            .mockResolvedValueOnce([
+                receipt,
+                {
+                    ...receipt,
+                    schemaDid: 'did:mock:schema2',
+                },
+            ]);
+
+        try {
+            await keymaster.publishChallengeReceipts('did:mock:response', { name: 'mock-receipt' });
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe('Invalid parameter: options.name');
+        }
+        buildReceipts.mockRestore();
     });
 
     it('should only allow the challenge requester to build receipts', async () => {

--- a/tests/keymaster/response.test.ts
+++ b/tests/keymaster/response.test.ts
@@ -494,6 +494,16 @@ describe('challenge receipts', () => {
 
         const receiptDoc = await keymaster.resolveDID(receiptDIDs[0]);
         expect(receiptDoc.didDocument?.controller).toBe(victor);
+
+        const defaultReceiptDIDs = await keymaster.publishChallengeReceipts(responseDID);
+        expect(defaultReceiptDIDs).toHaveLength(1);
+
+        const defaultReceiptAsset = await keymaster.resolveAsset(defaultReceiptDIDs[0]) as { challengeReceipt: ChallengeReceipt };
+        expect(defaultReceiptAsset.challengeReceipt).toStrictEqual({
+            ...receipts[0],
+            verifiedAt: expect.any(String),
+        });
+        expect(new Date(defaultReceiptAsset.challengeReceipt.verifiedAt).getTime()).not.toBeNaN();
     });
 
     it('should reject receipts for unsuccessful challenge responses', async () => {

--- a/tests/keymaster/response.test.ts
+++ b/tests/keymaster/response.test.ts
@@ -695,16 +695,6 @@ describe('challenge receipts', () => {
             responseCommitment: 'mock-commitment',
         };
 
-        try {
-            await keymaster.publishChallengeReceipts('did:mock:response', {
-                controller: 'did:mock:controller',
-            });
-            throw new ExpectedExceptionError();
-        }
-        catch (error: any) {
-            expect(error.message).toBe('Invalid parameter: options.controller');
-        }
-
         const buildReceipts = jest.spyOn(keymaster, 'buildChallengeReceipts')
             .mockResolvedValueOnce([
                 receipt,

--- a/tests/keymaster/response.test.ts
+++ b/tests/keymaster/response.test.ts
@@ -9,8 +9,6 @@ import { InvalidDIDError, ExpectedExceptionError, UnknownIDError } from '@mdip/c
 import HeliaClient from '@mdip/ipfs/helia';
 import { mockSchema } from './helper.ts';
 
-const ChallengeResponseCommitmentType = 'mdip.challenge.response.commitment.v1';
-
 let ipfs: HeliaClient;
 let gatekeeper: Gatekeeper;
 let wallet: WalletJsonMemory;
@@ -458,7 +456,6 @@ describe('challenge receipts', () => {
         const verification = await keymaster.verifyResponse(responseDID);
         const verifiedAt = '2026-01-01T00:00:00.000Z';
         const responseCommitment = cipher.hashJSON({
-            type: ChallengeResponseCommitmentType,
             responseDid: responseDID,
             responseNonce: verification.responseNonce,
         });

--- a/tests/keymaster/response.test.ts
+++ b/tests/keymaster/response.test.ts
@@ -495,6 +495,14 @@ describe('challenge receipts', () => {
         const receiptDoc = await keymaster.resolveDID(receiptDIDs[0]);
         expect(receiptDoc.didDocument?.controller).toBe(victor);
 
+        const defaultBuildReceipts = await keymaster.buildChallengeReceipts(responseDID);
+        expect(defaultBuildReceipts).toHaveLength(1);
+        expect(defaultBuildReceipts[0]).toStrictEqual({
+            ...receipts[0],
+            verifiedAt: expect.any(String),
+        });
+        expect(new Date(defaultBuildReceipts[0].verifiedAt).getTime()).not.toBeNaN();
+
         const defaultReceiptDIDs = await keymaster.publishChallengeReceipts(responseDID);
         expect(defaultReceiptDIDs).toHaveLength(1);
 
@@ -558,6 +566,18 @@ describe('challenge receipts', () => {
             responseNonce: 'mock-nonce',
             vps: [],
         };
+        const emptyVerification: ChallengeResponse = {
+            challenge: emptyChallengeDID,
+            credentials: [],
+            requested: 0,
+            fulfilled: 0,
+            match: true,
+            responseNonce: 'mock-nonce',
+        };
+
+        await expect(keymaster.buildChallengeReceipts('did:mock:response', {
+            verification: emptyVerification,
+        })).resolves.toStrictEqual([]);
 
         try {
             await keymaster.buildChallengeReceipts('did:mock:response', {

--- a/tests/keymaster/response.test.ts
+++ b/tests/keymaster/response.test.ts
@@ -1,12 +1,14 @@
 import Gatekeeper from '@mdip/gatekeeper';
 import Keymaster from '@mdip/keymaster';
-import { ChallengeResponse } from '@mdip/keymaster/types';
+import { ChallengeReceipt, ChallengeResponse } from '@mdip/keymaster/types';
 import CipherNode from '@mdip/cipher/node';
 import DbJsonMemory from '@mdip/gatekeeper/db/json-memory';
 import WalletJsonMemory from '@mdip/keymaster/wallet/json-memory';
 import { InvalidDIDError, ExpectedExceptionError, UnknownIDError } from '@mdip/common/errors';
 import HeliaClient from '@mdip/ipfs/helia';
 import { mockSchema } from './helper.ts';
+
+const ChallengeResponseCommitmentType = 'mdip.challenge.response.commitment.v1';
 
 let ipfs: HeliaClient;
 let gatekeeper: Gatekeeper;
@@ -73,6 +75,10 @@ describe('createResponse', () => {
         expect(response.challenge).toBe(challengeDID);
         expect(response.credentials.length).toBe(1);
         expect(response.credentials[0].vc).toBe(vcDid);
+        expect(response.responseNonce).toEqual(expect.any(String));
+
+        const publicAsset = await keymaster.resolveAsset(responseDID) as Record<string, unknown>;
+        expect(publicAsset).not.toHaveProperty('response');
     });
 
     it('should throw an exception on invalid challenge', async () => {
@@ -141,6 +147,7 @@ describe('verifyResponse', () => {
             requested: 0,
             fulfilled: 0,
             match: true,
+            responseNonce: expect.any(String),
             vps: [],
             responder: bob,
         };
@@ -415,6 +422,151 @@ describe('verifyResponse', () => {
         }
         catch (error: any) {
             expect(error.type).toBe(InvalidDIDError.type);
+        }
+    });
+});
+
+describe('challenge receipts', () => {
+    it('should build and publish receipts for successful challenge responses', async () => {
+        const alice = await keymaster.createId('Alice');
+        const carol = await keymaster.createId('Carol');
+        const victor = await keymaster.createId('Victor');
+
+        await keymaster.setCurrentId('Alice');
+        const schemaDid = await keymaster.createSchema(mockSchema);
+        const credential = await keymaster.bindCredential(schemaDid, carol);
+        const vcDid = await keymaster.issueCredential(credential);
+
+        await keymaster.setCurrentId('Carol');
+        await keymaster.acceptCredential(vcDid);
+
+        await keymaster.setCurrentId('Victor');
+        const challengeDID = await keymaster.createChallenge({
+            credentials: [
+                {
+                    schema: schemaDid,
+                    issuers: [alice],
+                },
+            ],
+        });
+
+        await keymaster.setCurrentId('Carol');
+        const responseDID = await keymaster.createResponse(challengeDID);
+
+        await keymaster.setCurrentId('Victor');
+        const verification = await keymaster.verifyResponse(responseDID);
+        const verifiedAt = '2026-01-01T00:00:00.000Z';
+        const responseCommitment = cipher.hashJSON({
+            type: ChallengeResponseCommitmentType,
+            responseDid: responseDID,
+            responseNonce: verification.responseNonce,
+        });
+
+        const receipts = await keymaster.buildChallengeReceipts(responseDID, { verification, verifiedAt });
+
+        expect(receipts).toStrictEqual([
+            {
+                version: 1,
+                attesterDid: alice,
+                schemaDid,
+                requesterDid: victor,
+                verifiedAt,
+                responseCommitment,
+            },
+        ]);
+
+        const receipt = receipts[0] as ChallengeReceipt & Record<string, unknown>;
+        expect(receipt).not.toHaveProperty('holderDid');
+        expect(receipt).not.toHaveProperty('credentialDid');
+        expect(receipt).not.toHaveProperty('vpDid');
+        expect(receipt).not.toHaveProperty('responseDid');
+        expect(receipt).not.toHaveProperty('responseNonce');
+        expect(receipt).not.toHaveProperty('credential');
+
+        const receiptDIDs = await keymaster.publishChallengeReceipts(responseDID, {
+            verification,
+            verifiedAt,
+            registry: 'local',
+        });
+
+        expect(receiptDIDs).toHaveLength(1);
+
+        const receiptAsset = await keymaster.resolveAsset(receiptDIDs[0]) as { challengeReceipt: ChallengeReceipt };
+        expect(receiptAsset.challengeReceipt).toStrictEqual(receipts[0]);
+
+        const receiptDoc = await keymaster.resolveDID(receiptDIDs[0]);
+        expect(receiptDoc.didDocument?.controller).toBe(victor);
+    });
+
+    it('should reject receipts for unsuccessful challenge responses', async () => {
+        await keymaster.createId('Alice');
+        await keymaster.createId('Carol');
+        await keymaster.createId('Victor');
+
+        await keymaster.setCurrentId('Alice');
+        const schemaDid = await keymaster.createSchema(mockSchema);
+
+        await keymaster.setCurrentId('Victor');
+        const challengeDID = await keymaster.createChallenge({
+            credentials: [
+                {
+                    schema: schemaDid,
+                },
+            ],
+        });
+
+        await keymaster.setCurrentId('Carol');
+        const responseDID = await keymaster.createResponse(challengeDID);
+
+        await keymaster.setCurrentId('Victor');
+        const verification = await keymaster.verifyResponse(responseDID);
+
+        try {
+            await keymaster.buildChallengeReceipts(responseDID, { verification });
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe('Invalid parameter: verification.match');
+        }
+    });
+
+    it('should only allow the challenge requester to build receipts', async () => {
+        const alice = await keymaster.createId('Alice');
+        const carol = await keymaster.createId('Carol');
+        await keymaster.createId('Victor');
+
+        await keymaster.setCurrentId('Alice');
+        const schemaDid = await keymaster.createSchema(mockSchema);
+        const credential = await keymaster.bindCredential(schemaDid, carol);
+        const vcDid = await keymaster.issueCredential(credential);
+
+        await keymaster.setCurrentId('Carol');
+        await keymaster.acceptCredential(vcDid);
+
+        await keymaster.setCurrentId('Victor');
+        const challengeDID = await keymaster.createChallenge({
+            credentials: [
+                {
+                    schema: schemaDid,
+                    issuers: [alice],
+                },
+            ],
+        });
+
+        await keymaster.setCurrentId('Carol');
+        const responseDID = await keymaster.createResponse(challengeDID);
+
+        await keymaster.setCurrentId('Victor');
+        const verification = await keymaster.verifyResponse(responseDID);
+
+        await keymaster.setCurrentId('Carol');
+
+        try {
+            await keymaster.buildChallengeReceipts(responseDID, { verification });
+            throw new ExpectedExceptionError();
+        }
+        catch (error: any) {
+            expect(error.message).toBe('Invalid parameter: requesterDid');
         }
     });
 });

--- a/tests/keymaster/response.test.ts
+++ b/tests/keymaster/response.test.ts
@@ -473,7 +473,7 @@ describe('challenge receipts', () => {
             },
         ]);
 
-        const receipt = receipts[0] as ChallengeReceipt & Record<string, unknown>;
+        const receipt = receipts[0];
         expect(receipt).not.toHaveProperty('holderDid');
         expect(receipt).not.toHaveProperty('credentialDid');
         expect(receipt).not.toHaveProperty('vpDid');


### PR DESCRIPTION
Adds Keymaster support for challenge usage receipts.

- Add encrypted `responseNonce` to challenge responses.
- Add `ChallengeReceipt` types and receipt helpers.
- Add `buildChallengeReceipts()` and `publishChallengeReceipts()`.
- Expose receipt helpers through the Keymaster client and API.
- Add tests covering the expected success flow and receipt privacy shape.
- Resolves: https://github.com/KeychainMDIP/kc/issues/1200