### PR TITLE
fix: make common logger browser safe

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -14,9 +14,10 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
+      "browser": "./dist/esm/index-browser.js",
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.cjs",
-      "types": "./dist/types/index.d.ts"
+      "require": "./dist/cjs/index.cjs"
     },
     "./env": {
       "import": "./dist/esm/env.js",
@@ -24,19 +25,20 @@
       "types": "./dist/types/env.d.ts"
     },
     "./utils": {
+      "types": "./dist/types/utils.d.ts",
       "import": "./dist/esm/utils.js",
-      "require": "./dist/cjs/utils.cjs",
-      "types": "./dist/types/utils.d.ts"
+      "require": "./dist/cjs/utils.cjs"
     },
     "./errors": {
+      "types": "./dist/types/errors.d.ts",
       "import": "./dist/esm/errors.js",
-      "require": "./dist/cjs/errors.cjs",
-      "types": "./dist/types/errors.d.ts"
+      "require": "./dist/cjs/errors.cjs"
     },
     "./logger": {
+      "types": "./dist/types/logger.d.ts",
+      "browser": "./dist/esm/logger-browser.js",
       "import": "./dist/esm/logger.js",
-      "require": "./dist/cjs/logger.cjs",
-      "types": "./dist/types/logger.d.ts"
+      "require": "./dist/cjs/logger.cjs"
     }
   },
   "typesVersions": {

--- a/packages/common/src/env-browser.ts
+++ b/packages/common/src/env-browser.ts
@@ -1,0 +1,13 @@
+export interface LoadEnvOptions {
+    cwd?: string;
+    envFileVar?: string;
+    filenames?: string[];
+}
+
+export function resolveEnvFiles(_options: LoadEnvOptions = {}): string[] {
+    return [];
+}
+
+export function loadEnv(_options: LoadEnvOptions = {}): string[] {
+    return [];
+}

--- a/packages/common/src/index-browser.ts
+++ b/packages/common/src/index-browser.ts
@@ -1,0 +1,3 @@
+export * from './errors.js';
+export * from './logger-browser.js';
+export * from './utils.js';

--- a/packages/common/src/index-browser.ts
+++ b/packages/common/src/index-browser.ts
@@ -1,3 +1,4 @@
+export * from './env-browser.js';
 export * from './errors.js';
 export * from './logger-browser.js';
 export * from './utils.js';

--- a/packages/common/src/logger-browser.ts
+++ b/packages/common/src/logger-browser.ts
@@ -1,11 +1,10 @@
 import pino, { type Logger, type LoggerOptions, type ChildLoggerOptions } from 'pino';
-import pinoPretty from 'pino-pretty';
 
 export type LogLevel = 'fatal' | 'error' | 'warn' | 'info' | 'debug' | 'trace' | 'silent';
 export type LoggerLike = Pick<Logger, 'debug' | 'info' | 'warn' | 'error'>;
 
 const DEFAULT_LEVEL: LogLevel = 'info';
-const DEFAULT_PRETTY = true;
+const DEFAULT_PRETTY = false;
 const LEVEL_ALIASES: Record<string, LogLevel> = {
     warning: 'warn',
 };
@@ -90,18 +89,7 @@ export function createLogger(
         level: resolvedLevel,
     };
 
-    if (options.transport) {
-        return pino(loggerOptions);
-    }
-
-    const stream = pinoPretty({
-        colorize: false,
-        translateTime: 'SYS:standard',
-        ignore: 'pid,hostname,service',
-        singleLine: true,
-    });
-
-    return pino(loggerOptions, stream);
+    return pino(loggerOptions);
 }
 
 export let logger = createLogger();

--- a/packages/common/src/logger.ts
+++ b/packages/common/src/logger.ts
@@ -90,7 +90,7 @@ export function createLogger(
         level: resolvedLevel,
     };
 
