### PR TITLE
feat: add challenge receipt reporting

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -38,6 +38,7 @@ const config = {
         '^\\.\\/windows\\.js$': '<rootDir>/services/mediators/hyperswarm/src/negentropy/windows.ts',
         '^\\.\\/abstract-json\\.js$': '<rootDir>/packages/gatekeeper/src/db/abstract-json.ts',
         '^\\.\\/published-credentials\\.js$': '<rootDir>/services/search-server/src/published-credentials.ts',
+        '^\\.\\/challenge-receipts\\.js$': '<rootDir>/services/search-server/src/challenge-receipts.ts',
         '^\\.\\/cipher-base\\.js$': '<rootDir>/packages/cipher/src/cipher-base.ts',
         '^\\.\\/encryption\\.js$': '<rootDir>/packages/keymaster/src/encryption.ts',
     },

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -2196,7 +2196,9 @@ export default class Keymaster implements KeymasterInterface {
             throw new InvalidParameterError('verification.vps');
         }
 
-        const timestamp = verifiedAt ?? new Date().toISOString();
+        const timestamp = verifiedAt
+            ? new Date(verifiedAt).toISOString()
+            : new Date().toISOString();
         const responseCommitment = this.createResponseCommitment(responseDID, response.responseNonce);
         const receipts: ChallengeReceipt[] = [];
 

--- a/services/explorer/src/App.tsx
+++ b/services/explorer/src/App.tsx
@@ -2,6 +2,7 @@ import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import JsonViewer from "./components/JsonViewer.js";
 import Events from "./components/Events.js";
 import Credentials from "./components/Credentials.js";
