### PR TITLE
fix: keep postgres password out of docker dsn

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,8 @@ services:
       - KC_LOG_LEVEL=${KC_LOG_LEVEL}
       - KC_MONGODB_URL=mongodb://mongodb:27017/?replicaSet=rs0
       - KC_REDIS_URL=redis://redis:6379
-      - KC_POSTGRES_URL=postgresql://${KC_POSTGRES_USER:-mdip}:${KC_POSTGRES_PASSWORD:-mdip}@postgres:5432/${KC_POSTGRES_DB:-mdip}
+      - PGPASSWORD=${KC_POSTGRES_PASSWORD:-mdip}
+      - KC_POSTGRES_URL=postgresql://${KC_POSTGRES_USER:-mdip}@postgres:5432/${KC_POSTGRES_DB:-mdip}
       - KC_IPFS_ENABLE=${KC_IPFS_ENABLE}
       - KC_IPFS_URL=http://ipfs:5001/api/v0
       - KC_IPFS_CLUSTER_URL=${KC_IPFS_CLUSTER_URL}
@@ -124,7 +125,8 @@ services:
       - KC_LOG_LEVEL=${KC_LOG_LEVEL}
       - KC_MONGODB_URL=mongodb://mongodb:27017/?replicaSet=rs0
       - KC_REDIS_URL=redis://redis:6379
-      - KC_POSTGRES_URL=postgresql://${KC_POSTGRES_USER:-mdip}:${KC_POSTGRES_PASSWORD:-mdip}@postgres:5432/${KC_POSTGRES_DB:-mdip}
+      - PGPASSWORD=${KC_POSTGRES_PASSWORD:-mdip}
+      - KC_POSTGRES_URL=postgresql://${KC_POSTGRES_USER:-mdip}@postgres:5432/${KC_POSTGRES_DB:-mdip}
     volumes:
       - ./data:/app/keymaster/data
     user: "${KC_UID}:${KC_GID}"
@@ -156,7 +158,8 @@ services:
       - KC_NODE_NAME=${KC_NODE_NAME}
       - KC_MDIP_PROTOCOL=${KC_MDIP_PROTOCOL}
       - KC_HYPR_DB=${KC_HYPR_DB:-sqlite}
-      - KC_HYPR_POSTGRES_URL=postgresql://${KC_POSTGRES_USER:-mdip}:${KC_POSTGRES_PASSWORD:-mdip}@postgres:5432/${KC_POSTGRES_DB:-mdip}
+      - PGPASSWORD=${KC_POSTGRES_PASSWORD:-mdip}
+      - KC_HYPR_POSTGRES_URL=postgresql://${KC_POSTGRES_USER:-mdip}@postgres:5432/${KC_POSTGRES_DB:-mdip}
       - KC_HYPR_EXPORT_INTERVAL=${KC_HYPR_EXPORT_INTERVAL}
       - KC_HYPR_NEGENTROPY_ENABLE=${KC_HYPR_NEGENTROPY_ENABLE}
       - KC_HYPR_NEGENTROPY_FRAME_SIZE_LIMIT=${KC_HYPR_NEGENTROPY_FRAME_SIZE_LIMIT}
@@ -188,7 +191,8 @@ services:
       - KC_KEYMASTER_URL=http://keymaster:4226
       - KC_MONGODB_URL=mongodb://mongodb:27017/?replicaSet=rs0
       - KC_REDIS_URL=redis://redis:6379
-      - KC_POSTGRES_URL=postgresql://${KC_POSTGRES_USER:-mdip}:${KC_POSTGRES_PASSWORD:-mdip}@postgres:5432/${KC_POSTGRES_DB:-mdip}
+      - PGPASSWORD=${KC_POSTGRES_PASSWORD:-mdip}
+      - KC_POSTGRES_URL=postgresql://${KC_POSTGRES_USER:-mdip}@postgres:5432/${KC_POSTGRES_DB:-mdip}
       - KC_NODE_ID=${KC_NODE_ID}
       - KC_SAT_CHAIN=TFTC
       - KC_SAT_NETWORK=testnet
