### PR TITLE
fix(search): canonicalize and deduplicate DID prefixes

### DIFF
--- a/packages/gatekeeper/src/db/index-export.ts
+++ b/packages/gatekeeper/src/db/index-export.ts
@@ -192,12 +192,12 @@ export async function buildIndexChangesResponse(
         }
     }
 
-    const dids: IndexExportDIDRecord[] = [];
+    const dids = new Map<string, IndexExportDIDRecord>();
     const eventsByDid = new Map<string, GatekeeperEvent[]>();
 
     for (const [did, change] of didChanges.entries()) {
         if (change.removed) {
-            dids.push({
+            dids.set(did, {
                 did,
                 events: [],
                 removed: true,
@@ -207,7 +207,9 @@ export async function buildIndexChangesResponse(
 
         const events = eventsByDid.get(did) ?? await getEvents(did);
         eventsByDid.set(did, events);
-        dids.push({ did, events });
+        const canonicalDid = getDidFromEvents(did, events);
+        dids.delete(canonicalDid);
+        dids.set(canonicalDid, { did: canonicalDid, events });
     }
 
     const blocks = Array.from(blockChanges.values())
@@ -224,7 +226,7 @@ export async function buildIndexChangesResponse(
         cursor,
         checkpointCursor,
         hasMore,
-        dids,
+        dids: Array.from(dids.values()),
         blocks,
     };
 

--- a/services/search-server/src/DidIndexer.ts
+++ b/services/search-server/src/DidIndexer.ts
@@ -338,6 +338,7 @@ export default class DidIndexer {
             await this.db.saveSyncState(INDEX_SYNC_STATE_KEYS.metricsLastError, null);
             this.log.info({
                 snapshots: result.snapshots.length,
+                agentsWithConflictingPrefixes: result.agentsWithConflictingPrefixes,
                 invalidCreatedTimes: result.invalidCreatedTimes,
                 futureCreatedOperations: result.futureCreatedOperations,
                 credentialsDatedByOperationCreated: result.credentialsDatedByOperationCreated,

--- a/services/search-server/src/network-metrics.ts
+++ b/services/search-server/src/network-metrics.ts
@@ -10,6 +10,7 @@ export const NETWORK_METRICS_EPOCH = '2024-01-01';
 
 export interface NetworkMetricsBuildResult {
     snapshots: NetworkMetricSnapshot[];
+    agentsWithConflictingPrefixes: number;
     invalidCreatedTimes: number;
     futureCreatedOperations: number;
     credentialsDatedByOperationCreated: number;
@@ -23,6 +24,13 @@ interface CredentialEvidence {
     credentialDid: string;
     schemas: Set<string>;
     validFrom: Set<string>;
+}
+
+interface AgentEvidence {
+    created: ReturnType<typeof creationDay>;
+    createPrefix?: string;
+    fallbackPrefix: string;
+    referencedPrefixes: Set<string>;
 }
 
 function utcDay(date: Date): string {
@@ -86,10 +94,10 @@ function didSuffix(did: string): string {
 function incrementPrefix(
     deltas: Map<string, Map<string, number>>,
     day: string,
-    did: string
+    prefix: string
 ): void {
     const dayDeltas = deltas.get(day) ?? new Map<string, number>();
-    increment(dayDeltas, didPrefix(did));
+    increment(dayDeltas, prefix);
     deltas.set(day, dayDeltas);
 }
 
@@ -150,8 +158,10 @@ export async function buildNetworkMetricSnapshots(
     const credentialPrefixDeltas = new Map<string, Map<string, number>>();
     const schemaDeltas = new Map<string, Map<string, number>>();
     const schemaDids = new Map<string, string>();
+    const agents = new Map<string, AgentEvidence>();
     const assetCreationDays = new Map<string, ReturnType<typeof creationDay>>();
     const credentials = new Map<string, CredentialEvidence>();
+    let agentsWithConflictingPrefixes = 0;
     let invalidCreatedTimes = 0;
     let futureCreatedOperations = 0;
     let credentialsDatedByOperationCreated = 0;
@@ -171,18 +181,20 @@ export async function buildNetworkMetricSnapshots(
             continue;
         }
 
-        const created = creationDay(anchor, today);
-        if (created.day) {
-            incrementPrefix(agentPrefixDeltas, created.day, history.did);
-        }
-        else if (created.future) {
-            futureCreatedOperations += 1;
-        }
-        else {
-            invalidCreatedTimes += 1;
-        }
+        const agentKey = didSuffix(history.did);
+        const foundAgent = agents.get(agentKey) ?? {
+            created: creationDay(anchor, today),
+            createPrefix: anchor.mdip.prefix,
+            fallbackPrefix: didPrefix(history.events[0]?.did ?? history.did),
+            referencedPrefixes: new Set<string>(),
+        };
+        foundAgent.createPrefix ??= anchor.mdip.prefix;
 
         for (const event of history.events) {
+            if ((event.operation.type === 'update' || event.operation.type === 'delete') &&
+                typeof event.operation.did === 'string') {
+                foundAgent.referencedPrefixes.add(didPrefix(event.operation.did));
+            }
             const doc = event.operation.type === 'update' ? event.operation.doc : undefined;
             if (!doc) {
                 continue;
@@ -207,6 +219,28 @@ export async function buildNetworkMetricSnapshots(
                 credentials.set(credentialKey, found);
             }
         }
+        agents.set(agentKey, foundAgent);
+    }
+
+    for (const evidence of agents.values()) {
+        const { created } = evidence;
+        if (created.future) {
+            futureCreatedOperations += 1;
+            continue;
+        }
+        if (!created.day) {
+            invalidCreatedTimes += 1;
+            continue;
+        }
+
+        let prefix = evidence.createPrefix ?? evidence.fallbackPrefix;
+        if (evidence.referencedPrefixes.size === 1 && !evidence.createPrefix) {
+            prefix = evidence.referencedPrefixes.values().next().value as string;
+        }
+        else if (evidence.referencedPrefixes.size > 1) {
+            agentsWithConflictingPrefixes += 1;
+        }
+        incrementPrefix(agentPrefixDeltas, created.day, prefix);
     }
 
     for (const [credentialKey, evidence] of credentials) {
@@ -254,7 +288,7 @@ export async function buildNetworkMetricSnapshots(
             }
         }
 
-        incrementPrefix(credentialPrefixDeltas, day, evidence.credentialDid);
+        incrementPrefix(credentialPrefixDeltas, day, didPrefix(evidence.credentialDid));
         incrementSchema(schemaDeltas, day, schemaKey);
     }
 
@@ -289,6 +323,7 @@ export async function buildNetworkMetricSnapshots(
 
     return {
         snapshots,
+        agentsWithConflictingPrefixes,
         invalidCreatedTimes,
         futureCreatedOperations,
         credentialsDatedByOperationCreated,

--- a/tests/gatekeeper/index-export.test.ts
+++ b/tests/gatekeeper/index-export.test.ts
@@ -1288,6 +1288,28 @@ describe('Gatekeeper DB index snapshot export', () => {
         ]);
     });
 
+    it('canonicalizes prefix aliases in incremental DID histories', async () => {
+        const canonicalDid = 'did:test:z1';
+        const aliasDid = 'did:mdip:z1';
+        const create = createEvent(canonicalDid, '2026-01-01T00:00:01.000Z');
+        const update = createEvent(aliasDid, '2026-01-01T00:00:02.000Z', 'update');
+
+        await db.addEvent(canonicalDid, create);
+        await db.addEvent(aliasDid, update);
+
+        const changes = await db.exportIndexChanges({ includeOperations: true });
+
+        expect(changes.cursor).toBe('2');
+        expect(changes.dids).toStrictEqual([{
+            did: canonicalDid,
+            events: [create, update],
+        }]);
+        expect(changes.operations?.map(record => record.did)).toStrictEqual([
+            canonicalDid,
+            aliasDid,
+        ]);
+    });
+
     it('pages incremental changes by cursor and limit', async () => {
         const didA = 'did:test:z1';
         const didB = 'did:test:z2';

--- a/tests/search-server/network-metrics.test.ts
+++ b/tests/search-server/network-metrics.test.ts
@@ -187,7 +187,7 @@ describe('network metric snapshot builder', () => {
 
     it('groups cumulative agent and credential totals by DID prefix', async () => {
         const testHolder = 'did:test:holder';
-        const mdipHolder = 'did:mdip:holder';
+        const mdipHolder = 'did:mdip:mdip-holder';
         const histories = [
             createAgentHistory(testHolder, '2026-08-01T00:00:00.000Z', [
                 manifestUpdate(testHolder, 'did:test:test-credential'),
@@ -213,6 +213,47 @@ describe('network metric snapshot builder', () => {
             credentialCount: 2,
             credentialDidCountsByPrefix: { 'did:mdip': 1, 'did:test': 1 },
         });
+    });
+
+    it('deduplicates agent aliases and selects one observed prefix per CID', async () => {
+        const observedDid = 'did:test:observed';
+        const observed = createAgentHistory(observedDid, '2026-08-01T00:00:00.000Z', [
+            createEvent('did:mdip:observed', {
+                type: 'update',
+                did: 'did:mdip:observed',
+            }),
+        ]);
+        const explicit = createAgentHistory('did:test:explicit', '2026-08-01T00:00:00.000Z', [
+            createEvent('did:test:explicit', {
+                type: 'update',
+                did: 'did:test:explicit',
+            }),
+        ]);
+        explicit.events[0].operation.mdip!.prefix = 'did:mdip';
+        const conflicting = createAgentHistory('did:test:conflicting', '2026-08-01T00:00:00.000Z', [
+            createEvent('did:test:conflicting', {
+                type: 'update',
+                did: 'did:test:conflicting',
+            }),
+            createEvent('did:mdip:conflicting', {
+                type: 'update',
+                did: 'did:mdip:conflicting',
+            }),
+        ]);
+
+        const result = await buildNetworkMetricSnapshots([
+            observed,
+            { did: 'did:mdip:observed', events: observed.events },
+            createAgentHistory('did:test:unchanged', '2026-08-01T00:00:00.000Z'),
+            explicit,
+            conflicting,
+        ], new Date('2026-08-01T12:00:00.000Z'));
+
+        expect(result.snapshots.at(-1)).toMatchObject({
+            agentDidCount: 4,
+            agentDidCountsByPrefix: { 'did:mdip': 2, 'did:test': 2 },
+        });
+        expect(result.agentsWithConflictingPrefixes).toBe(1);
     });
 
     it('deduplicates credential prefix aliases and matches their asset anchor by suffix', async () => {


### PR DESCRIPTION
## Overview

Prevents DID prefix aliases from creating duplicate search records or inflating agent network metrics.

- Canonicalises incremental Gatekeeper DID histories using the same create-event identity as full snapshots.
- Collapses `did:test:<CID>` and `did:mdip:<CID>` history aliases while preserving raw operation records and cursors.
- Deduplicates agent metrics by CID suffix.
  - Uses explicit `create.mdip.prefix` first, then a unique update/delete prefix, and finally the prefix assigned to the create event by Gatekeeper with `KC_GATEKEEPER_DID_PREFIX`.
  - Falls back to the create prefix when conflicting update prefixes exist.
  - Keeps `agentDidCount` equal to the sum of its prefix breakdown.