-    if (options.transport) {
+    if (options.transport !== undefined && options.transport !== null) {
         return pino(loggerOptions);
     }
 

--- a/packages/ipfs/src/helia-client.ts
+++ b/packages/ipfs/src/helia-client.ts
@@ -2,7 +2,7 @@ import { createHelia, Helia } from 'helia';
 import { json, JSON } from '@helia/json';
 import { unixfs, UnixFS } from '@helia/unixfs';
 import { FsBlockstore } from 'blockstore-fs';
-import { CID } from 'multiformats';
+import { CID } from 'multiformats/cid';
 import { base58btc } from 'multiformats/bases/base58';
 import * as jsonCodec from 'multiformats/codecs/json';
 import * as rawCodec from 'multiformats/codecs/raw';

--- a/packages/ipfs/src/utils.ts
+++ b/packages/ipfs/src/utils.ts
@@ -1,4 +1,4 @@
-import { CID } from 'multiformats';
+import { CID } from 'multiformats/cid';
 import { base58btc } from 'multiformats/bases/base58';
 import * as jsonCodec from 'multiformats/codecs/json';
 import * as rawCodec from 'multiformats/codecs/raw';

--- a/tests/common/env-browser.test.ts
+++ b/tests/common/env-browser.test.ts
@@ -1,0 +1,14 @@
+import { loadEnv, resolveEnvFiles } from '../../packages/common/src/env-browser.ts';
+
+describe('env-browser', () => {
+    it('uses no-op env loading in browser builds', () => {
+        const options = {
+            cwd: '/tmp/project',
+            envFileVar: 'KC_ENV_FILE',
+            filenames: ['.env', '.env.local'],
+        };
+
+        expect(resolveEnvFiles(options)).toEqual([]);
+        expect(loadEnv(options)).toEqual([]);
+    });
+});

--- a/tests/common/env-browser.test.ts
+++ b/tests/common/env-browser.test.ts
@@ -11,4 +11,9 @@ describe('env-browser', () => {
         expect(resolveEnvFiles(options)).toEqual([]);
         expect(loadEnv(options)).toEqual([]);
     });
+
+    it('uses no-op env loading with default options', () => {
+        expect(resolveEnvFiles()).toEqual([]);
+        expect(loadEnv()).toEqual([]);
+    });
 });

--- a/tests/common/env-browser.test.ts
+++ b/tests/common/env-browser.test.ts
@@ -3,7 +3,7 @@ import { loadEnv, resolveEnvFiles } from '../../packages/common/src/env-browser.
 describe('env-browser', () => {
     it('uses no-op env loading in browser builds', () => {
         const options = {
-            cwd: '/tmp/project',
+            cwd: '/workspace/project',
             envFileVar: 'KC_ENV_FILE',
             filenames: ['.env', '.env.local'],
         };

--- a/tests/common/logger.test.ts
+++ b/tests/common/logger.test.ts
@@ -49,20 +49,28 @@ describe('logger', () => {
         expect(loggerMod.getLogLevel()).toBe('info');
     });
 
-    it('getPrettyEnabled always returns true', () => {
+    it('getLogLevel falls back cleanly when process.env is unavailable', () => {
+        const originalProcess = (globalThis as any).process;
+
+        try {
+            (globalThis as any).process = undefined;
+            expect(loggerMod.getLogLevel()).toBe('info');
+        } finally {
+            (globalThis as any).process = originalProcess;
+        }
+    });
+
+    it('getPrettyEnabled returns the default pretty flag', () => {
         expect(loggerMod.getPrettyEnabled()).toBe(true);
     });
 
-    it('createLogger uses env level and pretty transport defaults', () => {
+    it('createLogger uses env level and pretty stream defaults', () => {
         loggerMod.createLogger({}, { KC_LOG_LEVEL: 'error' });
         const call = pinoMock.mock.calls.at(-1);
         expect(call).toBeTruthy();
         const options = call?.[0] as any;
         expect(options.level).toBe('error');
-        expect(options.transport?.target).toBe('pino-pretty');
-        expect(options.transport?.options?.singleLine).toBe(true);
-        expect(options.transport?.options?.ignore).toContain('service');
-        expect(options.transport?.options?.colorize).toBe(false);
+        expect(call?.[1]).toBeTruthy();
     });
 
     it('createLogger uses explicit level over env', () => {

--- a/tests/common/logger.test.ts
+++ b/tests/common/logger.test.ts
@@ -83,12 +83,16 @@ describe('logger', () => {
     it('createLogger respects explicit transport and accepts falsy transport', () => {
         const customTransport = { target: 'pino-pretty', options: { singleLine: false } };
         loggerMod.createLogger({ transport: customTransport }, { KC_LOG_LEVEL: 'info' });
-        let options = pinoMock.mock.calls.at(-1)?.[0] as any;
+        let call = pinoMock.mock.calls.at(-1);
+        let options = call?.[0] as any;
         expect(options.transport).toBe(customTransport);
+        expect(call?.[1]).toBeUndefined();
 
         loggerMod.createLogger({ transport: false as any }, { KC_LOG_LEVEL: 'info' });
-        options = pinoMock.mock.calls.at(-1)?.[0] as any;
+        call = pinoMock.mock.calls.at(-1);
+        options = call?.[0] as any;
         expect(options.transport).toBe(false);
+        expect(call?.[1]).toBeUndefined();
     });
 
     it('setLogger and childLogger delegate to the current logger', () => {


### PR DESCRIPTION
- Partially resolves: https://github.com/KeychainMDIP/kc/issues/1218

This PR makes @mdip/common safe to consume from browser builds while preserving the existing Node logger behavior. It adds browser-specific package export entries and a lightweight browser logger implementation that avoids Node-only assumptions such as process.env and pretty-print transports.

It also updates the Node logger to use pino-pretty as a stream instead of a transport for better CommonJS compatibility, and adjusts IPFS CID imports to use the explicit multiformats/cid subpath. A focused logger test was updated to cover the browser-safe environment fallback and the new pretty-stream behavior.