@@ -232,7 +236,8 @@ services:
       - KC_KEYMASTER_URL=http://keymaster:4226
       - KC_MONGODB_URL=mongodb://mongodb:27017/?replicaSet=rs0
       - KC_REDIS_URL=redis://redis:6379
-      - KC_POSTGRES_URL=postgresql://${KC_POSTGRES_USER:-mdip}:${KC_POSTGRES_PASSWORD:-mdip}@postgres:5432/${KC_POSTGRES_DB:-mdip}
+      - PGPASSWORD=${KC_POSTGRES_PASSWORD:-mdip}
+      - KC_POSTGRES_URL=postgresql://${KC_POSTGRES_USER:-mdip}@postgres:5432/${KC_POSTGRES_DB:-mdip}
       - KC_NODE_ID=${KC_NODE_ID}
       - KC_SAT_CHAIN=BTC
       - KC_SAT_NETWORK=bitcoin
@@ -274,7 +279,8 @@ services:
       - KC_KEYMASTER_URL=http://keymaster:4226
       - KC_MONGODB_URL=mongodb://mongodb:27017/?replicaSet=rs0
       - KC_REDIS_URL=redis://redis:6379
-      - KC_POSTGRES_URL=postgresql://${KC_POSTGRES_USER:-mdip}:${KC_POSTGRES_PASSWORD:-mdip}@postgres:5432/${KC_POSTGRES_DB:-mdip}
+      - PGPASSWORD=${KC_POSTGRES_PASSWORD:-mdip}
+      - KC_POSTGRES_URL=postgresql://${KC_POSTGRES_USER:-mdip}@postgres:5432/${KC_POSTGRES_DB:-mdip}
       - KC_NODE_ID=${KC_NODE_ID}
       - KC_SAT_CHAIN=TBTC
       - KC_SAT_NETWORK=testnet
@@ -318,7 +324,8 @@ services:
       - KC_KEYMASTER_URL=http://keymaster:4226
       - KC_MONGODB_URL=mongodb://mongodb:27017/?replicaSet=rs0
       - KC_REDIS_URL=redis://redis:6379
-      - KC_POSTGRES_URL=postgresql://${KC_POSTGRES_USER:-mdip}:${KC_POSTGRES_PASSWORD:-mdip}@postgres:5432/${KC_POSTGRES_DB:-mdip}
+      - PGPASSWORD=${KC_POSTGRES_PASSWORD:-mdip}
+      - KC_POSTGRES_URL=postgresql://${KC_POSTGRES_USER:-mdip}@postgres:5432/${KC_POSTGRES_DB:-mdip}
       - KC_NODE_ID=${KC_NODE_ID}
       - KC_SAT_CHAIN=Signet
       - KC_SAT_NETWORK=testnet
@@ -355,7 +362,8 @@ services:
       - KC_KEYMASTER_URL=http://keymaster:4226
       - KC_MONGODB_URL=mongodb://mongodb:27017/?replicaSet=rs0
       - KC_REDIS_URL=redis://redis:6379
-      - KC_POSTGRES_URL=postgresql://${KC_POSTGRES_USER:-mdip}:${KC_POSTGRES_PASSWORD:-mdip}@postgres:5432/${KC_POSTGRES_DB:-mdip}
+      - PGPASSWORD=${KC_POSTGRES_PASSWORD:-mdip}
+      - KC_POSTGRES_URL=postgresql://${KC_POSTGRES_USER:-mdip}@postgres:5432/${KC_POSTGRES_DB:-mdip}
       - KC_NODE_ID=${KC_NODE_ID}
       - KC_SAT_CHAIN=Signet
       - KC_SAT_NETWORK=testnet
@@ -425,7 +433,8 @@ services:
       - KC_SEARCH_SERVER_REFRESH_INTERVAL_MS=${KC_SEARCH_SERVER_REFRESH_INTERVAL_MS:-5000}
       - KC_SEARCH_SERVER_DB=${KC_SEARCH_SERVER_DB:-sqlite}
       - KC_SEARCH_SERVER_POSTGRES_URL=${KC_SEARCH_SERVER_POSTGRES_URL:-}