+import ChallengeReceipts from "./components/ChallengeReceipts.js";
 import GatekeeperClient from '@mdip/gatekeeper/client';
 import { createTheme, ThemeProvider } from "@mui/material/styles";
 import {
@@ -252,6 +253,14 @@ function App() {
                                     <Credentials
                                         gatekeeper={gatekeeper}
                                         isReady={isReady}
+                                        setError={setError}
+                                    />
+                                }
+                            />
+                            <Route
+                                path="/receipts"
+                                element={
+                                    <ChallengeReceipts
                                         setError={setError}
                                     />
                                 }

--- a/services/explorer/src/components/ChallengeReceipts.tsx
+++ b/services/explorer/src/components/ChallengeReceipts.tsx
@@ -1,0 +1,962 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import ArrowBackIosNewIcon from "@mui/icons-material/ArrowBackIosNew";
+import axios from "axios";
+import {
+    Box,
+    Button,
+    FormControl,
+    MenuItem,
+    Select,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+    TextField,
+    Typography,
+} from "@mui/material";
+import { Link as RouterLink, useSearchParams } from "react-router-dom";
+
+const searchServerURL = import.meta.env.VITE_SEARCH_SERVER || "http://localhost:4002";
+const VERSION = "/api/v1";
+const pageSizeOptions = [25, 50, 100];
+const usageFetchLimit = 500;
+const receiptBrowseFetchLimit = 500;
+
+interface ChallengeReceiptUsageRow {
+    attesterDid: string;
+    schemaDid: string;
+    requesterDid: string;
+    count: number;
+    firstVerifiedAt: string;
+    lastVerifiedAt: string;
+}
+
+interface ChallengeReceiptRow {
+    receiptDid: string;
+    attesterDid: string;
+    schemaDid: string;
+    requesterDid: string;
+    verifiedAt: string;
+    responseCommitment: string;
+    updatedAt: string;
+}
+
+interface AttesterUsageRow {
+    attesterDid: string;
+    count: number;
+    templateCount: number;
+    requesterCount: number;
+    firstVerifiedAt: string;
+    lastVerifiedAt: string;
+}
+
+function parsePositiveInteger(value: string | null, fallback: number): number {
+    const parsed = Number.parseInt(value ?? "", 10);
+
+    if (Number.isInteger(parsed) && parsed > 0) {
+        return parsed;
+    }
+
+    return fallback;
+}
+
+function parseNonNegativeInteger(value: string | null, fallback: number): number {
+    const parsed = Number.parseInt(value ?? "", 10);
+
+    if (Number.isInteger(parsed) && parsed >= 0) {
+        return parsed;
+    }
+
+    return fallback;
+}
+
+function formatTimestamp(value: string): string {
+    const date = new Date(value);
+
+    if (Number.isNaN(date.getTime())) {
+        return value;
+    }
+
+    return `${date.toISOString().replace("T", " ").slice(0, 16)}Z`;
+}
+
+function getStartOfDay(value: string): string | undefined {
+    if (!value) {
+        return undefined;
+    }
+
+    const date = new Date(`${value}T00:00:00.000Z`);
+    return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function getEndOfDay(value: string): string | undefined {
+    if (!value) {
+        return undefined;
+    }
+
+    const date = new Date(`${value}T23:59:59.999Z`);
+    return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+}
+
+function mapUsageRow(row: any): ChallengeReceiptUsageRow {
+    return {
+        attesterDid: row.attesterDid,
+        schemaDid: row.schemaDid,
+        requesterDid: row.requesterDid,
+        count: Number(row.count ?? 0),
+        firstVerifiedAt: row.firstVerifiedAt,
+        lastVerifiedAt: row.lastVerifiedAt,
+    };
+}
+
+function mapReceiptRow(row: any): ChallengeReceiptRow {
+    return {
+        receiptDid: row.receiptDid,
+        attesterDid: row.attesterDid,
+        schemaDid: row.schemaDid,
+        requesterDid: row.requesterDid,
+        verifiedAt: row.verifiedAt,
+        responseCommitment: row.responseCommitment,
+        updatedAt: row.updatedAt,
+    };
+}
+
+function DidLink(
+    {
+        did,
+        maxWidth = 420,
+    }: {
+        did: string;
+        maxWidth?: number | string;
+    }
+) {
+    return (
+        <Typography
+            component={RouterLink}
+            to={`/search?did=${encodeURIComponent(did)}`}
+            title={did}
+            onClick={(event) => {
+                event.stopPropagation();
+            }}
+            sx={{
+                display: "block",
+                fontFamily: "Courier, monospace",
+                textDecoration: "underline",
+                color: "primary.main",
+                cursor: "pointer",
+                maxWidth,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+            }}
+        >
+            {did}
+        </Typography>
+    );
+}
+
+function SelectableDid(
+    {
+        did,
+        onClick,
+        maxWidth = 420,
+    }: {
+        did: string;
+        onClick: () => void;
+        maxWidth?: number | string;
+    }
+) {
+    return (
+        <Typography
+            title={did}
+            onClick={(event) => {
+                event.stopPropagation();
+                onClick();
+            }}
+            sx={{
+                display: "block",
+                fontFamily: "Courier, monospace",
+                textDecoration: "underline",
+                color: "primary.main",
+                cursor: "pointer",
+                maxWidth,
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+            }}
+        >
+            {did}
+        </Typography>
+    );
+}
+
+function SummaryCard(
+    {
+        label,
+        value,
+    }: {
+        label: string;
+        value: number;
+    }
+) {
+    return (
+        <Box
+            sx={{
+                border: "1px solid",
+                borderColor: "divider",
+                borderRadius: 1,
+                p: 2,
+                minWidth: 230,
+                flex: "1 1 230px",
+            }}
+        >
+            <Box sx={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", gap: 2 }}>
+                <Typography
+                    sx={{
+                        fontSize: "0.9rem",
+                        fontWeight: 500,
+                        letterSpacing: "0.08em",
+                        textTransform: "uppercase",
+                    }}
+                >
+                    {label}
+                </Typography>
+                <Typography variant="h4" sx={{ fontSize: "2.1rem", lineHeight: 1 }}>
+                    {value}
+                </Typography>
+            </Box>
+        </Box>
+    );
+}
+
+function groupReceiptsByAttester(receipts: ChallengeReceiptRow[]): AttesterUsageRow[] {
+    const groups = new Map<string, {
+        commitments: Set<string>;
+        requesters: Set<string>;
+        templates: Set<string>;
+        row: AttesterUsageRow;
+    }>();
+
+    for (const receipt of receipts) {
+        const existing = groups.get(receipt.attesterDid);
+
+        if (!existing) {
+            groups.set(receipt.attesterDid, {
+                commitments: new Set([receipt.responseCommitment]),
+                requesters: new Set([receipt.requesterDid]),
+                templates: new Set([receipt.schemaDid]),
+                row: {
+                    attesterDid: receipt.attesterDid,
+                    count: 1,
+                    templateCount: 1,
+                    requesterCount: 1,
+                    firstVerifiedAt: receipt.verifiedAt,
+                    lastVerifiedAt: receipt.verifiedAt,
+                },
+            });
+            continue;
+        }
+
+        existing.commitments.add(receipt.responseCommitment);
+        existing.requesters.add(receipt.requesterDid);
+        existing.templates.add(receipt.schemaDid);
+        existing.row.count = existing.commitments.size;
+        existing.row.requesterCount = existing.requesters.size;
+        existing.row.templateCount = existing.templates.size;
+
+        if (receipt.verifiedAt < existing.row.firstVerifiedAt) {
+            existing.row.firstVerifiedAt = receipt.verifiedAt;
+        }
+        if (receipt.verifiedAt > existing.row.lastVerifiedAt) {
+            existing.row.lastVerifiedAt = receipt.verifiedAt;
+        }
+    }
+
+    return Array.from(groups.values())
+        .map(group => group.row)
+        .sort((a, b) => b.count - a.count || a.attesterDid.localeCompare(b.attesterDid));
+}
+
+function ChallengeReceipts({ setError }: { setError: (error: any) => void }) {
+    const [searchParams, setSearchParams] = useSearchParams();
+    const [draftAttesterDid, setDraftAttesterDid] = useState<string>(searchParams.get("attesterDid") ?? "");
+    const [draftDateFrom, setDraftDateFrom] = useState<string>(searchParams.get("dateFrom") ?? "");
+    const [draftDateTo, setDraftDateTo] = useState<string>(searchParams.get("dateTo") ?? "");
+    const [attesterRows, setAttesterRows] = useState<AttesterUsageRow[]>([]);
+    const [usageRows, setUsageRows] = useState<ChallengeReceiptUsageRow[]>([]);
+    const [receipts, setReceipts] = useState<ChallengeReceiptRow[]>([]);
+    const [receiptTotal, setReceiptTotal] = useState<number>(0);
+    const [isAttesterLoading, setIsAttesterLoading] = useState<boolean>(false);
+    const [isUsageLoading, setIsUsageLoading] = useState<boolean>(false);
+    const [isReceiptLoading, setIsReceiptLoading] = useState<boolean>(false);
+
+    const attesterDid = searchParams.get("attesterDid") ?? "";
+    const dateFrom = searchParams.get("dateFrom") ?? "";
+    const dateTo = searchParams.get("dateTo") ?? "";
+    const selectedSchemaDid = searchParams.get("detailSchemaDid") ?? "";
+    const selectedRequesterDid = searchParams.get("detailRequesterDid") ?? "";
+    const pageSize = parsePositiveInteger(searchParams.get("pageSize"), 25);
+    const page = parseNonNegativeInteger(searchParams.get("page"), 0);
+    const receiptPageSize = parsePositiveInteger(searchParams.get("receiptPageSize"), 25);
+    const receiptPage = parseNonNegativeInteger(searchParams.get("receiptPage"), 0);
+
+    const verifiedAfter = useMemo(() => getStartOfDay(dateFrom), [dateFrom]);
+    const verifiedBefore = useMemo(() => getEndOfDay(dateTo), [dateTo]);
+
+    const filteredAttesterRows = useMemo(() => {
+        const query = draftAttesterDid.trim().toLowerCase();
+
+        if (!query || attesterDid) {
+            return attesterRows;
+        }
+
+        return attesterRows.filter(row => row.attesterDid.toLowerCase().includes(query));
+    }, [attesterDid, attesterRows, draftAttesterDid]);
+
+    const totalPages = Math.max(1, Math.ceil(usageRows.length / pageSize));
+    const attesterTotalPages = Math.max(1, Math.ceil(filteredAttesterRows.length / pageSize));
+    const receiptTotalPages = Math.max(1, Math.ceil(receiptTotal / receiptPageSize));
+    const pagedUsageRows = useMemo(() => {
+        const from = page * pageSize;
+        const to = from + pageSize;
+
+        return usageRows.slice(from, to);
+    }, [page, pageSize, usageRows]);
+    const pagedAttesterRows = useMemo(() => {
+        const from = page * pageSize;
+        const to = from + pageSize;
+
+        return filteredAttesterRows.slice(from, to);
+    }, [filteredAttesterRows, page, pageSize]);
+
+    const selectedUsageRow = useMemo(
+        () => usageRows.find(row => row.schemaDid === selectedSchemaDid && row.requesterDid === selectedRequesterDid) ?? null,
+        [selectedRequesterDid, selectedSchemaDid, usageRows]
+    );
+
+    const totalSuccessfulUses = useMemo(
+        () => usageRows.reduce((sum, row) => sum + row.count, 0),
+        [usageRows]
+    );
+    const templateCount = useMemo(
+        () => new Set(usageRows.map(row => row.schemaDid)).size,
+        [usageRows]
+    );
+    const requesterCount = useMemo(
+        () => new Set(usageRows.map(row => row.requesterDid)).size,
+        [usageRows]
+    );
+
+    const updateParams = useCallback((
+        updates: Record<string, string | null | undefined>,
+        options?: { replace?: boolean }
+    ) => {
+        const next = new URLSearchParams(searchParams);
+
+        for (const [key, value] of Object.entries(updates)) {
+            if (!value) {
+                next.delete(key);
+            }
+            else {
+                next.set(key, value);
+            }
+        }
+
+        setSearchParams(next, options);
+    }, [searchParams, setSearchParams]);
+
+    function handleSearch() {
+        const next = new URLSearchParams();
+
+        if (draftAttesterDid.trim()) {
+            next.set("attesterDid", draftAttesterDid.trim());
+        }
+        if (draftDateFrom) {
+            next.set("dateFrom", draftDateFrom);
+        }
+        if (draftDateTo) {
+            next.set("dateTo", draftDateTo);
+        }
+        next.set("page", "0");
+        next.set("pageSize", pageSize.toString());
+
+        setSearchParams(next);
+    }
+
+    function handleSelectAttester(nextAttesterDid: string) {
+        const next = new URLSearchParams();
+
+        next.set("attesterDid", nextAttesterDid);
+        if (draftDateFrom) {
+            next.set("dateFrom", draftDateFrom);
+        }
+        if (draftDateTo) {
+            next.set("dateTo", draftDateTo);
+        }
+        next.set("page", "0");
+        next.set("pageSize", pageSize.toString());
+
+        setSearchParams(next);
+    }
+
+    function handleSelectUsageRow(row: ChallengeReceiptUsageRow) {
+        updateParams({
+            detailSchemaDid: row.schemaDid,
+            detailRequesterDid: row.requesterDid,
+            receiptPage: "0",
+        });
+    }
+
+    function handleBackFromReceipts() {
+        updateParams({
+            detailSchemaDid: null,
+            detailRequesterDid: null,
+            receiptPage: null,
+        }, { replace: true });
+    }
+
+    useEffect(() => {
+        setDraftAttesterDid(searchParams.get("attesterDid") ?? "");
+        setDraftDateFrom(searchParams.get("dateFrom") ?? "");
+        setDraftDateTo(searchParams.get("dateTo") ?? "");
+    }, [searchParams]);
+
+    useEffect(() => {
+        let ignore = false;
+
+        async function fetchAttesterRows() {
+            if (attesterDid) {
+                setAttesterRows([]);
+                setIsAttesterLoading(false);
+                return;
+            }
+
+            setIsAttesterLoading(true);
+
+            try {
+                const allReceipts: ChallengeReceiptRow[] = [];
+                let offset = 0;
+                let total = 0;
+
+                do {
+                    const response = await axios.get(`${searchServerURL}${VERSION}/metrics/challenge-receipts`, {
+                        params: {
+                            verifiedAfter,
+                            verifiedBefore,
+                            limit: receiptBrowseFetchLimit,
+                            offset,
+                        },
+                    });
+
+                    total = response.data.total ?? 0;
+                    allReceipts.push(...(response.data.receipts ?? []).map(mapReceiptRow));
+                    offset += receiptBrowseFetchLimit;
+                } while (offset < total);
+
+                if (!ignore) {
+                    setAttesterRows(groupReceiptsByAttester(allReceipts));
+                }
+            }
+            catch (error: any) {
+                if (!ignore) {
+                    setAttesterRows([]);
+                    setError(error);
+                }
+            }
+            finally {
+                if (!ignore) {
+                    setIsAttesterLoading(false);
+                }
+            }
+        }
+
+        fetchAttesterRows();
+
+        return () => {
+            ignore = true;
+        };
+    }, [attesterDid, setError, verifiedAfter, verifiedBefore]);
+
+    useEffect(() => {
+        let ignore = false;
+
+        async function fetchUsageRows() {
+            if (!attesterDid) {
+                setUsageRows([]);
+                setReceipts([]);
+                setReceiptTotal(0);
+                return;
+            }
+
+            setIsUsageLoading(true);
+
+            try {
+                const allRows: ChallengeReceiptUsageRow[] = [];
+                let offset = 0;
+                let total = 0;
+
+                do {
+                    const response = await axios.get(`${searchServerURL}${VERSION}/metrics/challenge-receipts/usage`, {
+                        params: {
+                            attesterDid,
+                            verifiedAfter,
+                            verifiedBefore,
+                            limit: usageFetchLimit,
+                            offset,
+                        },
+                    });
+
+                    total = response.data.total ?? 0;
+                    allRows.push(...(response.data.usage ?? []).map(mapUsageRow));
+                    offset += usageFetchLimit;
+                } while (offset < total);
+
+                if (!ignore) {
+                    setUsageRows(allRows);
+                }
+            }
+            catch (error: any) {
+                if (!ignore) {
+                    setUsageRows([]);
+                    setError(error);
+                }
+            }
+            finally {
+                if (!ignore) {
+                    setIsUsageLoading(false);
+                }
+            }
+        }
+
+        fetchUsageRows();
+
+        return () => {
+            ignore = true;
+        };
+    }, [attesterDid, setError, verifiedAfter, verifiedBefore]);
+
+    useEffect(() => {
+        const rowCount = attesterDid ? usageRows.length : filteredAttesterRows.length;
+        const maxPage = Math.max(0, Math.ceil(rowCount / pageSize) - 1);
+
+        if (page > maxPage) {
+            updateParams({ page: "0" }, { replace: true });
+        }
+    }, [attesterDid, filteredAttesterRows.length, page, pageSize, updateParams, usageRows.length]);
+
+    useEffect(() => {
+        let ignore = false;
+
+        async function fetchReceiptRows() {
+            if (!attesterDid || !selectedSchemaDid || !selectedRequesterDid) {
+                setReceipts([]);
+                setReceiptTotal(0);
+                return;
+            }
+
+            setIsReceiptLoading(true);
+
+            try {
+                const response = await axios.get(`${searchServerURL}${VERSION}/metrics/challenge-receipts`, {
+                    params: {
+                        attesterDid,
+                        schemaDid: selectedSchemaDid,
+                        requesterDid: selectedRequesterDid,
+                        verifiedAfter,
+                        verifiedBefore,
+                        limit: receiptPageSize,
+                        offset: receiptPage * receiptPageSize,
+                    },
+                });
+                const total = response.data.total ?? 0;
+
+                if (!ignore) {
+                    if (total > 0 && receiptPage * receiptPageSize >= total && receiptPage > 0) {
+                        updateParams({ receiptPage: "0" });
+                        return;
+                    }
+
+                    setReceiptTotal(total);
+                    setReceipts((response.data.receipts ?? []).map(mapReceiptRow));
+                }
+            }
+            catch (error: any) {
+                if (!ignore) {
+                    setReceipts([]);
+                    setReceiptTotal(0);
+                    setError(error);
+                }
+            }
+            finally {
+                if (!ignore) {
+                    setIsReceiptLoading(false);
+                }
+            }
+        }
+
+        fetchReceiptRows();
+
+        return () => {
+            ignore = true;
+        };
+    }, [
+        attesterDid,
+        receiptPage,
+        receiptPageSize,
+        selectedRequesterDid,
+        selectedSchemaDid,
+        setError,
+        updateParams,
+        verifiedAfter,
+        verifiedBefore,
+    ]);
+
+    return (
+        <Box sx={{ ml: 1, mt: 2, minWidth: 860 }}>
+            {selectedUsageRow ? (
+                <>
+                    <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap", mb: 2 }}>
+                        <Button
+                            variant="outlined"
+                            onClick={handleBackFromReceipts}
+                            startIcon={<ArrowBackIosNewIcon fontSize="small" />}
+                        >
+                            Back
+                        </Button>
+                        <Typography variant="h6">Receipts</Typography>
+                    </Box>
+
+                    <Box sx={{ display: "flex", flexDirection: "column", gap: 1, mb: 3 }}>
+                        <Box sx={{ display: "flex", alignItems: "baseline", gap: 2, flexWrap: "wrap" }}>
+                            <Typography variant="overline" sx={{ minWidth: 100 }}>
+                                Schema
+                            </Typography>
+                            <DidLink did={selectedUsageRow.schemaDid} maxWidth="100%" />
+                        </Box>
+                        <Box sx={{ display: "flex", alignItems: "baseline", gap: 2, flexWrap: "wrap" }}>
+                            <Typography variant="overline" sx={{ minWidth: 100 }}>
+                                Requester
+                            </Typography>
+                            <DidLink did={selectedUsageRow.requesterDid} maxWidth="100%" />
+                        </Box>
+                        <Box sx={{ display: "flex", alignItems: "baseline", gap: 2, flexWrap: "wrap" }}>
+                            <Typography variant="overline" sx={{ minWidth: 100 }}>
+                                Uses
+                            </Typography>
+                            <Typography>{selectedUsageRow.count}</Typography>
+                        </Box>
+                    </Box>
+
+                    <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 2, flexWrap: "wrap", mb: 2 }}>
+                        <Typography>
+                            {receiptTotal} receipt{receiptTotal === 1 ? "" : "s"}
+                        </Typography>
+                        <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap" }}>
+                            <FormControl size="small" sx={{ minWidth: 100 }}>
+                                <Select
+                                    value={receiptPageSize}
+                                    onChange={(event) => updateParams({
+                                        receiptPageSize: String(event.target.value),
+                                        receiptPage: "0",
+                                    })}
+                                >
+                                    {pageSizeOptions.map((option) => (
+                                        <MenuItem key={option} value={option}>
+                                            {option}
+                                        </MenuItem>
+                                    ))}
+                                </Select>
+                            </FormControl>
+                            <Box display="flex" alignItems="center" gap={1}>
+                                <Button
+                                    variant="outlined"
+                                    size="small"
+                                    disabled={receiptPage === 0}
+                                    onClick={() => updateParams({ receiptPage: String(receiptPage - 1) })}
+                                >
+                                    Prev
+                                </Button>
+                                <Typography>
+                                    Page {Math.min(receiptPage + 1, receiptTotalPages)} / {receiptTotalPages}
+                                </Typography>
+                                <Button
+                                    variant="outlined"
+                                    size="small"
+                                    disabled={receiptPage + 1 >= receiptTotalPages}
+                                    onClick={() => updateParams({ receiptPage: String(receiptPage + 1) })}
+                                >
+                                    Next
+                                </Button>
+                            </Box>
+                        </Box>
+                    </Box>
+
+                    {isReceiptLoading ? (
+                        <Typography>Loading receipts...</Typography>
+                    ) : receipts.length === 0 ? (
+                        <Typography>No receipts found for this usage row.</Typography>
+                    ) : (
+                        <TableContainer sx={{ border: "1px solid", borderColor: "divider", borderRadius: 1 }}>
+                            <Table size="small">
+                                <TableHead>
+                                    <TableRow>
+                                        <TableCell width={180}>Verified</TableCell>
+                                        <TableCell>Receipt DID</TableCell>
+                                    </TableRow>
+                                </TableHead>
+                                <TableBody>
+                                    {receipts.map((row) => (
+                                        <TableRow key={row.receiptDid}>
+                                            <TableCell>{formatTimestamp(row.verifiedAt)}</TableCell>
+                                            <TableCell>
+                                                <DidLink did={row.receiptDid} maxWidth="none" />
+                                            </TableCell>
+                                        </TableRow>
+                                    ))}
+                                </TableBody>
+                            </Table>
+                        </TableContainer>
+                    )}
+                </>
+            ) : (
+                <>
+                    <Box sx={{ display: "flex", flexDirection: "column", gap: 2, mb: 3 }}>
+                        <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap" }}>
+                            <TextField
+                                label="Attester DID"
+                                value={draftAttesterDid}
+                                onChange={(event) => setDraftAttesterDid(event.target.value)}
+                                size="small"
+                                required
+                                sx={{ flex: "1 1 100%" }}
+                            />
+                        </Box>
+                        <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap", alignItems: "center" }}>
+                            <TextField
+                                label="From"
+                                type="date"
+                                value={draftDateFrom}
+                                onChange={(event) => setDraftDateFrom(event.target.value)}
+                                size="small"
+                                InputLabelProps={{ shrink: true }}
+                                sx={{ width: 180 }}
+                            />
+                            <TextField
+                                label="To"
+                                type="date"
+                                value={draftDateTo}
+                                onChange={(event) => setDraftDateTo(event.target.value)}
+                                size="small"
+                                InputLabelProps={{ shrink: true }}
+                                sx={{ width: 180 }}
+                            />
+                            <Button
+                                variant="contained"
+                                onClick={handleSearch}
+                            >
+                                Search
+                            </Button>
+                        </Box>
+                    </Box>
+
+                    {!attesterDid ? (
+                        <>
+                            <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 2, flexWrap: "wrap", mb: 2 }}>
+                                <Box>
+                                    <Typography variant="h6">Attesters</Typography>
+                                    <Typography variant="body2" color="text.secondary">
+                                        Select an attester to view usage.
+                                    </Typography>
+                                </Box>
+                                <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap" }}>
+                                    <FormControl size="small" sx={{ minWidth: 100 }}>
+                                        <Select
+                                            value={pageSize}
+                                            onChange={(event) => updateParams({
+                                                pageSize: String(event.target.value),
+                                                page: "0",
+                                            })}
+                                        >
+                                            {pageSizeOptions.map((option) => (
+                                                <MenuItem key={option} value={option}>
+                                                    {option}
+                                                </MenuItem>
+                                            ))}
+                                        </Select>
+                                    </FormControl>
+                                    <Box display="flex" alignItems="center" gap={1}>
+                                        <Button
+                                            variant="outlined"
+                                            size="small"
+                                            disabled={page === 0}
+                                            onClick={() => updateParams({ page: String(page - 1) })}
+                                        >
+                                            Prev
+                                        </Button>
+                                        <Typography>
+                                            Page {Math.min(page + 1, attesterTotalPages)} / {attesterTotalPages}
+                                        </Typography>
+                                        <Button
+                                            variant="outlined"
+                                            size="small"
+                                            disabled={page + 1 >= attesterTotalPages}
+                                            onClick={() => updateParams({ page: String(page + 1) })}
+                                        >
+                                            Next
+                                        </Button>
+                                    </Box>
+                                </Box>
+                            </Box>
+
+                            {isAttesterLoading ? (
+                                <Typography>Loading attesters...</Typography>
+                            ) : filteredAttesterRows.length === 0 ? (
+                                <Typography>No challenge receipt usage found.</Typography>
+                            ) : (
+                                <TableContainer sx={{ border: "1px solid", borderColor: "divider", borderRadius: 1 }}>
+                                    <Table size="small">
+                                        <TableHead>
+                                            <TableRow>
+                                                <TableCell>Attester DID</TableCell>
+                                                <TableCell width={90}>Uses</TableCell>
+                                                <TableCell width={110}>Templates</TableCell>
+                                                <TableCell width={110}>Requesters</TableCell>
+                                                <TableCell width={170}>First Verified</TableCell>
+                                                <TableCell width={170}>Last Verified</TableCell>
+                                            </TableRow>
+                                        </TableHead>
+                                        <TableBody>
+                                            {pagedAttesterRows.map((row) => (
+                                                <TableRow
+                                                    key={row.attesterDid}
+                                                    hover
+                                                    onClick={() => handleSelectAttester(row.attesterDid)}
+                                                    sx={{ cursor: "pointer" }}
+                                                >
+                                                    <TableCell>
+                                                        <SelectableDid
+                                                            did={row.attesterDid}
+                                                            onClick={() => handleSelectAttester(row.attesterDid)}
+                                                            maxWidth={300}
+                                                        />
+                                                    </TableCell>
+                                                    <TableCell>{row.count}</TableCell>
+                                                    <TableCell>{row.templateCount}</TableCell>
+                                                    <TableCell>{row.requesterCount}</TableCell>
+                                                    <TableCell>{formatTimestamp(row.firstVerifiedAt)}</TableCell>
+                                                    <TableCell>{formatTimestamp(row.lastVerifiedAt)}</TableCell>
+                                                </TableRow>
+                                            ))}
+                                        </TableBody>
+                                    </Table>
+                                </TableContainer>
+                            )}
+                        </>
+                    ) : (
+                        <>
+                            <Typography variant="h6" sx={{ mb: 2 }}>Usage</Typography>
+                            <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap", mb: 2 }}>
+                                <SummaryCard label="Successful Uses" value={totalSuccessfulUses} />
+                                <SummaryCard label="Templates Used" value={templateCount} />
+                                <SummaryCard label="Requesters" value={requesterCount} />
+                            </Box>
+
+                            <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 2, flexWrap: "wrap", mb: 2 }}>
+                                <Box sx={{ minWidth: 0 }}>
+                                    <Typography variant="overline">Attester</Typography>
+                                    <DidLink did={attesterDid} maxWidth={620} />
+                                </Box>
+                                <Box sx={{ display: "flex", alignItems: "center", gap: 2, flexWrap: "wrap" }}>
+                                    <FormControl size="small" sx={{ minWidth: 100 }}>
+                                        <Select
+                                            value={pageSize}
+                                            onChange={(event) => updateParams({
+                                                pageSize: String(event.target.value),
+                                                page: "0",
+                                            })}
+                                        >
+                                            {pageSizeOptions.map((option) => (
+                                                <MenuItem key={option} value={option}>
+                                                    {option}
+                                                </MenuItem>
+                                            ))}
+                                        </Select>
+                                    </FormControl>
+                                    <Box display="flex" alignItems="center" gap={1}>
+                                        <Button
+                                            variant="outlined"
+                                            size="small"
+                                            disabled={page === 0}
+                                            onClick={() => updateParams({ page: String(page - 1) })}
+                                        >
+                                            Prev
+                                        </Button>
+                                        <Typography>
+                                            Page {Math.min(page + 1, totalPages)} / {totalPages}
+                                        </Typography>
+                                        <Button
+                                            variant="outlined"
+                                            size="small"
+                                            disabled={page + 1 >= totalPages}
+                                            onClick={() => updateParams({ page: String(page + 1) })}
+                                        >
+                                            Next
+                                        </Button>
+                                    </Box>
+                                </Box>
+                            </Box>
+
+                            {isUsageLoading ? (
+                                <Typography>Loading receipt usage...</Typography>
+                            ) : usageRows.length === 0 ? (
+                                <Typography>No challenge receipt usage found.</Typography>
+                            ) : (
+                                <TableContainer sx={{ border: "1px solid", borderColor: "divider", borderRadius: 1 }}>
+                                    <Table size="small">
+                                        <TableHead>
+                                            <TableRow>
+                                                <TableCell>Schema DID</TableCell>
+                                                <TableCell width={90}>Count</TableCell>
+                                                <TableCell width={170}>First Verified</TableCell>
+                                                <TableCell width={170}>Last Verified</TableCell>
+                                                <TableCell width={130}>Receipts</TableCell>
+                                            </TableRow>
+                                        </TableHead>
+                                        <TableBody>
+                                            {pagedUsageRows.map((row) => (
+                                                <TableRow
+                                                    key={`${row.schemaDid}:${row.requesterDid}`}
+                                                    hover
+                                                >
+                                                    <TableCell>
+                                                        <DidLink did={row.schemaDid} maxWidth={260} />
+                                                    </TableCell>
+                                                    <TableCell>{row.count}</TableCell>
+                                                    <TableCell>{formatTimestamp(row.firstVerifiedAt)}</TableCell>
+                                                    <TableCell>{formatTimestamp(row.lastVerifiedAt)}</TableCell>
+                                                    <TableCell>
+                                                        <Button
+                                                            variant="outlined"
+                                                            size="small"
+                                                            onClick={() => handleSelectUsageRow(row)}
+                                                        >
+                                                            View
+                                                        </Button>
+                                                    </TableCell>
+                                                </TableRow>
+                                            ))}
+                                        </TableBody>
+                                    </Table>
+                                </TableContainer>
+                            )}
+                        </>
+                    )}
+                </>
+            )}
+        </Box>
+    );
+}
+
+export default React.memo(ChallengeReceipts);

