### PR TITLE
Add DID prefix metrics and standardise snapshot routes

### DIFF
--- a/services/explorer/src/api/searchClient.ts
+++ b/services/explorer/src/api/searchClient.ts
@@ -58,11 +58,10 @@ export interface PublishedSchemaMetric {
 }
 
 export interface NetworkMetricSnapshot {
-    date: string;
     agentDidCount: number;
+    agentDidCountsByPrefix: Record<string, number>;
     credentialCount: number;
-    schemas: PublishedSchemaMetric[];
-    rebuiltAt: string;
+    credentialDidCountsByPrefix: Record<string, number>;
 }
 
 export interface PublishedCredentialRow {
@@ -144,6 +143,16 @@ export interface ChallengeReceiptUsageResult {
 function toNumber(value: unknown, fallback = 0): number {
     const parsed = Number(value);
     return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function mapPrefixCounts(value: unknown): Record<string, number> {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+        return {};
+    }
+
+    return Object.fromEntries(
+        Object.entries(value).map(([prefix, count]) => [prefix, toNumber(count)])
+    );
 }
 
 function mapPublishedCredentialRow(row: any): PublishedCredentialRow {
@@ -238,30 +247,38 @@ export async function searchDIDDocuments(query: string): Promise<string[]> {
     return response.data as string[];
 }
 
-export async function fetchPublishedSchemaMetrics(): Promise<PublishedSchemaMetric[]> {
-    const response = await axios.get(`${apiBaseUrl}/metrics/schemas/published`);
+export async function fetchPublishedSchemaMetrics(date?: string): Promise<PublishedSchemaMetric[] | null> {
+    try {
+        const path = date
+            ? `/metrics/snapshots/schemas/${encodeURIComponent(date)}`
+            : "/metrics/schemas/published";
+        const response = await axios.get(`${apiBaseUrl}${path}`);
 
-    return (response.data.schemas ?? []).map((row: any) => ({
-        schemaDid: row.schemaDid,
-        count: toNumber(row.count),
-    }));
+        return (response.data.schemas ?? []).map((row: any) => ({
+            schemaDid: row.schemaDid,
+            count: toNumber(row.count),
+        }));
+    }
+    catch (error: any) {
+        if (error?.response?.status === 404) {
+            return null;
+        }
+
+        throw error;
+    }
 }
 
 export async function fetchNetworkMetricSnapshot(date: string): Promise<NetworkMetricSnapshot | null> {
     try {
         const response = await axios.get(
-            `${apiBaseUrl}/metrics/network/snapshots/${encodeURIComponent(date)}`
+            `${apiBaseUrl}/metrics/snapshots/credentials/${encodeURIComponent(date)}`
         );
 
         return {
-            date: response.data.date,
             agentDidCount: toNumber(response.data.agentDidCount),
+            agentDidCountsByPrefix: mapPrefixCounts(response.data.agentDidCountsByPrefix),
             credentialCount: toNumber(response.data.credentialCount),
-            schemas: (response.data.schemas ?? []).map((row: any) => ({
-                schemaDid: row.schemaDid,
-                count: toNumber(row.count),
-            })),
-            rebuiltAt: response.data.rebuiltAt,
+            credentialDidCountsByPrefix: mapPrefixCounts(response.data.credentialDidCountsByPrefix),
         };
     }
     catch (error: any) {

--- a/services/explorer/src/components/Credentials.tsx
+++ b/services/explorer/src/components/Credentials.tsx
@@ -23,8 +23,8 @@ import {
 } from "../config.js";
 import {
     fetchDIDDocument,
-    fetchNetworkMetricSnapshot,
     fetchPublishedCredentials,
+    fetchPublishedSchemaMetrics,
     type PublishedCredentialRow,
     type PublishedSchemaMetric,
 } from "../api/searchClient.js";
@@ -363,11 +363,11 @@ function Credentials() {
             setSchemaMetricsMessage("Loading credential metrics...");
 
             try {
-                const snapshot = await fetchNetworkMetricSnapshot(selectedDate);
+                const schemas = await fetchPublishedSchemaMetrics(selectedDate);
 
                 if (!ignore) {
-                    setSchemaCounts(snapshot?.schemas ?? []);
-                    setSchemaMetricsMessage(snapshot ? "" : "No network snapshot exists for this date.");
+                    setSchemaCounts(schemas ?? []);
+                    setSchemaMetricsMessage(schemas ? "" : "No network snapshot exists for this date.");
                 }
             }
             catch (error: any) {

--- a/services/explorer/src/components/Network.tsx
+++ b/services/explorer/src/components/Network.tsx
@@ -13,7 +13,9 @@ import {
 import { Link as RouterLink, useSearchParams } from "react-router-dom";
 import {
     fetchNetworkMetricSnapshot,
+    fetchPublishedSchemaMetrics,
     type NetworkMetricSnapshot,
+    type PublishedSchemaMetric,
 } from "../api/searchClient.js";
 import { useSnackbar } from "../contexts/SnackbarProvider.js";
 
@@ -25,24 +27,32 @@ function Network() {
     const currentDate = today();
     const selectedDate = searchParams.get("date") || currentDate;
     const [snapshot, setSnapshot] = useState<NetworkMetricSnapshot | null>(null);
+    const [schemas, setSchemas] = useState<PublishedSchemaMetric[]>([]);
     const [message, setMessage] = useState("Loading network snapshot...");
 
     useEffect(() => {
         let ignore = false;
 
         setSnapshot(null);
+        setSchemas([]);
         setMessage("Loading network snapshot...");
 
-        fetchNetworkMetricSnapshot(selectedDate)
-            .then(result => {
+        Promise.all([
+            fetchNetworkMetricSnapshot(selectedDate),
+            fetchPublishedSchemaMetrics(selectedDate),
+        ])
+            .then(([result, schemaMetrics]) => {
                 if (ignore) {
                     return;
                 }
 
-                setSnapshot(result);
-                if (!result) {
+                if (!result || !schemaMetrics) {
                     setMessage("No network snapshot exists for this date.");
+                    return;
                 }
+
+                setSnapshot(result);
+                setSchemas(schemaMetrics);
             })
             .catch(error => {
                 if (!ignore) {
@@ -88,15 +98,23 @@ function Network() {
             ) : (
                 <>
                     <Typography color="text.secondary" sx={{ mb: 2 }}>
-                        Cumulative through {snapshot.date} (UTC)
+                        Cumulative through {selectedDate} (UTC)
                     </Typography>
 
                     <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap", mb: 3 }}>
                         {[
-                            ["Agent DIDs", snapshot.agentDidCount],
-                            ["Credentials", snapshot.credentialCount],
-                            ["Schemas in use", snapshot.schemas.length],
-                        ].map(([label, value]) => (
+                            {
+                                label: "Agent DIDs",
+                                value: snapshot.agentDidCount,
+                                prefixes: snapshot.agentDidCountsByPrefix,
+                            },
+                            {
+                                label: "Credentials",
+                                value: snapshot.credentialCount,
+                                prefixes: snapshot.credentialDidCountsByPrefix,
+                            },
+                            { label: "Schemas in use", value: schemas.length },
+                        ].map(({ label, value, prefixes }) => (
                             <Box
                                 key={label}
                                 sx={{
@@ -110,12 +128,25 @@ function Network() {
                             >
                                 <Typography variant="overline">{label}</Typography>
                                 <Typography variant="h4">{Number(value).toLocaleString()}</Typography>
+                                {prefixes && Object.entries(prefixes)
+                                    .sort(([a], [b]) => a.localeCompare(b))
+                                    .map(([prefix, count]) => (
+                                        <Box
+                                            key={prefix}
+                                            sx={{ display: "flex", justifyContent: "space-between", gap: 2, mt: 0.5 }}
+                                        >
+                                            <Typography color="text.secondary" sx={{ fontFamily: "Courier, monospace" }}>
+                                                {prefix}
+                                            </Typography>
+                                            <Typography>{count.toLocaleString()}</Typography>
+                                        </Box>
+                                    ))}
                             </Box>
                         ))}
                     </Box>
 
                     <Typography variant="h6" sx={{ mb: 1 }}>Schema usage</Typography>
-                    {snapshot.schemas.length === 0 ? (
+                    {schemas.length === 0 ? (
                         <Typography>No credential schemas were in use on this date.</Typography>
                     ) : (
                         <TableContainer sx={{ border: "1px solid", borderColor: "divider", borderRadius: 1 }}>
@@ -128,7 +159,7 @@ function Network() {
                                     </TableRow>
                                 </TableHead>
                                 <TableBody>
-                                    {snapshot.schemas.map((schema, index) => (
+                                    {schemas.map((schema, index) => (
                                         <TableRow key={schema.schemaDid}>
                                             <TableCell>{index + 1}</TableCell>
                                             <TableCell>

--- a/services/search-server/README.md
+++ b/services/search-server/README.md
@@ -82,6 +82,7 @@ KC_LOG_LEVEL=info
 - **Description**: Returns current published credential counts grouped by schema DID.
 - **Returns**:
     - `200 OK` + `{ "schemas": [{ "schemaDid": "...", "count": 42 }] }`
+    - `400 Bad Request` when the removed `date` query parameter is supplied.
 
 ### `GET /api/v1/metrics/credentials/published`
 - **Description**: Returns published credential rows with optional filtering and pagination.
@@ -97,12 +98,21 @@ KC_LOG_LEVEL=info
 - **Returns**:
     - `200 OK` + `{ "total": 123, "credentials": [{ "credentialDid": "...", "schemaDid": "...", "issuerDid": "...", "subjectDid": "...", "holderDid": "...", "updatedAt": "..." }] }`
 
-### `GET /api/v1/metrics/network/snapshots/:date`
-- **Description**: Returns cumulative network totals for one UTC day.
+### `GET /api/v1/metrics/snapshots/schemas/:date`
+- **Description**: Returns cumulative credential counts grouped by schema DID for one UTC day.
 - **Path Param**:
     - `date` (required, `YYYY-MM-DD`, must not be in the future)
 - **Returns**:
-    - `200 OK` + `{ "date": "2026-08-05", "agentDidCount": 123, "credentialCount": 456, "schemas": [{ "schemaDid": "did:test:...", "count": 42 }], "rebuiltAt": "..." }`
+    - `200 OK` + `{ "schemas": [{ "schemaDid": "...", "count": 42 }] }`
+    - `400 Bad Request` for an invalid or future date.
+    - `404 Not Found` when no snapshot exists for the date.
+
+### `GET /api/v1/metrics/snapshots/credentials/:date`
+- **Description**: Returns cumulative AgentDID and credential totals for one UTC day.
+- **Path Param**:
+    - `date` (required, `YYYY-MM-DD`, must not be in the future)
+- **Returns**:
+    - `200 OK` + `{ "agentDidCount": 123, "agentDidCountsByPrefix": { "did:mdip": 23, "did:test": 100 }, "credentialCount": 456, "credentialDidCountsByPrefix": { "did:mdip": 56, "did:test": 400 } }`
     - `400 Bad Request` for an invalid or future date.
     - `404 Not Found` when no snapshot exists for the date.
 
@@ -117,10 +127,19 @@ deletion, and credentials remain counted after revocation or unpublishing.
 Private credentials that have never been published cannot be counted by
 search-server.
 
-Each snapshot includes cumulative credential counts grouped by schema DID,
-ordered from most to least used. This historical breakdown differs from
-`/metrics/schemas/published`, which describes only the credentials currently
-present in AgentDID manifests.
+Agent DID prefixes come from the indexed DID, while credential DID prefixes
+come from the credential key as published in the AgentDID manifest. Prefixes
+are grouped dynamically as `did:<method>` rather than restricted to a fixed
+allow-list. Prefix aliases sharing the same DID suffix count once under the
+first published prefix encountered. Each total equals the sum of its
+per-prefix counts.
+
+Each snapshot stores cumulative credential counts grouped by schema DID,
+ordered from most to least used. Request this historical breakdown from
+`/metrics/snapshots/schemas/:date`. `/metrics/schemas/published` describes only
+the credentials currently present in AgentDID manifests.
+Schema prefix aliases sharing the same DID suffix are combined under the
+first full schema DID encountered.
 
 Metric dates before the MDIP epoch are included in the `2024-01-01` legacy
 baseline. Future-dated entries and entries without a usable timestamp are

--- a/services/search-server/src/db/postgres.ts
+++ b/services/search-server/src/db/postgres.ts
@@ -159,7 +159,9 @@ export default class Postgres implements DIDsDb {
             CREATE TABLE IF NOT EXISTS network_metric_snapshots (
                 snapshot_date TEXT PRIMARY KEY,
                 agent_did_count INTEGER NOT NULL CHECK (agent_did_count >= 0),
+                agent_did_counts_by_prefix JSONB NOT NULL DEFAULT '{}'::jsonb,
                 credential_count INTEGER NOT NULL CHECK (credential_count >= 0),
+                credential_did_counts_by_prefix JSONB NOT NULL DEFAULT '{}'::jsonb,
                 schema_counts JSONB NOT NULL DEFAULT '[]'::jsonb,
                 rebuilt_at TEXT NOT NULL
             );
@@ -705,14 +707,18 @@ export default class Postgres implements DIDsDb {
                     `INSERT INTO network_metric_snapshots (
                         snapshot_date,
                         agent_did_count,
+                        agent_did_counts_by_prefix,
                         credential_count,
+                        credential_did_counts_by_prefix,
                         schema_counts,
                         rebuilt_at
-                    ) VALUES ($1, $2, $3, $4, $5)`,
+                    ) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
                     [
                         snapshot.date,
                         snapshot.agentDidCount,
+                        JSON.stringify(snapshot.agentDidCountsByPrefix),
                         snapshot.credentialCount,
+                        JSON.stringify(snapshot.credentialDidCountsByPrefix),
                         JSON.stringify(snapshot.schemas),
                         snapshot.rebuiltAt,
                     ]
@@ -733,14 +739,18 @@ export default class Postgres implements DIDsDb {
         const result = await this.getPool().query<{
             date: string;
             agentDidCount: number;
+            agentDidCountsByPrefix: Record<string, number> | string;
             credentialCount: number;
+            credentialDidCountsByPrefix: Record<string, number> | string;
             schemaCounts: PublishedCredentialSchemaCount[] | string;
             rebuiltAt: string;
         }>(
             `SELECT
                 snapshot_date AS date,
                 agent_did_count AS "agentDidCount",
+                agent_did_counts_by_prefix AS "agentDidCountsByPrefix",
                 credential_count AS "credentialCount",
+                credential_did_counts_by_prefix AS "credentialDidCountsByPrefix",
                 schema_counts AS "schemaCounts",
                 rebuilt_at AS "rebuiltAt"
              FROM network_metric_snapshots
@@ -756,7 +766,13 @@ export default class Postgres implements DIDsDb {
         return {
             date: row.date,
             agentDidCount: row.agentDidCount,
+            agentDidCountsByPrefix: typeof row.agentDidCountsByPrefix === 'string'
+                ? JSON.parse(row.agentDidCountsByPrefix) as Record<string, number>
+                : row.agentDidCountsByPrefix,
             credentialCount: row.credentialCount,
+            credentialDidCountsByPrefix: typeof row.credentialDidCountsByPrefix === 'string'
+                ? JSON.parse(row.credentialDidCountsByPrefix) as Record<string, number>
+                : row.credentialDidCountsByPrefix,
             schemas: typeof row.schemaCounts === 'string'
                 ? JSON.parse(row.schemaCounts) as PublishedCredentialSchemaCount[]
                 : row.schemaCounts,

--- a/services/search-server/src/db/sqlite.ts
+++ b/services/search-server/src/db/sqlite.ts
@@ -137,7 +137,9 @@ export default class Sqlite implements DIDsDb {
             CREATE TABLE IF NOT EXISTS network_metric_snapshots (
                 snapshot_date TEXT PRIMARY KEY,
                 agent_did_count INTEGER NOT NULL CHECK (agent_did_count >= 0),
+                agent_did_counts_by_prefix TEXT NOT NULL DEFAULT '{}',
                 credential_count INTEGER NOT NULL CHECK (credential_count >= 0),
+                credential_did_counts_by_prefix TEXT NOT NULL DEFAULT '{}',
                 schema_counts TEXT NOT NULL DEFAULT '[]',
                 rebuilt_at TEXT NOT NULL
             );
@@ -704,14 +706,18 @@ export default class Sqlite implements DIDsDb {
                     `INSERT INTO network_metric_snapshots (
                         snapshot_date,
                         agent_did_count,
+                        agent_did_counts_by_prefix,
                         credential_count,
+                        credential_did_counts_by_prefix,
                         schema_counts,
                         rebuilt_at
-                    ) VALUES (?, ?, ?, ?, ?)`,
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
                     [
                         snapshot.date,
                         snapshot.agentDidCount,
+                        JSON.stringify(snapshot.agentDidCountsByPrefix),
                         snapshot.credentialCount,
+                        JSON.stringify(snapshot.credentialDidCountsByPrefix),
                         JSON.stringify(snapshot.schemas),
                         snapshot.rebuiltAt,
                     ]
@@ -733,14 +739,18 @@ export default class Sqlite implements DIDsDb {
         const row = await this.db.get<{
             date: string;
             agentDidCount: number | string;
+            agentDidCountsByPrefix: string;
             credentialCount: number | string;
+            credentialDidCountsByPrefix: string;
             schemaCounts: string;
             rebuiltAt: string;
         }>(
             `SELECT
                 snapshot_date AS date,
                 agent_did_count AS agentDidCount,
+                agent_did_counts_by_prefix AS agentDidCountsByPrefix,
                 credential_count AS credentialCount,
+                credential_did_counts_by_prefix AS credentialDidCountsByPrefix,
                 schema_counts AS schemaCounts,
                 rebuilt_at AS rebuiltAt
              FROM network_metric_snapshots
@@ -751,7 +761,9 @@ export default class Sqlite implements DIDsDb {
         return row ? {
             date: row.date,
             agentDidCount: Number(row.agentDidCount),
+            agentDidCountsByPrefix: JSON.parse(row.agentDidCountsByPrefix) as Record<string, number>,
             credentialCount: Number(row.credentialCount),
+            credentialDidCountsByPrefix: JSON.parse(row.credentialDidCountsByPrefix) as Record<string, number>,
             schemas: JSON.parse(row.schemaCounts) as PublishedCredentialSchemaCount[],
             rebuiltAt: row.rebuiltAt,
         } : null;

--- a/services/search-server/src/index.ts
+++ b/services/search-server/src/index.ts
@@ -241,15 +241,21 @@ async function main() {
 
     v1router.get("/metrics/schemas/published", async (req, res) => {
         try {
+            if (req.query.date !== undefined) {
+                return res.status(400).json({
+                    error: 'Use /api/v1/metrics/snapshots/schemas/:date for historical snapshots',
+                });
+            }
+
             const schemas = await didDb.getPublishedCredentialCountsBySchema();
-            res.json({ schemas });
+            return res.json({ schemas });
         } catch (error) {
             log.error({ error }, '/metrics/schemas/published error');
-            res.status(500).json({ error: String(error) });
+            return res.status(500).json({ error: String(error) });
         }
     });
 
-    v1router.get('/metrics/network/snapshots/:date', async (req, res) => {
+    v1router.get('/metrics/snapshots/schemas/:date', async (req, res) => {
         try {
             const date = parseSnapshotDate(req.params.date);
             if (!date) {
@@ -261,10 +267,35 @@ async function main() {
                 return res.status(404).json({ error: 'Snapshot not found' });
             }
 
-            return res.json(snapshot);
+            return res.json({ schemas: snapshot.schemas });
         }
         catch (error) {
-            log.error({ error }, '/metrics/network/snapshots/:date error');
+            log.error({ error }, '/metrics/snapshots/schemas/:date error');
+            return res.status(500).json({ error: String(error) });
+        }
+    });
+
+    v1router.get('/metrics/snapshots/credentials/:date', async (req, res) => {
+        try {
+            const date = parseSnapshotDate(req.params.date);
+            if (!date) {
+                return res.status(400).json({ error: 'date must be a valid, non-future UTC date in YYYY-MM-DD format' });
+            }
+
+            const snapshot = await didDb.getNetworkMetricSnapshot(date);
+            if (!snapshot) {
+                return res.status(404).json({ error: 'Snapshot not found' });
+            }
+
+            return res.json({
+                agentDidCount: snapshot.agentDidCount,
+                agentDidCountsByPrefix: snapshot.agentDidCountsByPrefix,
+                credentialCount: snapshot.credentialCount,
+                credentialDidCountsByPrefix: snapshot.credentialDidCountsByPrefix,
+            });
+        }
+        catch (error) {
+            log.error({ error }, '/metrics/snapshots/credentials/:date error');
             return res.status(500).json({ error: String(error) });
         }
     });

--- a/services/search-server/src/network-metrics.ts
+++ b/services/search-server/src/network-metrics.ts
@@ -20,6 +20,7 @@ export interface NetworkMetricsBuildResult {
 }
 
 interface CredentialEvidence {
+    credentialDid: string;
     schemas: Set<string>;
     validFrom: Set<string>;
 }
@@ -74,6 +75,32 @@ function increment(counts: Map<string, number>, key: string): void {
     counts.set(key, (counts.get(key) ?? 0) + 1);
 }
 
+function didPrefix(did: string): string {
+    return did.split(':', 2).join(':');
+}
+
+function didSuffix(did: string): string {
+    return did.split(':').pop()!;
+}
+
+function incrementPrefix(
+    deltas: Map<string, Map<string, number>>,
+    day: string,
+    did: string
+): void {
+    const dayDeltas = deltas.get(day) ?? new Map<string, number>();
+    increment(dayDeltas, didPrefix(did));
+    deltas.set(day, dayDeltas);
+}
+
+function sortedPrefixCounts(counts: Map<string, number>): Record<string, number> {
+    return Object.fromEntries(Array.from(counts).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+function totalPrefixCounts(counts: Map<string, number>): number {
+    return Array.from(counts.values()).reduce((total, count) => total + count, 0);
+}
+
 function incrementSchema(
     deltas: Map<string, Map<string, number>>,
     day: string,
@@ -90,8 +117,14 @@ function nextDay(day: string): string {
     return utcDay(date);
 }
 
-function sortedSchemaCounts(counts: Map<string, number>): PublishedCredentialSchemaCount[] {
-    return Array.from(counts, ([schemaDid, count]) => ({ schemaDid, count }))
+function sortedSchemaCounts(
+    counts: Map<string, number>,
+    schemaDids: Map<string, string>
+): PublishedCredentialSchemaCount[] {
+    return Array.from(counts, ([schemaKey, count]) => ({
+        schemaDid: schemaDids.get(schemaKey) as string,
+        count,
+    }))
         .sort((a, b) => b.count - a.count || a.schemaDid.localeCompare(b.schemaDid));
 }
 
@@ -113,9 +146,10 @@ export async function buildNetworkMetricSnapshots(
     now: Date = new Date()
 ): Promise<NetworkMetricsBuildResult> {
     const today = utcDay(now);
-    const agentDeltas = new Map<string, number>();
-    const credentialDeltas = new Map<string, number>();
+    const agentPrefixDeltas = new Map<string, Map<string, number>>();
+    const credentialPrefixDeltas = new Map<string, Map<string, number>>();
     const schemaDeltas = new Map<string, Map<string, number>>();
+    const schemaDids = new Map<string, string>();
     const assetCreationDays = new Map<string, ReturnType<typeof creationDay>>();
     const credentials = new Map<string, CredentialEvidence>();
     let invalidCreatedTimes = 0;
@@ -130,7 +164,7 @@ export async function buildNetworkMetricSnapshots(
         const anchor = history.events[0]?.operation;
 
         if (anchor?.type === 'create' && anchor.mdip?.type === 'asset') {
-            assetCreationDays.set(history.did, creationDay(anchor, today));
+            assetCreationDays.set(didSuffix(history.did), creationDay(anchor, today));
         }
 
         if (anchor?.type !== 'create' || anchor.mdip?.type !== 'agent') {
@@ -139,7 +173,7 @@ export async function buildNetworkMetricSnapshots(
 
         const created = creationDay(anchor, today);
         if (created.day) {
-            increment(agentDeltas, created.day);
+            incrementPrefix(agentPrefixDeltas, created.day, history.did);
         }
         else if (created.future) {
             futureCreatedOperations += 1;
@@ -156,27 +190,33 @@ export async function buildNetworkMetricSnapshots(
 
             for (const evidence of extractPublishedCredentialEvidence(history.did, doc)) {
                 const { credential, validFrom } = evidence;
-                const found = credentials.get(credential.credentialDid) ?? {
+                const credentialKey = didSuffix(credential.credentialDid);
+                const found = credentials.get(credentialKey) ?? {
+                    credentialDid: credential.credentialDid,
                     schemas: new Set<string>(),
                     validFrom: new Set<string>(),
                 };
-                found.schemas.add(credential.schemaDid);
+                const schemaKey = didSuffix(credential.schemaDid);
+                found.schemas.add(schemaKey);
+                if (!schemaDids.has(schemaKey)) {
+                    schemaDids.set(schemaKey, credential.schemaDid);
+                }
                 if (validFrom) {
                     found.validFrom.add(validFrom);
                 }
-                credentials.set(credential.credentialDid, found);
+                credentials.set(credentialKey, found);
             }
         }
     }
 
-    for (const [credentialDid, evidence] of credentials) {
+    for (const [credentialKey, evidence] of credentials) {
         if (evidence.schemas.size !== 1) {
             credentialsWithConflictingSchemas += 1;
             continue;
         }
 
-        const schemaDid = evidence.schemas.values().next().value as string;
-        const created = assetCreationDays.get(credentialDid);
+        const schemaKey = evidence.schemas.values().next().value as string;
+        const created = assetCreationDays.get(credentialKey);
         let day: string | undefined;
 
         if (created) {
@@ -214,29 +254,35 @@ export async function buildNetworkMetricSnapshots(
             }
         }
 
-        increment(credentialDeltas, day);
-        incrementSchema(schemaDeltas, day, schemaDid);
+        incrementPrefix(credentialPrefixDeltas, day, evidence.credentialDid);
+        incrementSchema(schemaDeltas, day, schemaKey);
     }
 
-    const deltaDays = [...agentDeltas.keys(), ...credentialDeltas.keys()];
+    const deltaDays = [...agentPrefixDeltas.keys(), ...credentialPrefixDeltas.keys()];
     const firstDay = deltaDays.sort()[0] ?? today;
     const rebuiltAt = now.toISOString();
     const snapshots: NetworkMetricSnapshot[] = [];
+    const agentDidCountsByPrefix = new Map<string, number>();
+    const credentialDidCountsByPrefix = new Map<string, number>();
     const schemaCounts = new Map<string, number>();
-    let agentDidCount = 0;
-    let credentialCount = 0;
 
     for (let day = firstDay; day <= today; day = nextDay(day)) {
-        agentDidCount += agentDeltas.get(day) ?? 0;
-        credentialCount += credentialDeltas.get(day) ?? 0;
+        for (const [prefix, count] of agentPrefixDeltas.get(day) ?? []) {
+            agentDidCountsByPrefix.set(prefix, (agentDidCountsByPrefix.get(prefix) ?? 0) + count);
+        }
+        for (const [prefix, count] of credentialPrefixDeltas.get(day) ?? []) {
+            credentialDidCountsByPrefix.set(prefix, (credentialDidCountsByPrefix.get(prefix) ?? 0) + count);
+        }
         for (const [schemaDid, count] of schemaDeltas.get(day) ?? []) {
             schemaCounts.set(schemaDid, (schemaCounts.get(schemaDid) ?? 0) + count);
         }
         snapshots.push({
             date: day,
-            agentDidCount,
-            credentialCount,
-            schemas: sortedSchemaCounts(schemaCounts),
+            agentDidCount: totalPrefixCounts(agentDidCountsByPrefix),
+            agentDidCountsByPrefix: sortedPrefixCounts(agentDidCountsByPrefix),
+            credentialCount: totalPrefixCounts(credentialDidCountsByPrefix),
+            credentialDidCountsByPrefix: sortedPrefixCounts(credentialDidCountsByPrefix),
+            schemas: sortedSchemaCounts(schemaCounts, schemaDids),
             rebuiltAt,
         });
     }

--- a/services/search-server/src/types.ts
+++ b/services/search-server/src/types.ts
@@ -120,7 +120,9 @@ export interface DIDEventHistory {
 export interface NetworkMetricSnapshot {
     date: string;
     agentDidCount: number;
+    agentDidCountsByPrefix: Record<string, number>;
     credentialCount: number;
+    credentialDidCountsByPrefix: Record<string, number>;
     schemas: PublishedCredentialSchemaCount[];
     rebuiltAt: string;
 }

--- a/tests/search-server/network-metrics.test.ts
+++ b/tests/search-server/network-metrics.test.ts
@@ -145,10 +145,10 @@ describe('network metric snapshot builder', () => {
         const result = await buildNetworkMetricSnapshots(histories, new Date('2026-08-05T12:00:00.000Z'));
 
         expect(result.snapshots).toStrictEqual([
-            { date: '2026-08-02', agentDidCount: 1, credentialCount: 0, schemas: [], rebuiltAt: '2026-08-05T12:00:00.000Z' },
-            { date: '2026-08-03', agentDidCount: 1, credentialCount: 1, schemas: [{ schemaDid: 'did:test:schema', count: 1 }], rebuiltAt: '2026-08-05T12:00:00.000Z' },
-            { date: '2026-08-04', agentDidCount: 1, credentialCount: 1, schemas: [{ schemaDid: 'did:test:schema', count: 1 }], rebuiltAt: '2026-08-05T12:00:00.000Z' },
-            { date: '2026-08-05', agentDidCount: 1, credentialCount: 1, schemas: [{ schemaDid: 'did:test:schema', count: 1 }], rebuiltAt: '2026-08-05T12:00:00.000Z' },
+            { date: '2026-08-02', agentDidCount: 1, agentDidCountsByPrefix: { 'did:test': 1 }, credentialCount: 0, credentialDidCountsByPrefix: {}, schemas: [], rebuiltAt: '2026-08-05T12:00:00.000Z' },
+            { date: '2026-08-03', agentDidCount: 1, agentDidCountsByPrefix: { 'did:test': 1 }, credentialCount: 1, credentialDidCountsByPrefix: { 'did:test': 1 }, schemas: [{ schemaDid: 'did:test:schema', count: 1 }], rebuiltAt: '2026-08-05T12:00:00.000Z' },
+            { date: '2026-08-04', agentDidCount: 1, agentDidCountsByPrefix: { 'did:test': 1 }, credentialCount: 1, credentialDidCountsByPrefix: { 'did:test': 1 }, schemas: [{ schemaDid: 'did:test:schema', count: 1 }], rebuiltAt: '2026-08-05T12:00:00.000Z' },
+            { date: '2026-08-05', agentDidCount: 1, agentDidCountsByPrefix: { 'did:test': 1 }, credentialCount: 1, credentialDidCountsByPrefix: { 'did:test': 1 }, schemas: [{ schemaDid: 'did:test:schema', count: 1 }], rebuiltAt: '2026-08-05T12:00:00.000Z' },
         ]);
         expect(result.credentialsDatedByOperationCreated).toBe(1);
         expect(result.credentialsDatedByValidFrom).toBe(0);
@@ -183,6 +183,82 @@ describe('network metric snapshot builder', () => {
         expect(result.credentialsDatedByOperationCreated).toBe(0);
         expect(result.credentialsDatedByValidFrom).toBe(3);
         expect(result.credentialsWithoutUsableDate).toBe(0);
+    });
+
+    it('groups cumulative agent and credential totals by DID prefix', async () => {
+        const testHolder = 'did:test:holder';
+        const mdipHolder = 'did:mdip:holder';
+        const histories = [
+            createAgentHistory(testHolder, '2026-08-01T00:00:00.000Z', [
+                manifestUpdate(testHolder, 'did:test:test-credential'),
+            ]),
+            createAgentHistory(mdipHolder, '2026-08-02T00:00:00.000Z', [
+                manifestUpdate(mdipHolder, 'did:mdip:mdip-credential'),
+            ]),
+            createCredentialHistory('did:test:test-credential', '2026-08-02T00:00:00.000Z'),
+            createCredentialHistory('did:mdip:mdip-credential', '2026-08-03T00:00:00.000Z'),
+        ];
+
+        const result = await buildNetworkMetricSnapshots(histories, new Date('2026-08-03T12:00:00.000Z'));
+
+        expect(result.snapshots[0]).toMatchObject({
+            agentDidCount: 1,
+            agentDidCountsByPrefix: { 'did:test': 1 },
+            credentialCount: 0,
+            credentialDidCountsByPrefix: {},
+        });
+        expect(result.snapshots.at(-1)).toMatchObject({
+            agentDidCount: 2,
+            agentDidCountsByPrefix: { 'did:mdip': 1, 'did:test': 1 },
+            credentialCount: 2,
+            credentialDidCountsByPrefix: { 'did:mdip': 1, 'did:test': 1 },
+        });
+    });
+
+    it('deduplicates credential prefix aliases and matches their asset anchor by suffix', async () => {
+        const holderDid = 'did:test:holder';
+        const histories = [
+            createAgentHistory(holderDid, '2026-08-01T00:00:00.000Z', [
+                manifestUpdate(holderDid, 'did:mdip:credential', {
+                    validFrom: '2026-08-01T00:00:00.000Z',
+                }),
+                manifestUpdate(holderDid, 'did:test:credential', {
+                    validFrom: '2026-08-01T00:00:00.000Z',
+                }),
+            ]),
+            createCredentialHistory('did:test:credential', '2026-08-03T00:00:00.000Z'),
+        ];
+
+        const result = await buildNetworkMetricSnapshots(histories, new Date('2026-08-03T12:00:00.000Z'));
+
+        expect(result.snapshots.find(snapshot => snapshot.date === '2026-08-02')).toMatchObject({
+            credentialCount: 0,
+            credentialDidCountsByPrefix: {},
+        });
+        expect(result.snapshots.at(-1)).toMatchObject({
+            credentialCount: 1,
+            credentialDidCountsByPrefix: { 'did:mdip': 1 },
+            schemas: [{ schemaDid: 'did:test:schema', count: 1 }],
+        });
+        expect(result.credentialsDatedByOperationCreated).toBe(1);
+        expect(result.credentialsDatedByValidFrom).toBe(0);
+    });
+
+    it('combines schema prefix aliases without reporting a conflict', async () => {
+        const holderDid = 'did:test:holder';
+        const histories = [createAgentHistory(holderDid, '2026-08-01T00:00:00.000Z', [
+            manifestUpdate(holderDid, 'did:test:credential-a', { schemaDid: 'did:mdip:schema' }),
+            manifestUpdate(holderDid, 'did:test:credential-a', { schemaDid: 'did:test:schema' }),
+            manifestUpdate(holderDid, 'did:test:credential-b', { schemaDid: 'did:test:schema' }),
+        ])];
+
+        const result = await buildNetworkMetricSnapshots(histories, new Date('2026-08-01T12:00:00.000Z'));
+
+        expect(result.snapshots.at(-1)).toMatchObject({
+            credentialCount: 2,
+            schemas: [{ schemaDid: 'did:mdip:schema', count: 2 }],
+        });
+        expect(result.credentialsWithConflictingSchemas).toBe(0);
     });
 
     it('moves fallback history when a late asset anchor arrives', async () => {
@@ -313,7 +389,7 @@ describe('network metric snapshot builder', () => {
         expect(baseline.snapshots[0]).toMatchObject({ date: '2024-01-01', agentDidCount: 1 });
         expect(baseline.snapshots).toHaveLength(3);
         expect(empty.snapshots).toStrictEqual([
-            { date: '2024-01-03', agentDidCount: 0, credentialCount: 0, schemas: [], rebuiltAt: now.toISOString() },
+            { date: '2024-01-03', agentDidCount: 0, agentDidCountsByPrefix: {}, credentialCount: 0, credentialDidCountsByPrefix: {}, schemas: [], rebuiltAt: now.toISOString() },
         ]);
     });
 
@@ -385,7 +461,9 @@ describe.each(adapterFactories)('$name network metric persistence', ({ create })
         const first: NetworkMetricSnapshot = {
             date: '2026-08-01',
             agentDidCount: 1,
+            agentDidCountsByPrefix: { 'did:test': 1 },
             credentialCount: 0,
+            credentialDidCountsByPrefix: {},
             schemas: [{ schemaDid: 'did:test:schema', count: 1 }],
             rebuiltAt: '2026-08-03T00:00:00.000Z',
         };
@@ -409,7 +487,9 @@ describe('network metric database branches', () => {
     const snapshot: NetworkMetricSnapshot = {
         date: '2026-08-01',
         agentDidCount: 2,
+        agentDidCountsByPrefix: { 'did:mdip': 1, 'did:test': 1 },
         credentialCount: 1,
+        credentialDidCountsByPrefix: { 'did:test': 1 },
         schemas: [{ schemaDid: 'did:test:schema', count: 1 }],
         rebuiltAt: '2026-08-03T00:00:00.000Z',
     };
@@ -485,7 +565,13 @@ describe('network metric database branches', () => {
                     rows: [{
                         date: params[0],
                         agentDidCount: snapshot.agentDidCount,
+                        agentDidCountsByPrefix: params[0] === snapshot.date
+                            ? JSON.stringify(snapshot.agentDidCountsByPrefix)
+                            : snapshot.agentDidCountsByPrefix,
                         credentialCount: snapshot.credentialCount,
+                        credentialDidCountsByPrefix: params[0] === snapshot.date
+                            ? JSON.stringify(snapshot.credentialDidCountsByPrefix)
+                            : snapshot.credentialDidCountsByPrefix,
                         schemaCounts: params[0] === snapshot.date
                             ? JSON.stringify(snapshot.schemas)
                             : snapshot.schemas,
@@ -523,7 +609,9 @@ describe('network metric database branches', () => {
             [
                 snapshot.date,
                 snapshot.agentDidCount,
+                JSON.stringify(snapshot.agentDidCountsByPrefix),
                 snapshot.credentialCount,
+                JSON.stringify(snapshot.credentialDidCountsByPrefix),
                 JSON.stringify(snapshot.schemas),
                 snapshot.rebuiltAt,
             ]


### PR DESCRIPTION
  ## Overview

Extends daily network snapshots with AgentDID and credential totals broken down by DID prefix. Updates Explorer to display these totals and retain historical schema usage and date navigation.

  ## API changes

  - Add `GET /api/v1/metrics/snapshots/credentials/:date`
  - Add `GET /api/v1/metrics/snapshots/schemas/:date`