### PR TITLE
feat(scripts): add consolidated multi-chain sync progress bar

### DIFF
--- a/scripts/sync-progress.mjs
+++ b/scripts/sync-progress.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * mdip-sync-progress.mjs
+ * --------------------------------------------------------------------------
+ * Collapses the firehose of Bitcoin Core "UpdateTip ... progress=" log lines
+ * emitted by `docker compose up` into ONE tidy multi-bar progress display
+ * (plus a single combined bar across all chains).
+ *
+ * Bitcoin Core prints one UpdateTip line PER BLOCK during initial block
+ * download. Each line already contains `progress=<0..1>`, so we just keep the
+ * latest value per container and redraw in place.
+ *
+ * Zero config, zero dependencies. Just pipe the compose output into it.
+ *
+ *   USAGE
+ *   -----
+ *   # against a running stack:
+ *   docker compose logs -f | node mdip-sync-progress.mjs
+ *
+ *   # or wrap start-node directly:
+ *   ./start-node | node mdip-sync-progress.mjs
+ *
+ * Only lines containing `progress=` are consumed; everything else is ignored,
+ * so Gatekeeper/Keymaster/IPFS logs won't pollute the view.
+ * --------------------------------------------------------------------------
+ */
+
+import readline from 'node:readline';
+
+const PROGRESS_RE = /^(\S+?)\s*\|.*?\bprogress=([0-9.]+)/;
+const HEIGHT_RE   = /\bheight=(\d+)/;
+const DATE_RE     = /\bdate='([^']+)'/;
+const BAR_WIDTH   = 28;
+
+const chains = new Map();      // name -> { progress, height, date }
+let lastLines = 0;
+let dirty = false;
+
+const rl = readline.createInterface({ input: process.stdin, terminal: false });
+
+rl.on('line', (line) => {
+  const m = PROGRESS_RE.exec(line);
+  if (!m) return;                                  // not a sync line, skip
+  const name = m[1].replace(/-1$/, '');            // btc-node-1 -> btc-node
+  const progress = parseFloat(m[2]);
+  const h = HEIGHT_RE.exec(line);
+  const d = DATE_RE.exec(line);
+  const prev = chains.get(name) || {};
+  chains.set(name, {
+    progress,
+    height: h ? h[1] : prev.height,
+    date:   d ? d[1].slice(0, 10) : prev.date,
+  });
+  dirty = true;
+});
+
+function bar(p, width = BAR_WIDTH) {
+  const filled = Math.max(0, Math.min(width, Math.round(p * width)));
+  return '█'.repeat(filled) + '░'.repeat(width - filled);
+}
+
+function render() {
+  if (!dirty) return;
+  dirty = false;
+
+  const names = [...chains.keys()].sort();
+  const overall = names.length
+    ? names.reduce((s, n) => s + chains.get(n).progress, 0) / names.length
+    : 0;
+
+  const lines = [];
+  lines.push('Syncing MDIP backing chains…');
+  lines.push('');
+  lines.push(`OVERALL      [${bar(overall)}] ${(overall * 100).toFixed(2).padStart(6)}%`);
+  lines.push('');
+  for (const name of names) {
+    const c = chains.get(name);
+    const done = c.progress >= 0.99995;
+    const pct = (c.progress * 100).toFixed(c.progress < 0.01 ? 4 : 2);
+    const tail = done ? '✓ synced' : `h=${c.height ?? '?'}  ${c.date ?? ''}`;
+    lines.push(`${name.padEnd(12)} [${bar(c.progress)}] ${pct.padStart(7)}%  ${tail}`);
+  }
+
+  // Redraw in place: jump cursor up over the previous block, clear each line.
+  if (lastLines > 0) process.stdout.write(`\x1b[${lastLines}A`);
+  process.stdout.write(lines.map((l) => l + '\x1b[K').join('\n') + '\n');
+  lastLines = lines.length;
+}
+
+setInterval(render, 200).unref();
+rl.on('close', () => { render(); process.exit(0); });


### PR DESCRIPTION
Closes #1211

## Summary
During `./start-node`, the backing Bitcoin Core nodes (`btc-node`, `tbtc-node`, `signet-node`, …) emit one `UpdateTip … progress=` log line per block during initial block download. The result is a multi-thousand-line firehose that buries the Gatekeeper/Keymaster/IPFS logs and makes it hard to see how far along a sync is.

This adds `scripts/sync-progress.mjs`, a zero-dependency Node filter that consumes the compose log stream and renders a single in-place display: one combined OVERALL bar plus a per-chain bar with height and block date.

## Usage
```
docker compose logs -f | node scripts/sync-progress.mjs
# or
./start-node | node scripts/sync-progress.mjs
```
Only lines containing `progress=` are consumed, so non-Bitcoin service logs are ignored.

## Notes
- Pure stdlib (`node:readline`), no new dependencies, consistent with the existing `scripts/btc-logs` / `scripts/signet-logs` helpers.
- - A more robust long-term approach would poll each node's `getblockchaininfo` (`verificationprogress`) over RPC instead of scraping stdout — happy to follow up with that if maintainers prefer.
Opening as a discussion-starter per CONTRIBUTING.md; glad to file a tracking issue and re-link if you'd like.