### PR TITLE
ci: show logs for failed services

### DIFF
--- a/start-node-ci
+++ b/start-node-ci
@@ -39,7 +39,15 @@ while true; do
   if [[ "$RETRY_COUNT" -ge "$MAX_RETRIES" ]]; then
     echo "❌ Timed out waiting for containers to be 'Up'"
     docker compose "${PROFILE_ARGS[@]}" ps -a
-    docker compose "${PROFILE_ARGS[@]}" logs --no-color --tail=200 "${SERVICES[@]}"
+
+    RUNNING_SERVICES=$(docker compose "${PROFILE_ARGS[@]}" ps --services --status running "${SERVICES[@]}")
+    for service in "${SERVICES[@]}"; do
+      if ! grep -qx "$service" <<< "$RUNNING_SERVICES"; then
+        echo "----- logs: $service -----"
+        docker compose "${PROFILE_ARGS[@]}" logs --no-color "$service" || true
+      fi
+    done
+
     exit 1
   fi
 


### PR DESCRIPTION
- Partially resolves: https://github.com/KeychainMDIP/kc/issues/1218
- 
This PR improves start-node-ci timeout diagnostics. When services fail to reach the running state, the script now prints the compose status and then shows logs only for services that are not running.

This keeps CI failure output focused on the containers that likely caused the startup failure, instead of dumping logs for every service.