### PR TITLE
ci: typecheck React wallet on pull requests

### DIFF
--- a/.github/workflows/build-react-wallet-webapp.yml
+++ b/.github/workflows/build-react-wallet-webapp.yml
@@ -2,9 +2,10 @@ name: Build React-Wallet webapp
 
 on:
   push:
+  pull_request:
 
 jobs:
-  build-android-webapp:
+  build-react-wallet-webapp:
     runs-on: ubuntu-latest
 
     steps:
@@ -22,13 +23,14 @@ jobs:
       - name: Compile TypeScript
         run: npm run build
 
-      - name: Install dependencies
-        run: |
-          cd ./apps/react-wallet
-          npm ci
+      - name: Install react-wallet dependencies
+        working-directory: ./apps/react-wallet
+        run: npm ci
 
-      - name: Build extension
-        run: |
-          cd ./apps/react-wallet
-          npm run build
+      - name: Typecheck react-wallet webapp
+        working-directory: ./apps/react-wallet
+        run: npm run typecheck
 
+      - name: Build react-wallet webapp
+        working-directory: ./apps/react-wallet
+        run: npm run build

--- a/apps/react-wallet/package.json
+++ b/apps/react-wallet/package.json
@@ -4,6 +4,7 @@
   "description": "MDIP Android Demo",
   "scripts": {
     "dev": "vite",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "build": "vite build",
     "preview": "vite preview",
     "android:run": "vite build --mode android && npx cap sync android && npx cap run android",

--- a/apps/react-wallet/src/components/DmailTab.tsx
+++ b/apps/react-wallet/src/components/DmailTab.tsx
@@ -598,7 +598,7 @@ const DmailTab: React.FC = () => {
             }
 
             // Create a Blob from the buffer
-            const blob = new Blob([buffer]);
+            const blob = new Blob([Uint8Array.from(buffer)]);
             // Create a temporary link to trigger the download
             const link = document.createElement('a');
             link.href = URL.createObjectURL(blob);

--- a/apps/react-wallet/src/components/DocumentTab.tsx
+++ b/apps/react-wallet/src/components/DocumentTab.tsx
@@ -63,7 +63,7 @@ const DocumentTab = () => {
             const docs = await keymaster.resolveDID(documentName, version ? { versionSequence: version } : {});
             setSelectedDocumentDocs(docs);
 
-            const currentVersion = docs.didDocumentMetadata?.version ?? 1;
+            const currentVersion = Number(docs.didDocumentMetadata?.version ?? 1);
             setDocVersion(currentVersion);
             if (version === undefined) {
                 setDocVersionMax(currentVersion);

--- a/apps/react-wallet/src/components/GroupVaultTab.tsx
+++ b/apps/react-wallet/src/components/GroupVaultTab.tsx
@@ -165,7 +165,7 @@ function GroupVaultTab() {
             }
 
             // Create a Blob from the buffer
-            const blob = new Blob([buffer]);
+            const blob = new Blob([Uint8Array.from(buffer)]);
             // Create a temporary link to trigger the download
             const link = document.createElement('a');
             link.href = URL.createObjectURL(blob);

--- a/apps/react-wallet/src/utils/utils.ts
+++ b/apps/react-wallet/src/utils/utils.ts
@@ -89,6 +89,10 @@ export async function scanQrCode() {
 
         let did: string | null = null;
         for (const b of barcodes) {
+            if (typeof b.rawValue !== 'string') {
+                continue;
+            }
+
             const candidate = extractDid(b.rawValue);
             if (candidate) {
                 did = candidate;
@@ -104,4 +108,3 @@ export async function scanQrCode() {
     } catch {}
     return null;
 }
-


### PR DESCRIPTION
- Partially resolves: https://github.com/KeychainMDIP/kc/issues/1218

This PR tightens the React wallet CI workflow by running it on pull requests, using working-directory instead of inline cd commands, and adding an explicit TypeScript typecheck step before the Vite production build.

It also fixes the small existing React wallet typing issues that the new check exposed: Blob construction from buffers, DID document version coercion, and QR scan handling when rawValue is missing.