--- a/services/explorer/src/components/Header.tsx
+++ b/services/explorer/src/components/Header.tsx
@@ -26,6 +26,9 @@ const Header = (
     else if (location.pathname.startsWith("/credentials")) {
         currentTab = "credentials";
     }
+    else if (location.pathname.startsWith("/receipts")) {
+        currentTab = "receipts";
+    }
 
     const handleTabChange = (event: React.SyntheticEvent, newValue: string) => {
         navigate("/" + newValue);
@@ -67,6 +70,7 @@ const Header = (
                 <Tab label="Search" value="search" />
                 <Tab label="Events" value="events" />
                 <Tab label="Credentials" value="credentials" />
+                <Tab label="Receipts" value="receipts" />
             </Tabs>
 
             <Box sx={{ ml: "auto", display: "flex", alignItems: "center" }}>

--- a/services/search-server/src/DidIndexer.ts
+++ b/services/search-server/src/DidIndexer.ts
@@ -2,6 +2,7 @@ import GatekeeperClient from "@mdip/gatekeeper/client";
 import type { DIDsDb } from "./types.js";
 import { childLogger } from "@mdip/common/logger";
 import { extractPublishedCredentials } from "./published-credentials.js";
+import { extractChallengeReceipts } from "./challenge-receipts.js";
 
 export interface DidIndexerOptions {
     intervalMs: number;
@@ -62,6 +63,7 @@ export default class DidIndexer {
                 const doc = await this.gatekeeper.resolveDID(did);
                 await this.db.storeDID(did, doc);
                 await this.db.replacePublishedCredentials(did, extractPublishedCredentials(did, doc));
+                await this.db.replaceChallengeReceipts(did, extractChallengeReceipts(did, doc));
             }
 
             await this.db.saveUpdatedAfter(now);

--- a/services/search-server/src/challenge-receipts.ts
+++ b/services/search-server/src/challenge-receipts.ts
@@ -1,0 +1,83 @@
+import { ChallengeReceiptRecord } from "./types.js";
+
+interface MaybeChallengeReceipt {
+    version?: unknown;
+    attesterDid?: unknown;
+    schemaDid?: unknown;
+    requesterDid?: unknown;
+    verifiedAt?: unknown;
+    responseCommitment?: unknown;
+}
+
+interface MaybeMdipDocument {
+    didDocument?: {
+        id?: unknown;
+    };
+    didDocumentData?: {
+        challengeReceipt?: unknown;
+    };
+    didDocumentMetadata?: {
+        updated?: unknown;
+        created?: unknown;
+    };
+}
+
+function isDid(value: unknown): value is string {
+    return typeof value === 'string' && value.startsWith('did:');
+}
+
+function isNonEmptyString(value: unknown): value is string {
+    return typeof value === 'string' && value.length > 0;
+}
+
+function isIsoDateString(value: unknown): value is string {
+    return typeof value === 'string' && !Number.isNaN(new Date(value).getTime());
+}
+
+function getFallbackUpdatedAt(doc: MaybeMdipDocument, verifiedAt: string): string {
+    const updatedAt = doc.didDocumentMetadata?.updated ?? doc.didDocumentMetadata?.created;
+
+    return typeof updatedAt === 'string' ? updatedAt : verifiedAt;
+}
+
+export function extractChallengeReceipts(
+    defaultReceiptDid: string,
+    doc: object
+): ChallengeReceiptRecord[] {
+    const mdipDoc = doc as MaybeMdipDocument;
+    const receiptDid = isDid(mdipDoc.didDocument?.id)
+        ? mdipDoc.didDocument.id
+        : defaultReceiptDid;
+
+    if (!isDid(receiptDid)) {
+        return [];
+    }
+
+    const value = mdipDoc.didDocumentData?.challengeReceipt;
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return [];
+    }
+
+    const receipt = value as MaybeChallengeReceipt;
+
+    if (receipt.version !== 1 ||
+        !isDid(receipt.attesterDid) ||
+        !isDid(receipt.schemaDid) ||
+        !isDid(receipt.requesterDid) ||
+        !isIsoDateString(receipt.verifiedAt) ||
+        !isNonEmptyString(receipt.responseCommitment)) {
+        return [];
+    }
+
+    return [
+        {
+            receiptDid,
+            attesterDid: receipt.attesterDid,
+            schemaDid: receipt.schemaDid,
+            requesterDid: receipt.requesterDid,
+            verifiedAt: receipt.verifiedAt,
+            responseCommitment: receipt.responseCommitment,
+            updatedAt: getFallbackUpdatedAt(mdipDoc, receipt.verifiedAt),
+        },
+    ];
+}

--- a/services/search-server/src/db/json-memory.ts
+++ b/services/search-server/src/db/json-memory.ts
@@ -1,4 +1,10 @@
 import {
+    ChallengeReceiptListOptions,
+    ChallengeReceiptListResult,
+    ChallengeReceiptRecord,
+    ChallengeReceiptUsageOptions,
+    ChallengeReceiptUsageRecord,
+    ChallengeReceiptUsageResult,
     DIDsDb,
     PublishedCredentialListOptions,
     PublishedCredentialListResult,
@@ -12,6 +18,7 @@ export default class DIDsDbMemory implements DIDsDb {
     private docs = new Map<string, JSONObject>();
     private config = new Map<string, string>();
     private publishedCredentials = new Map<string, PublishedCredentialRecord[]>();
+    private challengeReceipts = new Map<string, ChallengeReceiptRecord[]>();
     private static readonly ARRAY_WILDCARD_END = /\[\*]$/;
     private static readonly ARRAY_WILDCARD_MID = /\[\*]\./;
 
@@ -41,6 +48,16 @@ export default class DIDsDbMemory implements DIDsDb {
         }
 
         this.publishedCredentials.set(holderDid, Array.from(uniqueRecords.values()));
+    }
+
+    async replaceChallengeReceipts(receiptDid: string, records: ChallengeReceiptRecord[]): Promise<void> {
+        const uniqueRecords = new Map<string, ChallengeReceiptRecord>();
+
+        for (const record of records) {
+            uniqueRecords.set(record.receiptDid, { ...record });
+        }
+
+        this.challengeReceipts.set(receiptDid, Array.from(uniqueRecords.values()));
     }
 
     async getDID(did: string): Promise<object | null> {
@@ -89,6 +106,83 @@ export default class DIDsDbMemory implements DIDsDb {
             credentials: filtered
                 .slice(normalizedOffset, normalizedOffset + normalizedLimit)
                 .map(record => ({ ...record })),
+        };
+    }
+
+    async listChallengeReceipts(
+        options: ChallengeReceiptListOptions = {}
+    ): Promise<ChallengeReceiptListResult> {
+        const {
+            limit = 50,
+            offset = 0,
+        } = options;
+        const filtered = this.filterChallengeReceipts(options)
+            .sort((a, b) => b.verifiedAt.localeCompare(a.verifiedAt) || a.receiptDid.localeCompare(b.receiptDid));
+        const normalizedLimit = Math.max(0, limit);
+        const normalizedOffset = Math.max(0, offset);
+
+        return {
+            total: filtered.length,
+            receipts: filtered
+                .slice(normalizedOffset, normalizedOffset + normalizedLimit)
+                .map(record => ({ ...record })),
+        };
+    }
+
+    async getChallengeReceiptUsage(
+        options: ChallengeReceiptUsageOptions = {}
+    ): Promise<ChallengeReceiptUsageResult> {
+        const {
+            limit = 50,
+            offset = 0,
+        } = options;
+        const groups = new Map<string, {
+            commitments: Set<string>;
+            record: ChallengeReceiptUsageRecord;
+        }>();
+
+        for (const record of this.filterChallengeReceipts(options)) {
+            const key = `${record.attesterDid}\u0000${record.schemaDid}\u0000${record.requesterDid}`;
+            const existing = groups.get(key);
+
+            if (!existing) {
+                groups.set(key, {
+                    commitments: new Set([record.responseCommitment]),
+                    record: {
+                        attesterDid: record.attesterDid,
+                        schemaDid: record.schemaDid,
+                        requesterDid: record.requesterDid,
+                        count: 1,
+                        firstVerifiedAt: record.verifiedAt,
+                        lastVerifiedAt: record.verifiedAt,
+                    },
+                });
+                continue;
+            }
+
+            existing.commitments.add(record.responseCommitment);
+            existing.record.count = existing.commitments.size;
+            if (record.verifiedAt < existing.record.firstVerifiedAt) {
+                existing.record.firstVerifiedAt = record.verifiedAt;
+            }
+            if (record.verifiedAt > existing.record.lastVerifiedAt) {
+                existing.record.lastVerifiedAt = record.verifiedAt;
+            }
+        }
+
+        const usage = Array.from(groups.values())
+            .map(group => group.record)
+            .sort((a, b) =>
+                b.count - a.count ||
+                a.schemaDid.localeCompare(b.schemaDid) ||
+                a.requesterDid.localeCompare(b.requesterDid)
+            );
+        const normalizedLimit = Math.max(0, limit);
+        const normalizedOffset = Math.max(0, offset);
+
+        return {
+            total: usage.length,
+            usage: usage.slice(normalizedOffset, normalizedOffset + normalizedLimit),
         };
     }
 
@@ -164,12 +258,42 @@ export default class DIDsDbMemory implements DIDsDb {
         this.docs.clear();
         this.config.clear();
         this.publishedCredentials.clear();
+        this.challengeReceipts.clear();
     }
 
     private flattenPublishedCredentials(): PublishedCredentialRecord[] {
         return Array.from(this.publishedCredentials.values()).flatMap(records =>
             records.map(record => ({ ...record }))
         );
+    }
+
+    private flattenChallengeReceipts(): ChallengeReceiptRecord[] {
+        return Array.from(this.challengeReceipts.values()).flatMap(records =>
+            records.map(record => ({ ...record }))
+        );
+    }
+
+    private filterChallengeReceipts(
+        options: ChallengeReceiptListOptions | ChallengeReceiptUsageOptions
+    ): ChallengeReceiptRecord[] {
+        const {
+            attesterDid,
+            schemaDid,
+            requesterDid,
+            verifiedAfter,
+            verifiedBefore,
+        } = options;
+        const receiptDid = 'receiptDid' in options ? options.receiptDid : undefined;
+        const responseCommitment = 'responseCommitment' in options ? options.responseCommitment : undefined;
+
+        return this.flattenChallengeReceipts()
+            .filter(record => !receiptDid || record.receiptDid === receiptDid)
+            .filter(record => !attesterDid || record.attesterDid === attesterDid)
+            .filter(record => !schemaDid || record.schemaDid === schemaDid)
+            .filter(record => !requesterDid || record.requesterDid === requesterDid)
+            .filter(record => !responseCommitment || record.responseCommitment === responseCommitment)
+            .filter(record => !verifiedAfter || record.verifiedAt >= verifiedAfter)
+            .filter(record => !verifiedBefore || record.verifiedAt <= verifiedBefore);
     }
 
     private getPath(root: unknown, path: string): unknown {

--- a/services/search-server/src/db/postgres.ts
+++ b/services/search-server/src/db/postgres.ts
@@ -1,5 +1,10 @@
 import { Pool } from 'pg';
 import {
+    ChallengeReceiptListOptions,
+    ChallengeReceiptListResult,
+    ChallengeReceiptRecord,
+    ChallengeReceiptUsageOptions,
+    ChallengeReceiptUsageResult,
     DIDsDb,
     PublishedCredentialListOptions,
     PublishedCredentialListResult,
@@ -74,6 +79,31 @@ export default class Postgres implements DIDsDb {
 
             CREATE INDEX IF NOT EXISTS idx_published_credentials_schema_subject
                 ON published_credentials (schema_did, subject_did);
+
+            CREATE TABLE IF NOT EXISTS challenge_receipts (
+                receipt_did TEXT PRIMARY KEY,
+                attester_did TEXT NOT NULL,
+                schema_did TEXT NOT NULL,
+                requester_did TEXT NOT NULL,
+                verified_at TEXT NOT NULL,
+                response_commitment TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_challenge_receipts_attester
+                ON challenge_receipts (attester_did);
+
+            CREATE INDEX IF NOT EXISTS idx_challenge_receipts_schema
+                ON challenge_receipts (schema_did);
+
+            CREATE INDEX IF NOT EXISTS idx_challenge_receipts_requester
+                ON challenge_receipts (requester_did);
+
+            CREATE INDEX IF NOT EXISTS idx_challenge_receipts_verified
+                ON challenge_receipts (verified_at);
+
+            CREATE INDEX IF NOT EXISTS idx_challenge_receipts_commitment
+                ON challenge_receipts (response_commitment);
 
             CREATE TABLE IF NOT EXISTS config (
                 key TEXT PRIMARY KEY,
@@ -166,6 +196,58 @@ export default class Postgres implements DIDsDb {
                         record.issuerDid,
                         record.subjectDid,
                         record.revealed,
+                        record.updatedAt,
+                    ]
+                );
+            }
+
+            await client.query('COMMIT');
+        }
+        catch (error) {
+            await client.query('ROLLBACK');
+            throw error;
+        }
+        finally {
+            client.release();
+        }
+    }
+
+    async replaceChallengeReceipts(receiptDid: string, records: ChallengeReceiptRecord[]): Promise<void> {
+        const pool = this.getPool();
+        const client = await pool.connect();
+
+        try {
+            await client.query('BEGIN');
+            await client.query(
+                'DELETE FROM challenge_receipts WHERE receipt_did = $1',
+                [receiptDid]
+            );
+
+            for (const record of records) {
+                await client.query(
+                    `INSERT INTO challenge_receipts (
+                        receipt_did,
+                        attester_did,
+                        schema_did,
+                        requester_did,
+                        verified_at,
+                        response_commitment,
+                        updated_at
+                    ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+                    ON CONFLICT (receipt_did) DO UPDATE SET
+                        attester_did = EXCLUDED.attester_did,
+                        schema_did = EXCLUDED.schema_did,
+                        requester_did = EXCLUDED.requester_did,
+                        verified_at = EXCLUDED.verified_at,
+                        response_commitment = EXCLUDED.response_commitment,
+                        updated_at = EXCLUDED.updated_at`,
+                    [
+                        record.receiptDid,
+                        record.attesterDid,
+                        record.schemaDid,
+                        record.requesterDid,
+                        record.verifiedAt,
+                        record.responseCommitment,
                         record.updatedAt,
                     ]
                 );
@@ -286,6 +368,97 @@ export default class Postgres implements DIDsDb {
         return {
             total: totalResult.rows[0]?.total ?? 0,
             credentials: result.rows,
+        };
+    }
+
+    async listChallengeReceipts(
+        options: ChallengeReceiptListOptions = {}
+    ): Promise<ChallengeReceiptListResult> {
+        const pool = this.getPool();
+        const {
+            limit = 50,
+            offset = 0,
+        } = options;
+        const { where, params } = this.buildChallengeReceiptWhere(options);
+        const totalResult = await pool.query<CountRow>(
+            `SELECT COUNT(*)::int AS total
+             FROM challenge_receipts
+             ${where}`,
+            params
+        );
+        const pageParams = [...params, Math.max(0, limit), Math.max(0, offset)];
+        const limitParam = `$${pageParams.length - 1}`;
+        const offsetParam = `$${pageParams.length}`;
+        const result = await pool.query<ChallengeReceiptRecord>(
+            `SELECT
+                receipt_did AS "receiptDid",
+                attester_did AS "attesterDid",
+                schema_did AS "schemaDid",
+                requester_did AS "requesterDid",
+                verified_at AS "verifiedAt",
+                response_commitment AS "responseCommitment",
+                updated_at AS "updatedAt"
+             FROM challenge_receipts
+             ${where}
+             ORDER BY verified_at DESC, receipt_did ASC
+             LIMIT ${limitParam} OFFSET ${offsetParam}`,
+            pageParams
+        );
+
+        return {
+            total: totalResult.rows[0]?.total ?? 0,
+            receipts: result.rows,
+        };
+    }
+
+    async getChallengeReceiptUsage(
+        options: ChallengeReceiptUsageOptions = {}
+    ): Promise<ChallengeReceiptUsageResult> {
+        const pool = this.getPool();
+        const {
+            limit = 50,
+            offset = 0,
+        } = options;
+        const { where, params } = this.buildChallengeReceiptWhere(options);
+        const totalResult = await pool.query<CountRow>(
+            `SELECT COUNT(*)::int AS total
+             FROM (
+                SELECT 1
+                FROM challenge_receipts
+                ${where}
+                GROUP BY attester_did, schema_did, requester_did
+             ) AS grouped`,
+            params
+        );
+        const pageParams = [...params, Math.max(0, limit), Math.max(0, offset)];
+        const limitParam = `$${pageParams.length - 1}`;
+        const offsetParam = `$${pageParams.length}`;
+        const result = await pool.query<{
+            attesterDid: string;
+            schemaDid: string;
+            requesterDid: string;
+            count: number;
+            firstVerifiedAt: string;
+            lastVerifiedAt: string;
+        }>(
+            `SELECT
+                attester_did AS "attesterDid",
+                schema_did AS "schemaDid",
+                requester_did AS "requesterDid",
+                COUNT(DISTINCT response_commitment)::int AS count,
+                MIN(verified_at) AS "firstVerifiedAt",
+                MAX(verified_at) AS "lastVerifiedAt"
+             FROM challenge_receipts
+             ${where}
+             GROUP BY attester_did, schema_did, requester_did
+             ORDER BY count DESC, schema_did ASC, requester_did ASC
+             LIMIT ${limitParam} OFFSET ${offsetParam}`,
+            pageParams
+        );
+
+        return {
+            total: totalResult.rows[0]?.total ?? 0,
+            usage: result.rows,
         };
     }
 
@@ -419,6 +592,7 @@ export default class Postgres implements DIDsDb {
         const pool = this.getPool();
         await pool.query('DELETE FROM did_docs');
         await pool.query('DELETE FROM published_credentials');
+        await pool.query('DELETE FROM challenge_receipts');
         await pool.query('DELETE FROM config');
     }
 
@@ -432,6 +606,56 @@ export default class Postgres implements DIDsDb {
 
     protected createPool(): Pool {
         return new Pool({ connectionString: this.url });
+    }
+
+    private buildChallengeReceiptWhere(
+        options: ChallengeReceiptListOptions | ChallengeReceiptUsageOptions
+    ): { where: string; params: unknown[] } {
+        const clauses: string[] = [];
+        const params: unknown[] = [];
+        let index = 1;
+        const receiptDid = 'receiptDid' in options ? options.receiptDid : undefined;
+        const responseCommitment = 'responseCommitment' in options ? options.responseCommitment : undefined;
+
+        if (receiptDid) {
+            clauses.push(`receipt_did = $${index++}`);
+            params.push(receiptDid);
+        }
+
+        if (options.attesterDid) {
+            clauses.push(`attester_did = $${index++}`);
+            params.push(options.attesterDid);
+        }
+
+        if (options.schemaDid) {
+            clauses.push(`schema_did = $${index++}`);
+            params.push(options.schemaDid);
+        }
+
+        if (options.requesterDid) {
+            clauses.push(`requester_did = $${index++}`);
+            params.push(options.requesterDid);
+        }
+
+        if (responseCommitment) {
+            clauses.push(`response_commitment = $${index++}`);
+            params.push(responseCommitment);
+        }
+
+        if (options.verifiedAfter) {
+            clauses.push(`verified_at >= $${index++}`);
+            params.push(options.verifiedAfter);
+        }
+
+        if (options.verifiedBefore) {
+            clauses.push(`verified_at <= $${index++}`);
+            params.push(options.verifiedBefore);
+        }
+
+        return {
+            where: clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '',
+            params,
+        };
     }
 
     private toJsonLiterals(values: unknown[]): string[] {

--- a/services/search-server/src/db/sqlite.ts
+++ b/services/search-server/src/db/sqlite.ts
@@ -1,6 +1,11 @@
 import sqlite3 from 'sqlite3';
 import { open, Database } from 'sqlite';
 import {
+    ChallengeReceiptListOptions,
+    ChallengeReceiptListResult,
+    ChallengeReceiptRecord,
+    ChallengeReceiptUsageOptions,
+    ChallengeReceiptUsageResult,
     DIDsDb,
     PublishedCredentialListOptions,
     PublishedCredentialListResult,
@@ -59,6 +64,31 @@ export default class Sqlite implements DIDsDb {
 
             CREATE INDEX IF NOT EXISTS idx_published_credentials_schema_subject
                 ON published_credentials (schema_did, subject_did);
+
+            CREATE TABLE IF NOT EXISTS challenge_receipts (
+                receipt_did TEXT PRIMARY KEY,
+                attester_did TEXT NOT NULL,
+                schema_did TEXT NOT NULL,
+                requester_did TEXT NOT NULL,
+                verified_at TEXT NOT NULL,
+                response_commitment TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_challenge_receipts_attester
+                ON challenge_receipts (attester_did);
+
+            CREATE INDEX IF NOT EXISTS idx_challenge_receipts_schema
+                ON challenge_receipts (schema_did);
+
+            CREATE INDEX IF NOT EXISTS idx_challenge_receipts_requester
+                ON challenge_receipts (requester_did);
+
+            CREATE INDEX IF NOT EXISTS idx_challenge_receipts_verified
+                ON challenge_receipts (verified_at);
+
+            CREATE INDEX IF NOT EXISTS idx_challenge_receipts_commitment
+                ON challenge_receipts (response_commitment);
 
             CREATE TABLE IF NOT EXISTS config (
                                                   key TEXT PRIMARY KEY,
@@ -161,6 +191,56 @@ export default class Sqlite implements DIDsDb {
                     record.issuerDid,
                     record.subjectDid,
                     record.revealed ? 1 : 0,
+                    record.updatedAt,
+                ]);
+            }
+
+            await this.db.exec('COMMIT');
+        }
+        catch (error) {
+            await this.db.exec('ROLLBACK');
+            throw error;
+        }
+    }
+
+    async replaceChallengeReceipts(receiptDid: string, records: ChallengeReceiptRecord[]): Promise<void> {
+        if (!this.db) {
+            throw new Error('DB not connected');
+        }
+
+        await this.db.exec('BEGIN');
+
+        try {
+            await this.db.run(
+                'DELETE FROM challenge_receipts WHERE receipt_did = ?',
+                [receiptDid]
+            );
+
+            for (const record of records) {
+                await this.db.run(`
+                    INSERT INTO challenge_receipts (
+                        receipt_did,
+                        attester_did,
+                        schema_did,
+                        requester_did,
+                        verified_at,
+                        response_commitment,
+                        updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(receipt_did) DO UPDATE SET
+                        attester_did = excluded.attester_did,
+                        schema_did = excluded.schema_did,
+                        requester_did = excluded.requester_did,
+                        verified_at = excluded.verified_at,
+                        response_commitment = excluded.response_commitment,
+                        updated_at = excluded.updated_at
+                `, [
+                    record.receiptDid,
+                    record.attesterDid,
+                    record.schemaDid,
+                    record.requesterDid,
+                    record.verifiedAt,
+                    record.responseCommitment,
                     record.updatedAt,
                 ]);
             }
@@ -292,6 +372,114 @@ export default class Sqlite implements DIDsDb {
         };
     }
 
+    async listChallengeReceipts(
+        options: ChallengeReceiptListOptions = {}
+    ): Promise<ChallengeReceiptListResult> {
+        if (!this.db) {
+            throw new Error('DB not connected');
+        }
+
+        const {
+            limit = 50,
+            offset = 0,
+        } = options;
+        const { where, params } = this.buildChallengeReceiptWhere(options);
+        const totalRow = await this.db.get<{ total: number | string }>(
+            `SELECT COUNT(*) AS total FROM challenge_receipts ${where}`,
+            params
+        );
+        const rows = await this.db.all<{
+            receiptDid: string;
+            attesterDid: string;
+            schemaDid: string;
+            requesterDid: string;
+            verifiedAt: string;
+            responseCommitment: string;
+            updatedAt: string;
+        }[]>(
+            `SELECT
+                receipt_did AS receiptDid,
+                attester_did AS attesterDid,
+                schema_did AS schemaDid,
+                requester_did AS requesterDid,
+                verified_at AS verifiedAt,
+                response_commitment AS responseCommitment,
+                updated_at AS updatedAt
+             FROM challenge_receipts
+             ${where}
+             ORDER BY verified_at DESC, receipt_did ASC
+             LIMIT ? OFFSET ?`,
+            [...params, Math.max(0, limit), Math.max(0, offset)]
+        );
+
+        return {
+            total: Number(totalRow?.total ?? 0),
+            receipts: rows.map(row => ({
+                receiptDid: row.receiptDid,
+                attesterDid: row.attesterDid,
+                schemaDid: row.schemaDid,
+                requesterDid: row.requesterDid,
+                verifiedAt: row.verifiedAt,
+                responseCommitment: row.responseCommitment,
+                updatedAt: row.updatedAt,
+            })),
+        };
+    }
+
+    async getChallengeReceiptUsage(
+        options: ChallengeReceiptUsageOptions = {}
+    ): Promise<ChallengeReceiptUsageResult> {
+        if (!this.db) {
+            throw new Error('DB not connected');
+        }
+
+        const {
+            limit = 50,
+            offset = 0,
+        } = options;
+        const { where, params } = this.buildChallengeReceiptWhere(options);
+        const totalRow = await this.db.get<{ total: number | string }>(
+            `SELECT COUNT(*) AS total
+             FROM (
+                SELECT 1
+                FROM challenge_receipts
+                ${where}
+                GROUP BY attester_did, schema_did, requester_did
+             )`,
+            params
+        );
+        const rows = await this.db.all<{
+            attesterDid: string;
+            schemaDid: string;
+            requesterDid: string;
+            count: number | string;
+            firstVerifiedAt: string;
+            lastVerifiedAt: string;
+        }[]>(
+            `SELECT
+                attester_did AS attesterDid,
+                schema_did AS schemaDid,
+                requester_did AS requesterDid,
+                COUNT(DISTINCT response_commitment) AS count,
+                MIN(verified_at) AS firstVerifiedAt,
+                MAX(verified_at) AS lastVerifiedAt
+             FROM challenge_receipts
+             ${where}
+             GROUP BY attester_did, schema_did, requester_did
+             ORDER BY count DESC, schema_did ASC, requester_did ASC
+             LIMIT ? OFFSET ?`,
+            [...params, Math.max(0, limit), Math.max(0, offset)]
+        );
+
+        return {
+            total: Number(totalRow?.total ?? 0),
+            usage: rows.map(row => ({
+                ...row,
+                count: Number(row.count),
+            })),
+        };
+    }
+
     async searchDocs(q: string): Promise<string[]> {
         if (!this.db) {
             throw new Error('DB not connected');
@@ -394,7 +582,57 @@ export default class Sqlite implements DIDsDb {
         await this.db.exec(`
             DELETE FROM did_docs;
             DELETE FROM published_credentials;
+            DELETE FROM challenge_receipts;
             DELETE FROM config;
         `);
+    }
+
+    private buildChallengeReceiptWhere(
+        options: ChallengeReceiptListOptions | ChallengeReceiptUsageOptions
+    ): { where: string; params: unknown[] } {
+        const clauses: string[] = [];
+        const params: unknown[] = [];
+        const receiptDid = 'receiptDid' in options ? options.receiptDid : undefined;
+        const responseCommitment = 'responseCommitment' in options ? options.responseCommitment : undefined;
+
+        if (receiptDid) {
+            clauses.push('receipt_did = ?');
+            params.push(receiptDid);
+        }
+
+        if (options.attesterDid) {
+            clauses.push('attester_did = ?');
+            params.push(options.attesterDid);
+        }
+
+        if (options.schemaDid) {
+            clauses.push('schema_did = ?');
+            params.push(options.schemaDid);
+        }
+
+        if (options.requesterDid) {
+            clauses.push('requester_did = ?');
+            params.push(options.requesterDid);
+        }
+
+        if (responseCommitment) {
+            clauses.push('response_commitment = ?');
+            params.push(responseCommitment);
+        }
+
+        if (options.verifiedAfter) {
+            clauses.push('verified_at >= ?');
+            params.push(options.verifiedAfter);
+        }
+
+        if (options.verifiedBefore) {
+            clauses.push('verified_at <= ?');
+            params.push(options.verifiedBefore);
+        }
+
+        return {
+            where: clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '',
+            params,
+        };
     }
 }

--- a/services/search-server/src/index.ts
+++ b/services/search-server/src/index.ts
@@ -302,6 +302,66 @@ async function main() {
         }
     });
 
+    v1router.get("/metrics/challenge-receipts", async (req, res) => {
+        try {
+            const receiptDid = req.query.receiptDid?.toString();
+            const attesterDid = req.query.attesterDid?.toString();
+            const schemaDid = req.query.schemaDid?.toString();
+            const requesterDid = req.query.requesterDid?.toString();
+            const responseCommitment = req.query.responseCommitment?.toString();
+            const verifiedAfter = req.query.verifiedAfter?.toString();
+            const verifiedBefore = req.query.verifiedBefore?.toString();
+            const limit = parseNonNegativeInteger(req.query.limit, 50);
+            const offset = parseNonNegativeInteger(req.query.offset, 0);
+            const result = await didDb.listChallengeReceipts({
+                receiptDid,
+                attesterDid,
+                schemaDid,
+                requesterDid,
+                responseCommitment,
+                verifiedAfter,
+                verifiedBefore,
+                limit,
+                offset,
+            });
+
+            res.json(result);
+        } catch (error) {
+            log.error({ error }, '/metrics/challenge-receipts error');
+            res.status(500).json({ error: String(error) });
+        }
+    });
+
+    v1router.get("/metrics/challenge-receipts/usage", async (req, res) => {
+        try {
+            const attesterDid = req.query.attesterDid?.toString();
+            if (!attesterDid) {
+                return res.status(400).json({ error: 'attesterDid is required' });
+            }
+
+            const schemaDid = req.query.schemaDid?.toString();
+            const requesterDid = req.query.requesterDid?.toString();
+            const verifiedAfter = req.query.verifiedAfter?.toString();
+            const verifiedBefore = req.query.verifiedBefore?.toString();
+            const limit = parseNonNegativeInteger(req.query.limit, 50);
+            const offset = parseNonNegativeInteger(req.query.offset, 0);
+            const result = await didDb.getChallengeReceiptUsage({
+                attesterDid,
+                schemaDid,
+                requesterDid,
+                verifiedAfter,
+                verifiedBefore,
+                limit,
+                offset,
+            });
+
+            res.json(result);
+        } catch (error) {
+            log.error({ error }, '/metrics/challenge-receipts/usage error');
+            res.status(500).json({ error: String(error) });
+        }
+    });
+
     if (apiRateLimiter) {
         app.use('/api', apiRateLimiter);
     }

--- a/services/search-server/src/types.ts
+++ b/services/search-server/src/types.ts
@@ -28,6 +28,57 @@ export interface PublishedCredentialListResult {
     credentials: PublishedCredentialRecord[];
 }
 
+export interface ChallengeReceiptRecord {
+    receiptDid: string;
+    attesterDid: string;
+    schemaDid: string;
+    requesterDid: string;
+    verifiedAt: string;
+    responseCommitment: string;
+    updatedAt: string;
+}
+
+export interface ChallengeReceiptListOptions {
+    receiptDid?: string;
+    attesterDid?: string;
+    schemaDid?: string;
+    requesterDid?: string;
+    responseCommitment?: string;
+    verifiedAfter?: string;
+    verifiedBefore?: string;
+    limit?: number;
+    offset?: number;
+}
+
+export interface ChallengeReceiptListResult {
+    total: number;
+    receipts: ChallengeReceiptRecord[];
+}
+
+export interface ChallengeReceiptUsageOptions {
+    attesterDid?: string;
+    schemaDid?: string;
+    requesterDid?: string;
+    verifiedAfter?: string;
+    verifiedBefore?: string;
+    limit?: number;
+    offset?: number;
+}
+
+export interface ChallengeReceiptUsageRecord {
+    attesterDid: string;
+    schemaDid: string;
+    requesterDid: string;
+    count: number;
+    firstVerifiedAt: string;
+    lastVerifiedAt: string;
+}
+
+export interface ChallengeReceiptUsageResult {
+    total: number;
+    usage: ChallengeReceiptUsageRecord[];
+}
+
 export interface DIDsDb {
     connect(): Promise<void>;
     disconnect(): Promise<void>;
@@ -37,9 +88,12 @@ export interface DIDsDb {
 
     storeDID(did: string, doc: object): Promise<void>;
     replacePublishedCredentials(holderDid: string, records: PublishedCredentialRecord[]): Promise<void>;
+    replaceChallengeReceipts(receiptDid: string, records: ChallengeReceiptRecord[]): Promise<void>;
     getDID(did: string): Promise<object | null>;
     getPublishedCredentialCountsBySchema(): Promise<PublishedCredentialSchemaCount[]>;
     listPublishedCredentials(options?: PublishedCredentialListOptions): Promise<PublishedCredentialListResult>;
+    listChallengeReceipts(options?: ChallengeReceiptListOptions): Promise<ChallengeReceiptListResult>;
+    getChallengeReceiptUsage(options?: ChallengeReceiptUsageOptions): Promise<ChallengeReceiptUsageResult>;
     searchDocs(q: string): Promise<string[]>;
     queryDocs(where: Record<string, unknown>): Promise<string[]>;
     wipeDb(): Promise<void>;

--- a/tests/keymaster/response.test.ts
+++ b/tests/keymaster/response.test.ts
@@ -512,6 +512,12 @@ describe('challenge receipts', () => {
             verifiedAt: expect.any(String),
         });
         expect(new Date(defaultReceiptAsset.challengeReceipt.verifiedAt).getTime()).not.toBeNaN();
+
+        const normalizedReceipts = await keymaster.buildChallengeReceipts(responseDID, {
+            verification,
+            verifiedAt: 'January 1, 2026 00:00:00 UTC',
+        });
+        expect(normalizedReceipts[0].verifiedAt).toBe('2026-01-01T00:00:00.000Z');
     });
 
     it('should reject receipts for unsuccessful challenge responses', async () => {

--- a/tests/search-server/challenge-receipts.test.ts
+++ b/tests/search-server/challenge-receipts.test.ts
@@ -1,0 +1,456 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { jest } from '@jest/globals';
+import { setLogger } from '../../packages/common/src/logger.ts';
+import DIDsDbMemory from '../../services/search-server/src/db/json-memory.ts';
+import Sqlite from '../../services/search-server/src/db/sqlite.ts';
+import DidIndexer from '../../services/search-server/src/DidIndexer.ts';
+import { extractChallengeReceipts } from '../../services/search-server/src/challenge-receipts.ts';
+import type {
+    ChallengeReceiptRecord,
+    ChallengeReceiptUsageRecord,
+    DIDsDb,
+} from '../../services/search-server/src/types.ts';
+
+function createReceiptDoc(
+    receiptDid: string,
+    {
+        attesterDid = 'did:test:attester-1',
+        schemaDid = 'did:test:schema-1',
+        requesterDid = 'did:test:requester-1',
+        verifiedAt = '2026-04-01T10:00:00.000Z',
+        responseCommitment = 'mock-commitment-1',
+        updatedAt = '2026-04-01T10:01:00.000Z',
+        challengeReceipt,
+    }: {
+        attesterDid?: string;
+        schemaDid?: string;
+        requesterDid?: string;
+        verifiedAt?: string;
+        responseCommitment?: string;
+        updatedAt?: string;
+        challengeReceipt?: unknown;
+    } = {}
+) {
+    return {
+        didDocument: {
+            id: receiptDid,
+        },
+        didDocumentData: {
+            challengeReceipt: challengeReceipt ?? {
+                version: 1,
+                attesterDid,
+                schemaDid,
+                requesterDid,
+                verifiedAt,
+                responseCommitment,
+            },
+        },
+        didDocumentMetadata: {
+            updated: updatedAt,
+        },
+    };
+}
+
+type DbHarness = {
+    db: DIDsDb;
+    cleanup: () => Promise<void>;
+};
+
+const adapterFactories = [
+    {
+        name: 'memory',
+        create: async (): Promise<DbHarness> => {
+            const db = new DIDsDbMemory();
+            await db.connect();
+
+            return {
+                db,
+                cleanup: async () => {
+                    await db.disconnect();
+                },
+            };
+        },
+    },
+    {
+        name: 'sqlite',
+        create: async (): Promise<DbHarness> => {
+            const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'search-server-receipts-'));
+            const db = await Sqlite.create('receipts.db', tempDir);
+
+            return {
+                db,
+                cleanup: async () => {
+                    await db.disconnect();
+                    fs.rmSync(tempDir, { recursive: true, force: true });
+                },
+            };
+        },
+    },
+] as const;
+
+beforeEach(() => {
+    const logger = {
+        child: jest.fn(),
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    };
+
+    logger.child.mockReturnValue(logger);
+    setLogger(logger as any);
+});
+
+describe('extractChallengeReceipts', () => {
+    it('extracts a normalized row from a valid challenge receipt asset', () => {
+        const receiptDid = 'did:test:receipt-1';
+        const doc = createReceiptDoc(receiptDid);
+
+        expect(extractChallengeReceipts(receiptDid, doc)).toStrictEqual<ChallengeReceiptRecord[]>([
+            {
+                receiptDid,
+                attesterDid: 'did:test:attester-1',
+                schemaDid: 'did:test:schema-1',
+                requesterDid: 'did:test:requester-1',
+                verifiedAt: '2026-04-01T10:00:00.000Z',
+                responseCommitment: 'mock-commitment-1',
+                updatedAt: '2026-04-01T10:01:00.000Z',
+            },
+        ]);
+    });
+
+    it('falls back to verifiedAt when DID metadata does not include an update timestamp', () => {
+        const receiptDid = 'did:test:receipt-1';
+        const doc = createReceiptDoc(receiptDid);
+        delete (doc.didDocumentMetadata as { updated?: string }).updated;
+
+        expect(extractChallengeReceipts(receiptDid, doc)[0].updatedAt).toBe('2026-04-01T10:00:00.000Z');
+    });
+
+    it('ignores malformed receipt assets', () => {
+        const receiptDid = 'did:test:receipt-1';
+
+        expect(extractChallengeReceipts(receiptDid, {})).toStrictEqual([]);
+        expect(extractChallengeReceipts('not-a-did', createReceiptDoc('not-a-did'))).toStrictEqual([]);
+        expect(extractChallengeReceipts(receiptDid, createReceiptDoc(receiptDid, {
+            challengeReceipt: [],
+        }))).toStrictEqual([]);
+        expect(extractChallengeReceipts(receiptDid, createReceiptDoc(receiptDid, {
+            challengeReceipt: {
+                version: 2,
+                attesterDid: 'did:test:attester-1',
+                schemaDid: 'did:test:schema-1',
+                requesterDid: 'did:test:requester-1',
+                verifiedAt: '2026-04-01T10:00:00.000Z',
+                responseCommitment: 'mock-commitment-1',
+            },
+        }))).toStrictEqual([]);
+        expect(extractChallengeReceipts(receiptDid, createReceiptDoc(receiptDid, {
+            verifiedAt: 'not-a-date',
+        }))).toStrictEqual([]);
+        expect(extractChallengeReceipts(receiptDid, createReceiptDoc(receiptDid, {
+            responseCommitment: '',
+        }))).toStrictEqual([]);
+    });
+});
+
+describe.each(adapterFactories)('$name challenge receipt storage', ({ create }) => {
+    it('lists, filters, groups, replaces, and wipes challenge receipt rows', async () => {
+        const { db, cleanup } = await create();
+
+        try {
+            const rows: ChallengeReceiptRecord[] = [
+                {
+                    receiptDid: 'did:test:receipt-1',
+                    attesterDid: 'did:test:attester-1',
+                    schemaDid: 'did:test:schema-1',
+                    requesterDid: 'did:test:requester-1',
+                    verifiedAt: '2026-04-01T10:00:00.000Z',
+                    responseCommitment: 'mock-commitment-1',
+                    updatedAt: '2026-04-01T10:01:00.000Z',
+                },
+                {
+                    receiptDid: 'did:test:receipt-2',
+                    attesterDid: 'did:test:attester-1',
+                    schemaDid: 'did:test:schema-1',
+                    requesterDid: 'did:test:requester-1',
+                    verifiedAt: '2026-04-01T11:00:00.000Z',
+                    responseCommitment: 'mock-commitment-2',
+                    updatedAt: '2026-04-01T11:01:00.000Z',
+                },
+                {
+                    receiptDid: 'did:test:receipt-3',
+                    attesterDid: 'did:test:attester-1',
+                    schemaDid: 'did:test:schema-2',
+                    requesterDid: 'did:test:requester-2',
+                    verifiedAt: '2026-04-02T10:00:00.000Z',
+                    responseCommitment: 'mock-commitment-3',
+                    updatedAt: '2026-04-02T10:01:00.000Z',
+                },
+                {
+                    receiptDid: 'did:test:receipt-4',
+                    attesterDid: 'did:test:attester-2',
+                    schemaDid: 'did:test:schema-1',
+                    requesterDid: 'did:test:requester-1',
+                    verifiedAt: '2026-04-03T10:00:00.000Z',
+                    responseCommitment: 'mock-commitment-4',
+                    updatedAt: '2026-04-03T10:01:00.000Z',
+                },
+                {
+                    receiptDid: 'did:test:receipt-5',
+                    attesterDid: 'did:test:attester-1',
+                    schemaDid: 'did:test:schema-1',
+                    requesterDid: 'did:test:requester-1',
+                    verifiedAt: '2026-04-01T12:00:00.000Z',
+                    responseCommitment: 'mock-commitment-2',
+                    updatedAt: '2026-04-01T12:01:00.000Z',
+                },
+            ];
+
+            for (const row of rows) {
+                await db.replaceChallengeReceipts(row.receiptDid, [row]);
+            }
+
+            expect(await db.listChallengeReceipts({
+                attesterDid: 'did:test:attester-1',
+                schemaDid: 'did:test:schema-1',
+                requesterDid: 'did:test:requester-1',
+                verifiedAfter: '2026-04-01T10:30:00.000Z',
+                verifiedBefore: '2026-04-01T11:30:00.000Z',
+                limit: 10,
+                offset: 0,
+            })).toStrictEqual({
+                total: 1,
+                receipts: [rows[1]],
+            });
+
+            expect(await db.listChallengeReceipts({
+                responseCommitment: 'mock-commitment-3',
+                limit: 10,
+                offset: 0,
+            })).toStrictEqual({
+                total: 1,
+                receipts: [rows[2]],
+            });
+
+            expect(await db.getChallengeReceiptUsage({
+                attesterDid: 'did:test:attester-1',
+                limit: 10,
+                offset: 0,
+            })).toStrictEqual({
+                total: 2,
+                usage: [
+                    {
+                        attesterDid: 'did:test:attester-1',
+                        schemaDid: 'did:test:schema-1',
+                        requesterDid: 'did:test:requester-1',
+                        count: 2,
+                        firstVerifiedAt: '2026-04-01T10:00:00.000Z',
+                        lastVerifiedAt: '2026-04-01T12:00:00.000Z',
+                    },
+                    {
+                        attesterDid: 'did:test:attester-1',
+                        schemaDid: 'did:test:schema-2',
+                        requesterDid: 'did:test:requester-2',
+                        count: 1,
+                        firstVerifiedAt: '2026-04-02T10:00:00.000Z',
+                        lastVerifiedAt: '2026-04-02T10:00:00.000Z',
+                    },
+                ] satisfies ChallengeReceiptUsageRecord[],
+            });
+
+            await db.replaceChallengeReceipts('did:test:receipt-2', []);
+            expect(await db.listChallengeReceipts({
+                receiptDid: 'did:test:receipt-2',
+                limit: 10,
+                offset: 0,
+            })).toStrictEqual({
+                total: 0,
+                receipts: [],
+            });
+
+            await db.wipeDb();
+            expect(await db.getChallengeReceiptUsage({
+                attesterDid: 'did:test:attester-1',
+                limit: 10,
+                offset: 0,
+            })).toStrictEqual({
+                total: 0,
+                usage: [],
+            });
+        }
+        finally {
+            await cleanup();
+        }
+    });
+});
+
+describe('postgres challenge receipt adapter with mocked pool', () => {
+    async function loadPostgresModule() {
+        jest.resetModules();
+        const module = await import('../../services/search-server/src/db/postgres.ts');
+        return module.default;
+    }
+
+    it('creates receipt schema and supports replace, list, usage, and wipe queries', async () => {
+        const record: ChallengeReceiptRecord = {
+            receiptDid: 'did:test:receipt-1',
+            attesterDid: 'did:test:attester-1',
+            schemaDid: 'did:test:schema-1',
+            requesterDid: 'did:test:requester-1',
+            verifiedAt: '2026-04-01T10:00:00.000Z',
+            responseCommitment: 'mock-commitment-1',
+            updatedAt: '2026-04-01T10:01:00.000Z',
+        };
+        const poolQuery = jest.fn(async (sql: string) => {
+            const text = String(sql);
+
+            if (text.includes('CREATE TABLE IF NOT EXISTS challenge_receipts')) {
+                return { rowCount: 0, rows: [] };
+            }
+            if (text.includes('COUNT(*)::int AS total') && text.includes('GROUP BY attester_did')) {
+                return { rowCount: 1, rows: [{ total: 1 }] };
+            }
+            if (text.includes('COUNT(*)::int AS total')) {
+                return { rowCount: 1, rows: [{ total: 1 }] };
+            }
+            if (text.includes('receipt_did AS "receiptDid"')) {
+                return { rowCount: 1, rows: [record] };
+            }
+            if (text.includes('attester_did AS "attesterDid"')) {
+                return {
+                    rowCount: 1,
+                    rows: [{
+                        attesterDid: record.attesterDid,
+                        schemaDid: record.schemaDid,
+                        requesterDid: record.requesterDid,
+                        count: 1,
+                        firstVerifiedAt: record.verifiedAt,
+                        lastVerifiedAt: record.verifiedAt,
+                    }],
+                };
+            }
+            if (text === 'DELETE FROM did_docs' ||
+                text === 'DELETE FROM published_credentials' ||
+                text === 'DELETE FROM challenge_receipts' ||
+                text === 'DELETE FROM config') {
+                return { rowCount: 1, rows: [] };
+            }
+
+            return { rowCount: 0, rows: [] };
+        });
+        const mockClient = {
+            query: jest.fn().mockResolvedValue(undefined),
+            release: jest.fn(),
+        };
+        const mockPool = {
+            query: poolQuery,
+            connect: jest.fn().mockResolvedValue(mockClient),
+            end: jest.fn().mockResolvedValue(undefined),
+        };
+        const Postgres = await loadPostgresModule();
+
+        class TestPostgres extends Postgres {
+            protected createPool(): any {
+                return mockPool;
+            }
+        }
+
+        const db = new TestPostgres('postgresql://example');
+        await db.connect();
+        await db.replaceChallengeReceipts(record.receiptDid, [record]);
+
+        expect(await db.listChallengeReceipts({
+            receiptDid: record.receiptDid,
+            attesterDid: record.attesterDid,
+            schemaDid: record.schemaDid,
+            requesterDid: record.requesterDid,
+            responseCommitment: record.responseCommitment,
+            verifiedAfter: '2026-04-01T00:00:00.000Z',
+            verifiedBefore: '2026-04-02T00:00:00.000Z',
+            limit: 5,
+            offset: 10,
+        })).toStrictEqual({
+            total: 1,
+            receipts: [record],
+        });
+
+        expect(await db.getChallengeReceiptUsage({
+            attesterDid: record.attesterDid,
+            schemaDid: record.schemaDid,
+            requesterDid: record.requesterDid,
+            verifiedAfter: '2026-04-01T00:00:00.000Z',
+            verifiedBefore: '2026-04-02T00:00:00.000Z',
+            limit: 5,
+            offset: 10,
+        })).toStrictEqual({
+            total: 1,
+            usage: [{
+                attesterDid: record.attesterDid,
+                schemaDid: record.schemaDid,
+                requesterDid: record.requesterDid,
+                count: 1,
+                firstVerifiedAt: record.verifiedAt,
+                lastVerifiedAt: record.verifiedAt,
+            }],
+        });
+
+        await db.wipeDb();
+        await db.disconnect();
+
+        expect(mockClient.query).toHaveBeenCalledWith(
+            'DELETE FROM challenge_receipts WHERE receipt_did = $1',
+            [record.receiptDid]
+        );
+        expect(mockClient.query).toHaveBeenCalledWith(
+            expect.stringContaining('INSERT INTO challenge_receipts'),
+            [
+                record.receiptDid,
+                record.attesterDid,
+                record.schemaDid,
+                record.requesterDid,
+                record.verifiedAt,
+                record.responseCommitment,
+                record.updatedAt,
+            ]
+        );
+        expect(poolQuery).toHaveBeenCalledWith('DELETE FROM challenge_receipts');
+        expect(mockPool.end).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('DidIndexer challenge receipt indexing', () => {
+    it('stores challenge receipt rows during refresh', async () => {
+        const db = new DIDsDbMemory();
+        const receiptDid = 'did:test:receipt-1';
+        const doc = createReceiptDoc(receiptDid);
+        const gatekeeper = {
+            isReady: jest.fn().mockResolvedValue(true),
+            getDIDs: jest.fn().mockResolvedValue([receiptDid]),
+            resolveDID: jest.fn().mockResolvedValue(doc),
+        };
+        const indexer = new DidIndexer(gatekeeper as any, db, { intervalMs: 60_000 });
+
+        await indexer.startIndexing();
+        indexer.stopIndexing();
+
+        expect(await db.listChallengeReceipts({
+            attesterDid: 'did:test:attester-1',
+            limit: 10,
+            offset: 0,
+        })).toStrictEqual({
+            total: 1,
+            receipts: [{
+                receiptDid,
+                attesterDid: 'did:test:attester-1',
+                schemaDid: 'did:test:schema-1',
+                requesterDid: 'did:test:requester-1',
+                verifiedAt: '2026-04-01T10:00:00.000Z',
+                responseCommitment: 'mock-commitment-1',
+                updatedAt: '2026-04-01T10:01:00.000Z',
+            }],
+        });
+    });
+});

--- a/tests/search-server/challenge-receipts.test.ts
+++ b/tests/search-server/challenge-receipts.test.ts
@@ -287,6 +287,165 @@ describe.each(adapterFactories)('$name challenge receipt storage', ({ create }) 
     });
 });
 
+describe('memory challenge receipt ordering', () => {
+    it('sorts receipts and grouped usage deterministically', async () => {
+        const db = new DIDsDbMemory();
+        await db.connect();
+
+        const rows: ChallengeReceiptRecord[] = [
+            {
+                receiptDid: 'did:test:receipt-3',
+                attesterDid: 'did:test:attester-1',
+                schemaDid: 'did:test:schema-b',
+                requesterDid: 'did:test:requester-b',
+                verifiedAt: '2026-04-01T10:00:00.000Z',
+                responseCommitment: 'mock-commitment-b-b',
+                updatedAt: '2026-04-01T10:01:00.000Z',
+            },
+            {
+                receiptDid: 'did:test:receipt-2',
+                attesterDid: 'did:test:attester-1',
+                schemaDid: 'did:test:schema-b',
+                requesterDid: 'did:test:requester-a',
+                verifiedAt: '2026-04-01T10:00:00.000Z',
+                responseCommitment: 'mock-commitment-b-a',
+                updatedAt: '2026-04-01T10:01:00.000Z',
+            },
+            {
+                receiptDid: 'did:test:receipt-1',
+                attesterDid: 'did:test:attester-1',
+                schemaDid: 'did:test:schema-a',
+                requesterDid: 'did:test:requester-a',
+                verifiedAt: '2026-04-01T10:00:00.000Z',
+                responseCommitment: 'mock-commitment-a-a-late',
+                updatedAt: '2026-04-01T10:01:00.000Z',
+            },
+            {
+                receiptDid: 'did:test:receipt-0',
+                attesterDid: 'did:test:attester-1',
+                schemaDid: 'did:test:schema-a',
+                requesterDid: 'did:test:requester-a',
+                verifiedAt: '2026-04-01T09:00:00.000Z',
+                responseCommitment: 'mock-commitment-a-a-early',
+                updatedAt: '2026-04-01T09:01:00.000Z',
+            },
+        ];
+
+        try {
+            for (const row of rows) {
+                await db.replaceChallengeReceipts(row.receiptDid, [row]);
+            }
+
+            expect((await db.listChallengeReceipts({
+                attesterDid: 'did:test:attester-1',
+                limit: 10,
+                offset: 0,
+            })).receipts.map(row => row.receiptDid)).toStrictEqual([
+                'did:test:receipt-1',
+                'did:test:receipt-2',
+                'did:test:receipt-3',
+                'did:test:receipt-0',
+            ]);
+
+            expect(await db.getChallengeReceiptUsage({
+                attesterDid: 'did:test:attester-1',
+                limit: 10,
+                offset: 0,
+            })).toStrictEqual({
+                total: 3,
+                usage: [
+                    {
+                        attesterDid: 'did:test:attester-1',
+                        schemaDid: 'did:test:schema-a',
+                        requesterDid: 'did:test:requester-a',
+                        count: 2,
+                        firstVerifiedAt: '2026-04-01T09:00:00.000Z',
+                        lastVerifiedAt: '2026-04-01T10:00:00.000Z',
+                    },
+                    {
+                        attesterDid: 'did:test:attester-1',
+                        schemaDid: 'did:test:schema-b',
+                        requesterDid: 'did:test:requester-a',
+                        count: 1,
+                        firstVerifiedAt: '2026-04-01T10:00:00.000Z',
+                        lastVerifiedAt: '2026-04-01T10:00:00.000Z',
+                    },
+                    {
+                        attesterDid: 'did:test:attester-1',
+                        schemaDid: 'did:test:schema-b',
+                        requesterDid: 'did:test:requester-b',
+                        count: 1,
+                        firstVerifiedAt: '2026-04-01T10:00:00.000Z',
+                        lastVerifiedAt: '2026-04-01T10:00:00.000Z',
+                    },
+                ] satisfies ChallengeReceiptUsageRecord[],
+            });
+        }
+        finally {
+            await db.disconnect();
+        }
+    });
+});
+
+describe('sqlite challenge receipt adapter errors', () => {
+    it('rejects challenge receipt calls when disconnected', async () => {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'search-server-receipts-'));
+        const db = await Sqlite.create('receipts.db', tempDir);
+        await db.disconnect();
+
+        try {
+            await expect(db.replaceChallengeReceipts('did:test:receipt-1', []))
+                .rejects.toThrow('DB not connected');
+            await expect(db.listChallengeReceipts())
+                .rejects.toThrow('DB not connected');
+            await expect(db.getChallengeReceiptUsage())
+                .rejects.toThrow('DB not connected');
+        }
+        finally {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('rolls back failed challenge receipt replacements', async () => {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'search-server-receipts-'));
+        const db = await Sqlite.create('receipts.db', tempDir);
+        const record: ChallengeReceiptRecord = {
+            receiptDid: 'did:test:receipt-1',
+            attesterDid: 'did:test:attester-1',
+            schemaDid: 'did:test:schema-1',
+            requesterDid: 'did:test:requester-1',
+            verifiedAt: '2026-04-01T10:00:00.000Z',
+            responseCommitment: 'mock-commitment-1',
+            updatedAt: '2026-04-01T10:01:00.000Z',
+        };
+        const sqliteDb = (db as any).db;
+        const failure = new Error('mock insert failure');
+        const runSpy = jest.spyOn(sqliteDb, 'run')
+            .mockResolvedValueOnce(undefined as never)
+            .mockRejectedValueOnce(failure as never);
+
+        try {
+            await expect(db.replaceChallengeReceipts(record.receiptDid, [record]))
+                .rejects.toThrow('mock insert failure');
+            runSpy.mockRestore();
+
+            expect(await db.listChallengeReceipts({
+                receiptDid: record.receiptDid,
+                limit: 10,
+                offset: 0,
+            })).toStrictEqual({
+                total: 0,
+                receipts: [],
+            });
+        }
+        finally {
+            runSpy.mockRestore();
+            await db.disconnect();
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+});
+
 describe('postgres challenge receipt adapter with mocked pool', () => {
     async function loadPostgresModule() {
         jest.resetModules();
@@ -417,6 +576,52 @@ describe('postgres challenge receipt adapter with mocked pool', () => {
             ]
         );
         expect(poolQuery).toHaveBeenCalledWith('DELETE FROM challenge_receipts');
+        expect(mockPool.end).toHaveBeenCalledTimes(1);
+    });
+
+    it('rolls back and releases the client when replacement fails', async () => {
+        const record: ChallengeReceiptRecord = {
+            receiptDid: 'did:test:receipt-1',
+            attesterDid: 'did:test:attester-1',
+            schemaDid: 'did:test:schema-1',
+            requesterDid: 'did:test:requester-1',
+            verifiedAt: '2026-04-01T10:00:00.000Z',
+            responseCommitment: 'mock-commitment-1',
+            updatedAt: '2026-04-01T10:01:00.000Z',
+        };
+        const failure = new Error('mock insert failure');
+        const mockClient = {
+            query: jest.fn(async (sql: string) => {
+                if (String(sql).includes('INSERT INTO challenge_receipts')) {
+                    throw failure;
+                }
+
+                return { rowCount: 0, rows: [] };
+            }),
+            release: jest.fn(),
+        };
+        const mockPool = {
+            query: jest.fn().mockResolvedValue({ rowCount: 0, rows: [] } as never),
+            connect: jest.fn().mockResolvedValue(mockClient as never),
+            end: jest.fn().mockResolvedValue(undefined as never),
+        };
+        const Postgres = await loadPostgresModule();
+
+        class TestPostgres extends Postgres {
+            protected createPool(): any {
+                return mockPool;
+            }
+        }
+
+        const db = new TestPostgres('postgresql://example');
+        await db.connect();
+
+        await expect(db.replaceChallengeReceipts(record.receiptDid, [record]))
+            .rejects.toThrow('mock insert failure');
+        await db.disconnect();
+
+        expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
+        expect(mockClient.release).toHaveBeenCalledTimes(1);
         expect(mockPool.end).toHaveBeenCalledTimes(1);
     });
 });

--- a/tests/search-server/db-branches.test.ts
+++ b/tests/search-server/db-branches.test.ts
@@ -1,0 +1,198 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { jest } from '@jest/globals';
+import { setLogger } from '../../packages/common/src/logger.ts';
+import DIDsDbMemory from '../../services/search-server/src/db/json-memory.ts';
+import Sqlite from '../../services/search-server/src/db/sqlite.ts';
+import type {
+    ChallengeReceiptRecord,
+    PublishedCredentialRecord,
+} from '../../services/search-server/src/types.ts';
+
+const publishedCredentialA: PublishedCredentialRecord = {
+    holderDid: 'did:test:holder-1',
+    credentialDid: 'did:test:credential-1',
+    schemaDid: 'did:test:schema-a',
+    issuerDid: 'did:test:issuer-1',
+    subjectDid: 'did:test:subject-1',
+    revealed: true,
+    updatedAt: '2026-04-01T10:00:00.000Z',
+};
+
+const publishedCredentialB: PublishedCredentialRecord = {
+    holderDid: 'did:test:holder-2',
+    credentialDid: 'did:test:credential-2',
+    schemaDid: 'did:test:schema-b',
+    issuerDid: 'did:test:issuer-2',
+    subjectDid: 'did:test:subject-2',
+    revealed: false,
+    updatedAt: '2026-04-01T11:00:00.000Z',
+};
+
+const challengeReceipt: ChallengeReceiptRecord = {
+    receiptDid: 'did:test:receipt-1',
+    attesterDid: 'did:test:attester-1',
+    schemaDid: 'did:test:schema-1',
+    requesterDid: 'did:test:requester-1',
+    verifiedAt: '2026-04-01T10:00:00.000Z',
+    responseCommitment: 'mock-commitment-1',
+    updatedAt: '2026-04-01T10:01:00.000Z',
+};
+
+beforeEach(() => {
+    const logger = {
+        child: jest.fn(),
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    };
+
+    logger.child.mockReturnValue(logger);
+    setLogger(logger as any);
+});
+
+describe('search DB branch behavior', () => {
+    it('exercises memory defaults, tie breakers, and non-matching wildcard queries', async () => {
+        const db = new DIDsDbMemory();
+        await db.connect();
+
+        try {
+            await db.replacePublishedCredentials(publishedCredentialA.holderDid, [publishedCredentialA]);
+            await db.replacePublishedCredentials(publishedCredentialB.holderDid, [publishedCredentialB]);
+            await db.replaceChallengeReceipts(challengeReceipt.receiptDid, [challengeReceipt]);
+            await db.storeDID('did:test:wildcards', {
+                didDocument: { id: 'did:test:wildcards' },
+                didDocumentData: {
+                    notArray: 'value',
+                    notObject: ['value'],
+                },
+            });
+
+            expect(await db.getPublishedCredentialCountsBySchema()).toStrictEqual([
+                { schemaDid: publishedCredentialA.schemaDid, count: 1 },
+                { schemaDid: publishedCredentialB.schemaDid, count: 1 },
+            ]);
+            expect((await db.listPublishedCredentials()).total).toBe(2);
+            expect((await db.listPublishedCredentials({
+                issuerDid: publishedCredentialA.issuerDid,
+                subjectDid: publishedCredentialA.subjectDid,
+            })).credentials).toStrictEqual([publishedCredentialA]);
+            expect((await db.listChallengeReceipts()).receipts).toStrictEqual([challengeReceipt]);
+            expect((await db.getChallengeReceiptUsage()).usage).toStrictEqual([{
+                attesterDid: challengeReceipt.attesterDid,
+                schemaDid: challengeReceipt.schemaDid,
+                requesterDid: challengeReceipt.requesterDid,
+                count: 1,
+                firstVerifiedAt: challengeReceipt.verifiedAt,
+                lastVerifiedAt: challengeReceipt.verifiedAt,
+            }]);
+
+            expect(await db.queryDocs({ 'didDocumentData.notArray[*]': { $in: ['value'] } })).toStrictEqual([]);
+            expect(await db.queryDocs({ 'didDocumentData.notArray[*].kind': { $in: ['value'] } })).toStrictEqual([]);
+            expect(await db.queryDocs({ 'didDocumentData.notObject.*': { $in: ['value'] } })).toStrictEqual([]);
+            expect(await db.queryDocs({ 'didDocumentData.notObject.*.kind': { $in: ['value'] } })).toStrictEqual([]);
+        }
+        finally {
+            await db.disconnect();
+        }
+    });
+
+    it('exercises sqlite defaults, fallbacks, and path normalization', async () => {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'search-server-db-branches-'));
+        const originalCwd = process.cwd();
+
+        try {
+            fs.mkdirSync(path.join(tempDir, 'data'));
+            process.chdir(tempDir);
+            const defaultDb = await Sqlite.create();
+            await defaultDb.disconnect();
+            new Sqlite();
+        }
+        finally {
+            process.chdir(originalCwd);
+        }
+
+        const db = await Sqlite.create('branches.db', tempDir);
+
+        try {
+            await db.replacePublishedCredentials(publishedCredentialA.holderDid, [publishedCredentialA]);
+            await db.replacePublishedCredentials(publishedCredentialB.holderDid, [publishedCredentialB]);
+            await db.replaceChallengeReceipts(challengeReceipt.receiptDid, [challengeReceipt]);
+            await db.storeDID('did:test:path', {
+                didDocument: { id: 'did:test:path' },
+            });
+
+            expect((await db.listPublishedCredentials()).total).toBe(2);
+            expect((await db.listPublishedCredentials({ revealed: true })).credentials).toStrictEqual([publishedCredentialA]);
+            expect((await db.listPublishedCredentials({ revealed: false })).credentials).toStrictEqual([publishedCredentialB]);
+            expect((await db.listChallengeReceipts()).receipts).toStrictEqual([challengeReceipt]);
+            expect((await db.getChallengeReceiptUsage()).usage).toStrictEqual([{
+                attesterDid: challengeReceipt.attesterDid,
+                schemaDid: challengeReceipt.schemaDid,
+                requesterDid: challengeReceipt.requesterDid,
+                count: 1,
+                firstVerifiedAt: challengeReceipt.verifiedAt,
+                lastVerifiedAt: challengeReceipt.verifiedAt,
+            }]);
+            expect(await db.queryDocs({ 'didDocument.id': { $in: ['did:test:path'] } })).toStrictEqual(['did:test:path']);
+            await expect(db.queryDocs({ '$didDocument.id': { $in: ['did:test:path'] } }))
+                .rejects.toThrow('JSON path error');
+
+            const sqliteDb = (db as any).db;
+            const getSpy = jest.spyOn(sqliteDb, 'get').mockResolvedValue(undefined as never);
+            const allSpy = jest.spyOn(sqliteDb, 'all').mockResolvedValue([] as never);
+
+            try {
+                expect(await db.listPublishedCredentials()).toStrictEqual({ total: 0, credentials: [] });
+                expect(await db.listChallengeReceipts()).toStrictEqual({ total: 0, receipts: [] });
+                expect(await db.getChallengeReceiptUsage()).toStrictEqual({ total: 0, usage: [] });
+            }
+            finally {
+                getSpy.mockRestore();
+                allSpy.mockRestore();
+            }
+        }
+        finally {
+            await db.disconnect();
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('exercises postgres challenge receipt defaults and empty totals', async () => {
+        jest.resetModules();
+        const Postgres = (await import('../../services/search-server/src/db/postgres.ts')).default;
+        const poolQuery = jest.fn(async (sql: string) => {
+            const text = String(sql);
+
+            if (text.includes('COUNT(*)::int AS total') ||
+                text.includes('receipt_did AS "receiptDid"') ||
+                text.includes('attester_did AS "attesterDid"')) {
+                return { rowCount: 0, rows: [] };
+            }
+
+            return { rowCount: 0, rows: [] };
+        });
+        const mockPool = {
+            query: poolQuery,
+            connect: jest.fn(),
+            end: jest.fn().mockResolvedValue(undefined as never),
+        };
+
+        class TestPostgres extends Postgres {
+            protected createPool(): any {
+                return mockPool;
+            }
+        }
+
+        const db = new TestPostgres('postgresql://example');
+        await db.connect();
+
+        expect(await db.listChallengeReceipts()).toStrictEqual({ total: 0, receipts: [] });
+        expect(await db.getChallengeReceiptUsage()).toStrictEqual({ total: 0, usage: [] });
+
+        await db.disconnect();
+        expect(mockPool.end).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
 Adds challenge receipt indexing and reporting for successful credential reuse. Search-server now extracts challengeReceipt assets, stores aggregate-safe receipt fields, and exposes receipt list and usage metrics endpoints. Explorer now includes a Receipts tab where users can browse attesters, filter by billing period, view usage by template, and drill into the receipts behind each usage row.