-      - KC_POSTGRES_URL=postgresql://${KC_POSTGRES_USER:-mdip}:${KC_POSTGRES_PASSWORD:-mdip}@postgres:5432/${KC_POSTGRES_DB:-mdip}
+      - PGPASSWORD=${KC_POSTGRES_PASSWORD:-mdip}
+      - KC_POSTGRES_URL=postgresql://${KC_POSTGRES_USER:-mdip}@postgres:5432/${KC_POSTGRES_DB:-mdip}
       - KC_SEARCH_SERVER_TRUST_PROXY=${KC_SEARCH_SERVER_TRUST_PROXY:-false}
       - KC_SEARCH_SERVER_RATE_LIMIT_ENABLED=${KC_SEARCH_SERVER_RATE_LIMIT_ENABLED:-false}
       - KC_SEARCH_SERVER_RATE_LIMIT_WINDOW_VALUE=${KC_SEARCH_SERVER_RATE_LIMIT_WINDOW_VALUE:-1}

--- a/packages/common/src/env.ts
+++ b/packages/common/src/env.ts
@@ -122,5 +122,9 @@ export function loadEnv(options: LoadEnvOptions = {}): string[] {
         loadedFiles.push(envFile);
     }
 
+    if (process.env.KC_POSTGRES_PASSWORD !== undefined) {
+        process.env.PGPASSWORD ??= process.env.KC_POSTGRES_PASSWORD;
+    }
+
     return loadedFiles;
 }

--- a/sample.env
+++ b/sample.env
@@ -44,7 +44,7 @@ KC_POSTGRES_PORT=5432
 KC_POSTGRES_DB=mdip
 KC_POSTGRES_USER=mdip
 KC_POSTGRES_PASSWORD=mdip
-KC_POSTGRES_URL=postgresql://mdip:mdip@localhost:5432/mdip
+KC_POSTGRES_URL=postgresql://mdip@postgres:5432/mdip
 
 # React-Wallet
 KC_REACT_WALLET_PORT=4228
@@ -65,7 +65,7 @@ KC_SEARCH_SERVER_RATE_LIMIT_SKIP_PATHS=/api/v1/ready,/api/v1/status
 
 # Hyperswarm
 KC_HYPR_DB=sqlite # Sync store backend for hyperswarm mediator: sqlite | postgres
-KC_HYPR_POSTGRES_URL=postgresql://mdip:mdip@localhost:5432/mdip
+KC_HYPR_POSTGRES_URL=postgresql://mdip@postgres:5432/mdip
 KC_HYPR_EXPORT_INTERVAL=2 # Seconds between export-loop ticks. integer >= 1.
 KC_MDIP_PROTOCOL=/MDIP/v1.0-public
 KC_HYPR_LEGACY_SYNC_ENABLE=true # Enables legacy sync for peers without negentropy. true|false.

--- a/tests/common/env.test.ts
+++ b/tests/common/env.test.ts
@@ -70,6 +70,22 @@ describe('loadEnv', () => {
         expect(process.env.ROOT_ONLY).toBe('mounted');
     });
 
+    test('maps KC_POSTGRES_PASSWORD to PGPASSWORD without overriding PGPASSWORD', () => {
+        const envFile = path.join(tempDir, '.env');
+
+        fs.writeFileSync(envFile, 'KC_POSTGRES_PASSWORD=postgres-password\n');
+
+        loadEnv({ cwd: tempDir });
+
+        expect(process.env.PGPASSWORD).toBe('postgres-password');
+
+        process.env = { ...ORIGINAL_ENV, PGPASSWORD: 'explicit-password' };
+
+        loadEnv({ cwd: tempDir });
+
+        expect(process.env.PGPASSWORD).toBe('explicit-password');
+    });
+
     test('deduplicates KC_ENV_FILE when it matches a discovered env file', () => {
         const workspaceDir = path.join(tempDir, 'repo');
         const serviceDir = path.join(workspaceDir, 'services', 'search-server');


### PR DESCRIPTION
This change fixes Postgres connection handling for Docker-based services when KC_POSTGRES_PASSWORD contains URL-reserved characters.