### PR TITLE
fix(gatekeeper): clean expired dependencies

### DIFF
--- a/doc/gatekeeper-api.json
+++ b/doc/gatekeeper-api.json
@@ -1898,10 +1898,10 @@
     },
     "/db/verify": {
       "get": {
-        "summary": "Verify all DIDs in the database",
+        "summary": "Check all DIDs in the database",
         "responses": {
           "200": {
-            "description": "Verification results for all DIDs in the database.",
+            "description": "Resolution and expiry results for all DIDs in the database.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1913,15 +1913,15 @@
                     },
                     "verified": {
                       "type": "integer",
-                      "description": "The count of DIDs that passed verification."
+                      "description": "The count of cached or successfully resolved DIDs retained."
                     },
                     "expired": {
                       "type": "integer",
-                      "description": "The count of DIDs that had expired and were removed."
+                      "description": "The count of expired DIDs and their dependencies that were removed."
                     },
                     "invalid": {
                       "type": "integer",
-                      "description": "The count of DIDs that failed verification and were removed."
+                      "description": "The count of DIDs that failed resolution and were removed."
                     }
                   }
                 }

--- a/packages/gatekeeper/src/gatekeeper.ts
+++ b/packages/gatekeeper/src/gatekeeper.ts
@@ -48,11 +48,14 @@ enum ImportStatus {
     DEFERRED = 'deferred',
 }
 
+const retryableResolutionErrors = new WeakSet<object>();
+
 export default class Gatekeeper implements GatekeeperInterface {
     private db: GatekeeperDb;
     private eventsQueue: GatekeeperEvent[];
     private readonly eventsSeen: Record<string, boolean>;
     private verifiedDIDs: Record<string, boolean>;
+    private mutationRevision: number;
     private isProcessingEvents: boolean;
     private ipfs?: IPFSClient;
     private cipher: CipherNode;
@@ -63,6 +66,9 @@ export default class Gatekeeper implements GatekeeperInterface {
     private readonly ipfsEnabled: boolean;
     supportedRegistries: string[];
     private didLocks = new Map<string, Promise<void>>();
+    private activeMutations = new Set<string>();
+    private pendingExpiredControllers = new Map<string, string>();
+    private verifyDbInFlight?: Promise<VerifyDbResult>;
     constructor(options: GatekeeperOptions) {
         if (!options || !options.db) {
             throw new InvalidParameterError('missing options.db');
@@ -76,6 +82,7 @@ export default class Gatekeeper implements GatekeeperInterface {
         this.eventsQueue = [];
         this.eventsSeen = {};
         this.verifiedDIDs = {};
+        this.mutationRevision = 0;
         this.isProcessingEvents = false;
         this.ipfsEnabled = options.ipfsEnabled ?? true;
         if (this.ipfsEnabled) {
@@ -105,85 +112,309 @@ export default class Gatekeeper implements GatekeeperInterface {
         }
     }
 
+    private didKey(did: string): string {
+        return did.split(':').pop() || did;
+    }
+
+    private async readForResolution<T>(read: () => Promise<T>): Promise<T> {
+        try {
+            return await read();
+        }
+        catch (error) {
+            if (typeof error === 'object' && error !== null) {
+                retryableResolutionErrors.add(error);
+            }
+            throw error;
+        }
+    }
+
+    private invalidateVerifiedDID(did: string): void {
+        this.mutationRevision += 1;
+        delete this.verifiedDIDs[this.didKey(did)];
+    }
+
+    private async mutateDID<T>(did: string, fn: () => Promise<T>): Promise<T> {
+        const key = this.didKey(did);
+        this.activeMutations.add(key);
+        this.invalidateVerifiedDID(did);
+        try {
+            return await fn();
+        }
+        finally {
+            this.invalidateVerifiedDID(did);
+            this.activeMutations.delete(key);
+        }
+    }
+
     private async withDidLock<T>(did: string, fn: () => Promise<T>): Promise<T> {
-        const prev = this.didLocks.get(did) ?? Promise.resolve();
+        const key = this.didKey(did);
+        const prev = this.didLocks.get(key) ?? Promise.resolve();
         let release: () => void = () => { };
         const gate = new Promise<void>(r => (release = r));
+        const current = prev.then(() => gate, () => gate);
 
-        this.didLocks.set(did, prev.then(() => gate, () => gate));
+        this.didLocks.set(key, current);
 
         try {
             await prev;
             return await fn();
         } finally {
             release();
-            if (this.didLocks.get(did) === gate) {
-                this.didLocks.delete(did);
+            if (this.didLocks.get(key) === current) {
+                this.didLocks.delete(key);
             }
         }
     }
 
-    async verifyDb(options?: { chatty?: boolean }): Promise<VerifyDbResult> {
+    verifyDb(options?: { chatty?: boolean }): Promise<VerifyDbResult> {
+        this.verifyDbInFlight ??= this.runVerifyDb(options).finally(() => {
+            this.verifyDbInFlight = undefined;
+        });
+        return this.verifyDbInFlight;
+    }
+
+    private async runVerifyDb(options?: { chatty?: boolean }): Promise<VerifyDbResult> {
         const chatty = options?.chatty ?? true;
         const dids = await this.getDIDs() as string[];
         const total = dids.length;
-        let n = 0;
-        let expired = 0;
-        let invalid = 0;
-        let verified = Object.keys(this.verifiedDIDs).length;
-
+        const snapshotKeys = new Set(dids.map(did => this.didKey(did)));
+        const now = Date.now();
+        const inspectedDIDs = new Set<string>();
+        const expiredDIDs = new Set<string>();
+        const expiredAgents = new Set<string>();
+        const failedDIDs = new Set<string>();
+        const dependents = new Map<string, string[]>();
         const verifyStart = chatty ? Date.now() : 0;
-
-        for (const did of dids) {
-            n += 1;
-
-            if (this.verifiedDIDs[did]) {
-                continue;
-            }
-
-            let validUntil = null;
-
+        const resolveCurrent = async (did: string): Promise<{
+            doc?: MdipDocument;
+            expiresAt?: number;
+            invalid: boolean;
+            notFound?: boolean;
+            retryable?: boolean;
+        }> => {
             try {
-                const doc = await this.resolveDID(did, { verify: true });
-                validUntil = doc.mdip?.validUntil;
+                const doc = await this.resolveDID(did);
+                if (doc.didResolutionMetadata?.error) {
+                    return {
+                        invalid: true,
+                        notFound: doc.didResolutionMetadata.error === 'notFound',
+                    };
+                }
+
+                const validUntil = doc.mdip?.validUntil;
+                if (!validUntil) {
+                    return { doc, invalid: false };
+                }
+
+                const expiresAt = new Date(validUntil).getTime();
+                return isNaN(expiresAt)
+                    ? { doc, invalid: false }
+                    : { doc, expiresAt, invalid: false };
+            }
+            catch (error) {
+                const retryable = typeof error === 'object'
+                    && error !== null
+                    && retryableResolutionErrors.has(error);
+                return { invalid: !retryable, retryable };
+            }
+        };
+
+        const inspectDID = async (did: string, n: number): Promise<void> => {
+            inspectedDIDs.add(did);
+            const key = this.didKey(did);
+            const revision = this.mutationRevision;
+            try {
+                const { doc, expiresAt, invalid, retryable } = await resolveCurrent(did);
+                if (invalid || retryable || !doc) {
+                    throw new InvalidOperationError('DID resolution failed');
+                }
+
+                const controller = doc.didDocument?.controller;
+                if (controller) {
+                    const controllerKey = this.didKey(controller);
+                    const controlledDIDs = dependents.get(controllerKey) ?? [];
+                    controlledDIDs.push(did);
+                    dependents.set(controllerKey, controlledDIDs);
+                }
+
+                if (expiresAt !== undefined) {
+                    if (expiresAt < now) {
+                        if (chatty) {
+                            this.log.warn(`${n}/${total} ${did} expired`);
+                        }
+                        expiredDIDs.add(did);
+                        if (doc.mdip?.type === 'agent') {
+                            expiredAgents.add(did);
+                        }
+                    }
+                    else if (chatty) {
+                        const minutesLeft = Math.round((expiresAt - now) / 60 / 1000);
+                        this.log.debug(`expiring ${n}/${total} ${did} in ${minutesLeft} minutes`);
+                    }
+                    return;
+                }
+
+                if (chatty) {
+                    this.log.debug(`resolved ${n}/${total} ${did} OK`);
+                }
+                if (revision === this.mutationRevision && !this.activeMutations.has(key)) {
+                    this.verifiedDIDs[key] = true;
+                }
             }
             catch {
                 if (chatty) {
-                    this.log.warn(`removing ${n}/${total} ${did} invalid`);
+                    this.log.warn(`${n}/${total} ${did} invalid`);
                 }
-                invalid += 1;
-                await this.db.deleteEvents(did);
+                failedDIDs.add(did);
+            }
+        };
+
+        for (let n = 0; n < dids.length; n += 1) {
+            const did = dids[n];
+            if (!this.verifiedDIDs[this.didKey(did)]) {
+                await inspectDID(did, n + 1);
+            }
+        }
+
+        if (expiredAgents.size > 0 || failedDIDs.size > 0 || this.pendingExpiredControllers.size > 0) {
+            for (let n = 0; n < dids.length; n += 1) {
+                const did = dids[n];
+                if (!inspectedDIDs.has(did)) {
+                    await inspectDID(did, n + 1);
+                }
+            }
+        }
+
+        const removedExpiredDIDs = new Set<string>();
+        const removedInvalidDIDs = new Set<string>();
+        let dependencyDiscoveryFailed = false;
+
+        for (const did of failedDIDs) {
+            await this.withDidLock(did, async () => {
+                const current = await resolveCurrent(did);
+                if (current.retryable) {
+                    dependencyDiscoveryFailed = true;
+                    return;
+                }
+                if (current.invalid || !current.doc) {
+                    await this.removeDIDUnlocked(did);
+                    removedInvalidDIDs.add(did);
+                    return;
+                }
+
+                const controller = current.doc.didDocument?.controller;
+                if (controller) {
+                    const controllerKey = this.didKey(controller);
+                    const controlledDIDs = dependents.get(controllerKey) ?? [];
+                    controlledDIDs.push(did);
+                    dependents.set(controllerKey, controlledDIDs);
+                }
+
+                if (current.expiresAt !== undefined && current.expiresAt < Date.now()) {
+                    expiredDIDs.add(did);
+                    if (current.doc.mdip?.type === 'agent') {
+                        expiredAgents.add(did);
+                    }
+                }
+            });
+        }
+
+        const expiredControllers = new Map(this.pendingExpiredControllers);
+        for (const agentDID of expiredAgents) {
+            expiredControllers.set(this.didKey(agentDID), agentDID);
+        }
+
+        for (const [agentKey, agentDID] of expiredControllers) {
+            await this.withDidLock(agentDID, async () => {
+                const agent = await resolveCurrent(agentDID);
+                if (agent.retryable) {
+                    this.pendingExpiredControllers.set(agentKey, agentDID);
+                    return;
+                }
+                if (agent.notFound) {
+                    this.pendingExpiredControllers.set(agentKey, agentDID);
+                    if (snapshotKeys.has(agentKey)) {
+                        removedExpiredDIDs.add(agentDID);
+                    }
+                }
+                else if (agent.invalid) {
+                    this.pendingExpiredControllers.set(agentKey, agentDID);
+                    return;
+                }
+                else if (agent.doc?.mdip?.type !== 'agent'
+                    || agent.expiresAt === undefined
+                    || agent.expiresAt >= Date.now()) {
+                    this.pendingExpiredControllers.delete(agentKey);
+                    return;
+                }
+                if (dependencyDiscoveryFailed) {
+                    this.pendingExpiredControllers.set(agentKey, agentDID);
+                    return;
+                }
+
+                let revalidationFailed = false;
+                for (const assetDID of dependents.get(agentKey) ?? []) {
+                    await this.withDidLock(assetDID, async () => {
+                        const asset = await resolveCurrent(assetDID);
+                        const controller = asset.doc?.didDocument?.controller;
+                        if (asset.notFound) {
+                            removedExpiredDIDs.add(assetDID);
+                            return;
+                        }
+                        if (asset.invalid || asset.retryable) {
+                            revalidationFailed = true;
+                        }
+                        else if (asset.doc?.mdip?.type === 'asset'
+                            && controller
+                            && this.didKey(controller) === agentKey) {
+                            await this.removeDIDUnlocked(assetDID);
+                            removedExpiredDIDs.add(assetDID);
+                        }
+                    });
+                    if (revalidationFailed) {
+                        this.pendingExpiredControllers.set(agentKey, agentDID);
+                        return;
+                    }
+                }
+
+                if (!agent.notFound) {
+                    await this.removeDIDUnlocked(agentDID);
+                    removedExpiredDIDs.add(agentDID);
+                }
+                this.pendingExpiredControllers.delete(agentKey);
+            });
+        }
+
+        for (const did of expiredDIDs) {
+            if (expiredAgents.has(did) || removedExpiredDIDs.has(did) || removedInvalidDIDs.has(did)) {
                 continue;
             }
 
-            if (validUntil) {
-                const expires = new Date(validUntil);
-                const now = new Date();
-
-                if (expires < now) {
-                    if (chatty) {
-                        this.log.warn(`removing ${n}/${total} ${did} expired`);
-                    }
-                    await this.db.deleteEvents(did);
-                    expired += 1;
+            await this.withDidLock(did, async () => {
+                const current = await resolveCurrent(did);
+                if (current.retryable) {
+                    return;
                 }
-                else {
-                    const minutesLeft = Math.round((expires.getTime() - now.getTime()) / 60 / 1000);
-
-                    if (chatty) {
-                        this.log.debug(`expiring ${n}/${total} ${did} in ${minutesLeft} minutes`);
-                    }
-                    verified += 1;
+                if (current.notFound) {
+                    removedExpiredDIDs.add(did);
                 }
-            }
-            else {
-                if (chatty) {
-                    this.log.debug(`verifying ${n}/${total} ${did} OK`);
+                else if (current.invalid) {
+                    await this.removeDIDUnlocked(did);
+                    removedInvalidDIDs.add(did);
                 }
-                this.verifiedDIDs[did] = true;
-                verified += 1;
-            }
+                else if (current.expiresAt !== undefined && current.expiresAt < Date.now()) {
+                    await this.removeDIDUnlocked(did);
+                    removedExpiredDIDs.add(did);
+                }
+            });
         }
+
+        const invalidKeys = new Set([...removedInvalidDIDs].map(did => this.didKey(did)));
+        const expired = new Set([...removedExpiredDIDs]
+            .map(did => this.didKey(did))
+            .filter(key => !invalidKeys.has(key))).size;
+        const invalid = invalidKeys.size;
+        const verified = total - expired - invalid;
 
         // Clear queue of permanently invalid events
         this.eventsQueue = [];
@@ -279,9 +510,11 @@ export default class Gatekeeper implements GatekeeperInterface {
 
     // For testing purposes
     async resetDb(): Promise<boolean> {
-        await this.db.resetDb();
-        this.clearEventsSeen();
+        this.mutationRevision += 1;
         this.verifiedDIDs = {};
+        await this.db.resetDb();
+        this.pendingExpiredControllers.clear();
+        this.clearEventsSeen();
         this.eventsQueue = [];
         return true;
     }
@@ -544,14 +777,13 @@ export default class Gatekeeper implements GatekeeperInterface {
                 return did;
             }
 
-            await this.db.addEvent(did, {
+            await this.mutateDID(did, () => this.db.addEvent(did, {
                 registry: 'local',
                 time: operation.created!,
                 ordinal: [0],
                 operation,
                 did
-            });
-
+            }));
             await this.queueOperation(registry, operation);
             return did;
         });
@@ -569,7 +801,9 @@ export default class Gatekeeper implements GatekeeperInterface {
         did?: string,
         options?: ResolveDIDOptions
     ): Promise<MdipDocument> {
-        const events = did && isValidDID(did) ? await this.db.getEvents(did) : [];
+        const events = did && isValidDID(did)
+            ? await this.readForResolution(() => this.db.getEvents(did))
+            : [];
 
         return resolveDIDFromEvents({
             did,
@@ -578,7 +812,7 @@ export default class Gatekeeper implements GatekeeperInterface {
             didPrefix: this.didPrefix,
             generateCID: (operation) => this.generateCID(operation),
             generateDID: (operation) => this.generateDID(operation),
-            getBlock: (registry, block) => this.db.getBlock(registry, block),
+            getBlock: (registry, block) => this.readForResolution(() => this.db.getBlock(registry, block)),
             verifyCreateOperation: (operation) => this.verifyCreateOperation(operation),
             verifyUpdateOperation: (operation, doc) => this.verifyUpdateOperation(operation, doc),
         });
@@ -589,29 +823,28 @@ export default class Gatekeeper implements GatekeeperInterface {
             throw new InvalidOperationError('missing operation.did')
         }
 
-        const doc = await this.resolveDID(operation.did);
-        const updateValid = await this.verifyUpdateOperation(operation, doc);
-
-        if (!updateValid) {
-            return false;
-        }
-
-        const registry = doc.mdip?.registry;
-
-        // Reject operations with unsupported registries
-        if (!registry || !this.supportedRegistries.includes(registry)) {
-            throw new InvalidOperationError(`registry ${registry} not supported`);
-        }
-
         return this.withDidLock(operation.did, async () => {
-            await this.db.addEvent(operation.did!, {
+            const doc = await this.resolveDID(operation.did);
+            const updateValid = await this.verifyUpdateOperation(operation, doc);
+
+            if (!updateValid) {
+                return false;
+            }
+
+            const registry = doc.mdip?.registry;
+
+            // Reject operations with unsupported registries
+            if (!registry || !this.supportedRegistries.includes(registry)) {
+                throw new InvalidOperationError(`registry ${registry} not supported`);
+            }
+
+            await this.mutateDID(operation.did!, () => this.db.addEvent(operation.did!, {
                 registry: 'local',
                 time: operation.signature?.signed || '',
                 ordinal: [0],
                 operation,
                 did: operation.did
-            });
-
+            }));
             await this.queueOperation(registry, operation);
 
             return true;
@@ -691,13 +924,17 @@ export default class Gatekeeper implements GatekeeperInterface {
         return this.importBatch(dids.flat());
     }
 
+    private async removeDIDUnlocked(did: string): Promise<void> {
+        await this.mutateDID(did, () => this.db.deleteEvents(did));
+    }
+
     async removeDIDs(dids: string[]): Promise<boolean> {
         if (!Array.isArray(dids)) {
             throw new InvalidParameterError('dids');
         }
 
         for (const did of dids) {
-            await this.db.deleteEvents(did);
+            await this.withDidLock(did, () => this.removeDIDUnlocked(did));
         }
 
         return true;
@@ -748,7 +985,7 @@ export default class Gatekeeper implements GatekeeperInterface {
                         // If this import is on the native registry, replace the current one
                         const index = currentEvents.indexOf(opMatch);
                         currentEvents[index] = event;
-                        await this.db.setEvents(lockedDid, currentEvents);
+                        await this.mutateDID(lockedDid, () => this.db.setEvents(lockedDid, currentEvents));
                         return ImportStatus.ADDED;
                     }
 
@@ -761,13 +998,13 @@ export default class Gatekeeper implements GatekeeperInterface {
                     }
 
                     if (currentEvents.length === 0) {
-                        await this.db.addEvent(lockedDid, event);
+                        await this.mutateDID(lockedDid, () => this.db.addEvent(lockedDid, event));
                         return ImportStatus.ADDED;
                     }
 
                     // TEMP during did:test, operation.previd is optional
                     if (!event.operation.previd) {
-                        await this.db.addEvent(lockedDid, event);
+                        await this.mutateDID(lockedDid, () => this.db.addEvent(lockedDid, event));
                         return ImportStatus.ADDED;
                     }
 
@@ -780,7 +1017,7 @@ export default class Gatekeeper implements GatekeeperInterface {
                     const index = currentEvents.indexOf(idMatch);
 
                     if (index === currentEvents.length - 1) {
-                        await this.db.addEvent(lockedDid, event);
+                        await this.mutateDID(lockedDid, () => this.db.addEvent(lockedDid, event));
                         return ImportStatus.ADDED;
                     }
 
@@ -794,9 +1031,9 @@ export default class Gatekeeper implements GatekeeperInterface {
                             (event.ordinal && nextEvent.ordinal && compareOrdinals(event.ordinal, nextEvent.ordinal) < 0)) {
                             // reorg event, discard the rest of the operation sequence and replace with this event
                             const newSequence = [...currentEvents.slice(0, index + 1), event];
-                            await this.db.setEvents(lockedDid, newSequence, {
+                            await this.mutateDID(lockedDid, () => this.db.setEvents(lockedDid, newSequence, {
                                 operationEvents: [event],
-                            });
+                            }));
                             return ImportStatus.ADDED;
                         }
                     }

--- a/sample.env
+++ b/sample.env
@@ -14,7 +14,7 @@ KC_GATEKEEPER_REGISTRIES=hyperswarm
 KC_GATEKEEPER_JSON_LIMIT=10mb
 KC_GATEKEEPER_MAX_OP_BYTES=262144
 KC_GATEKEEPER_GC_INTERVAL=60
-KC_GATEKEEPER_STATUS_INTERVAL=0 # Periodic status report. 0 = disabled. An initial report runs at startup.
+KC_GATEKEEPER_STATUS_INTERVAL=5 # Periodic status report. 0 = disabled. An initial report runs at startup.
 KC_GATEKEEPER_SERVE_CLIENT=true
 KC_GATEKEEPER_TRUST_PROXY=false # Trust proxy headers. Set if behind reverse proxy/load balancer
 KC_GATEKEEPER_RATE_LIMIT_ENABLED=false # Whether the rate limiter is enabled

--- a/sample.env
+++ b/sample.env
@@ -14,7 +14,7 @@ KC_GATEKEEPER_REGISTRIES=hyperswarm
 KC_GATEKEEPER_JSON_LIMIT=10mb
 KC_GATEKEEPER_MAX_OP_BYTES=262144
 KC_GATEKEEPER_GC_INTERVAL=60
-KC_GATEKEEPER_STATUS_INTERVAL=1
+KC_GATEKEEPER_STATUS_INTERVAL=0 # Periodic status report. 0 = disabled. An initial report runs at startup.
 KC_GATEKEEPER_SERVE_CLIENT=true
 KC_GATEKEEPER_TRUST_PROXY=false # Trust proxy headers. Set if behind reverse proxy/load balancer
 KC_GATEKEEPER_RATE_LIMIT_ENABLED=false # Whether the rate limiter is enabled

--- a/scripts/admin-cli.js
+++ b/scripts/admin-cli.js
@@ -317,7 +317,7 @@ program
 
 program
     .command('verify-db')
-    .description('Verify all the DIDs in the db')
+    .description('Check all the DIDs in the db and remove expired dependencies')
     .action(async () => {
         try {
             const response = await gatekeeper.verifyDb();

--- a/services/gatekeeper/server/src/gatekeeper-api.ts
+++ b/services/gatekeeper/server/src/gatekeeper-api.ts
@@ -1718,11 +1718,11 @@ v1router.get('/db/reset', trackedRoute(async (req, res) => {
  * @swagger
  * /db/verify:
  *   get:
- *     summary: Verify all DIDs in the database
+ *     summary: Check all DIDs in the database
  *
  *     responses:
  *       200:
- *         description: Verification results for all DIDs in the database.
+ *         description: Resolution and expiry results for all DIDs in the database.
  *         content:
  *           application/json:
  *             schema:
@@ -1733,13 +1733,13 @@ v1router.get('/db/reset', trackedRoute(async (req, res) => {
  *                   description: The total number of DIDs that were checked.
  *                 verified:
  *                   type: integer
- *                   description: The count of DIDs that passed verification.
+ *                   description: The count of cached or successfully resolved DIDs retained.
  *                 expired:
  *                   type: integer
- *                   description: The count of DIDs that had expired and were removed.
+ *                   description: The count of expired DIDs and their dependencies that were removed.
  *                 invalid:
  *                   type: integer
- *                   description: The count of DIDs that failed verification and were removed.
+ *                   description: The count of DIDs that failed resolution and were removed.
  *       500:
  *         description: Internal Server Error.
  *         content:

--- a/tests/gatekeeper/helper.ts
+++ b/tests/gatekeeper/helper.ts
@@ -18,9 +18,10 @@ export default class TestHelper {
             version?: number;
             registry?: string;
             prefix?: string;
+            validUntil?: string;
         } = {}
     ): Promise<Operation> {
-        const { version = 1, registry = 'local', prefix } = options;
+        const { version = 1, registry = 'local', prefix, validUntil } = options;
         const operation: Operation = {
             type: "create",
             created: new Date().toISOString(),
@@ -34,6 +35,9 @@ export default class TestHelper {
 
         if (prefix) {
             operation.mdip!.prefix = prefix;
+        }
+        if (validUntil) {
+            operation.mdip!.validUntil = validUntil;
         }
 
         const msgHash = this.cipher.hashJSON(operation);

--- a/tests/gatekeeper/sync.test.ts
+++ b/tests/gatekeeper/sync.test.ts
@@ -202,6 +202,73 @@ describe('removeDIDs', () => {
         const ok = await gatekeeper.removeDIDs(['did:test:mock']);
         expect(ok).toBe(true);
     });
+
+    it('should serialize removals through DID aliases', async () => {
+        const order: string[] = [];
+        let signalStarted: () => void = () => { };
+        let releaseFirst: () => void = () => { };
+        const started = new Promise<void>(resolve => (signalStarted = resolve));
+        const release = new Promise<void>(resolve => (releaseFirst = resolve));
+        const deleteEvents = jest.spyOn(db, 'deleteEvents')
+            .mockImplementationOnce(async () => {
+                order.push('first started');
+                signalStarted();
+                await release;
+                order.push('first finished');
+            })
+            .mockImplementationOnce(async () => {
+                order.push('second started');
+            });
+
+        try {
+            const first = gatekeeper.removeDIDs(['did:test:mock']);
+            await started;
+            const second = gatekeeper.removeDIDs(['did:custom:mock']);
+            await Promise.resolve();
+            expect(order).toStrictEqual(['first started']);
+
+            releaseFirst();
+            await Promise.all([first, second]);
+            expect(order).toStrictEqual(['first started', 'first finished', 'second started']);
+            const didLocks = (gatekeeper as unknown as { didLocks: Map<string, Promise<void>> }).didLocks;
+            expect(didLocks.has('mock')).toBe(false);
+        }
+        finally {
+            releaseFirst();
+            deleteEvents.mockRestore();
+        }
+    });
+
+    it('should not append an update after a concurrent removal', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const did = await gatekeeper.createDID(await helper.createAgentOp(keypair));
+        const updateOp = await helper.createUpdateOp(keypair, did, await gatekeeper.resolveDID(did));
+        const originalDeleteEvents = db.deleteEvents.bind(db);
+        let signalRemoval: () => void = () => { };
+        let releaseRemoval: () => void = () => { };
+        const removalStarted = new Promise<void>(resolve => (signalRemoval = resolve));
+        const removalRelease = new Promise<void>(resolve => (releaseRemoval = resolve));
+        const deleteEvents = jest.spyOn(db, 'deleteEvents').mockImplementationOnce(async (removedDID) => {
+            signalRemoval();
+            await removalRelease;
+            return originalDeleteEvents(removedDID);
+        });
+
+        const removal = gatekeeper.removeDIDs([did]);
+        try {
+            await removalStarted;
+            const update = expect(gatekeeper.updateDID(updateOp)).rejects.toThrow('doc.didDocument');
+            releaseRemoval();
+            await removal;
+            await update;
+            expect(await gatekeeper.exportDID(did)).toStrictEqual([]);
+        }
+        finally {
+            releaseRemoval();
+            await removal.catch(() => { });
+            deleteEvents.mockRestore();
+        }
+    });
 });
 
 describe('exportBatch', () => {

--- a/tests/gatekeeper/sync.test.ts
+++ b/tests/gatekeeper/sync.test.ts
@@ -201,6 +201,7 @@ describe('removeDIDs', () => {
     it('should return true if unknown DIDs specified', async () => {
         const ok = await gatekeeper.removeDIDs(['did:test:mock']);
         expect(ok).toBe(true);
+        await expect(gatekeeper.removeDIDs([''])).rejects.toThrow('Invalid DID');
     });
 
     it('should serialize removals through DID aliases', async () => {

--- a/tests/gatekeeper/verify.test.ts
+++ b/tests/gatekeeper/verify.test.ts
@@ -2,6 +2,7 @@ import CipherNode from '@mdip/cipher/node';
 import Gatekeeper from '@mdip/gatekeeper';
 import DbJsonMemory from '@mdip/gatekeeper/db/json-memory.ts';
 import HeliaClient from '@mdip/ipfs/helia';
+import { jest } from '@jest/globals';
 import TestHelper from './helper.ts';
 
 const mockConsole = {
@@ -56,9 +57,12 @@ describe('verifyDb', () => {
         await gatekeeper.createDID(assetOp);
 
         const verify1 = await gatekeeper.verifyDb();
+        const resolveDID = jest.spyOn(gatekeeper, 'resolveDID');
         const verify2 = await gatekeeper.verifyDb();
 
         expect(verify1).toStrictEqual(verify2);
+        expect(resolveDID).not.toHaveBeenCalled();
+        resolveDID.mockRestore();
     });
 
     it('should get same results with chatty turned off', async () => {
@@ -74,7 +78,62 @@ describe('verifyDb', () => {
         expect(verify1).toStrictEqual(verify2);
     });
 
-    it('should remove invalid DIDs', async () => {
+    it('should share an in-flight verification run', async () => {
+        let signalRun: () => void = () => { };
+        let releaseRun: () => void = () => { };
+        const runStarted = new Promise<void>(resolve => (signalRun = resolve));
+        const runRelease = new Promise<void>(resolve => (releaseRun = resolve));
+        const getDIDs = jest.spyOn(gatekeeper, 'getDIDs').mockImplementationOnce(async () => {
+            signalRun();
+            await runRelease;
+            return [];
+        });
+
+        const first = gatekeeper.verifyDb({ chatty: false });
+        try {
+            await runStarted;
+            const second = gatekeeper.verifyDb({ chatty: false });
+            expect(second).toBe(first);
+            expect(getDIDs).toHaveBeenCalledTimes(1);
+
+            releaseRun();
+            await expect(Promise.all([first, second])).resolves.toStrictEqual([
+                { total: 0, verified: 0, expired: 0, invalid: 0 },
+                { total: 0, verified: 0, expired: 0, invalid: 0 },
+            ]);
+
+            await gatekeeper.verifyDb({ chatty: false });
+            expect(getDIDs).toHaveBeenCalledTimes(2);
+        }
+        finally {
+            releaseRun();
+            await first.catch(() => { });
+            getDIDs.mockRestore();
+        }
+    });
+
+    it('should allow verification to retry after failure', async () => {
+        const getDIDs = jest.spyOn(gatekeeper, 'getDIDs')
+            .mockRejectedValueOnce(new Error('mock failure'));
+
+        try {
+            const first = gatekeeper.verifyDb({ chatty: false });
+            expect(gatekeeper.verifyDb({ chatty: false })).toBe(first);
+            await expect(first).rejects.toThrow('mock failure');
+            await expect(gatekeeper.verifyDb({ chatty: false })).resolves.toStrictEqual({
+                total: 0,
+                verified: 0,
+                expired: 0,
+                invalid: 0,
+            });
+            expect(getDIDs).toHaveBeenCalledTimes(2);
+        }
+        finally {
+            getDIDs.mockRestore();
+        }
+    });
+
+    it('should leave signature auditing to explicit verified resolution', async () => {
         const keypair = cipher.generateRandomJwk();
         const agentOp = await helper.createAgentOp(keypair);
         const agentDID = await gatekeeper.createDID(agentOp);
@@ -91,10 +150,11 @@ describe('verifyDb', () => {
 
         const { verified, expired, invalid, total } = await gatekeeper.verifyDb();
 
-        expect(verified).toBe(0);
+        expect(verified).toBe(1);
         expect(expired).toBe(0);
-        expect(invalid).toBe(1);
+        expect(invalid).toBe(0);
         expect(total).toBe(1);
+        await expect(gatekeeper.resolveDID(assetDID, { verify: true })).rejects.toThrow();
     });
 
     it('should remove expired DIDs', async () => {
@@ -119,6 +179,603 @@ describe('verifyDb', () => {
         expect(expired).toBe(1);
         expect(invalid).toBe(0);
         expect(total).toBe(3);
+    });
+
+    it('should count an expired DID removed after the scan as expired', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const agentDID = await gatekeeper.createDID(await helper.createAgentOp(keypair));
+        const assetDID = await gatekeeper.createDID(await helper.createAssetOp(agentDID, keypair, {
+            validUntil: new Date(Date.now() - 1_000).toISOString(),
+        }));
+        const originalResolveDID = gatekeeper.resolveDID.bind(gatekeeper);
+        const staleAssetDoc = await originalResolveDID(assetDID);
+        await gatekeeper.removeDIDs([assetDID]);
+        const getDIDs = jest.spyOn(gatekeeper, 'getDIDs').mockResolvedValueOnce([agentDID, assetDID]);
+        let assetResolutions = 0;
+        const resolveDID = jest.spyOn(gatekeeper, 'resolveDID').mockImplementation(async (did, options) => {
+            if (did === assetDID && ++assetResolutions === 1) {
+                return staleAssetDoc;
+            }
+            return originalResolveDID(did, options);
+        });
+
+        try {
+            expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+                total: 2,
+                verified: 1,
+                expired: 1,
+                invalid: 0,
+            });
+            expect(await gatekeeper.getDIDs()).toStrictEqual([agentDID]);
+        }
+        finally {
+            getDIDs.mockRestore();
+            resolveDID.mockRestore();
+        }
+    });
+
+    it('should remove cached assets before an expired agent with a custom prefix', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const expiresAt = Date.now() + 60_000;
+        const agentOp = await helper.createAgentOp(keypair, {
+            prefix: 'did:custom',
+            validUntil: new Date(expiresAt).toISOString(),
+        });
+        const agentDID = await gatekeeper.createDID(agentOp);
+        const assetDID1 = await gatekeeper.createDID(await helper.createAssetOp(agentDID, keypair));
+        const assetDID2 = await gatekeeper.createDID(await helper.createAssetOp(agentDID, keypair));
+
+        expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+            total: 3,
+            verified: 3,
+            expired: 0,
+            invalid: 0,
+        });
+
+        const resolveDID = jest.spyOn(gatekeeper, 'resolveDID');
+        const deleteEvents = jest.spyOn(db, 'deleteEvents');
+        jest.useFakeTimers();
+        jest.setSystemTime(expiresAt + 1);
+        try {
+            expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+                total: 3,
+                verified: 0,
+                expired: 3,
+                invalid: 0,
+            });
+            expect(resolveDID).toHaveBeenCalledTimes(6);
+            expect(deleteEvents.mock.calls.map(([did]) => did.split(':').pop())).toStrictEqual([
+                assetDID1,
+                assetDID2,
+                agentDID,
+            ].map(did => did.split(':').pop()));
+            expect(await gatekeeper.getDIDs()).toStrictEqual([]);
+        }
+        finally {
+            jest.useRealTimers();
+            resolveDID.mockRestore();
+            deleteEvents.mockRestore();
+        }
+    });
+
+    it('should not remove an agent renewed after the GC scan', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const expiresAt = Date.now() + 60_000;
+        const agentDID = await gatekeeper.createDID(await helper.createAgentOp(keypair, {
+            validUntil: new Date(expiresAt).toISOString(),
+        }));
+        const assetDID = await gatekeeper.createDID(await helper.createAssetOp(agentDID, keypair));
+        await gatekeeper.verifyDb({ chatty: false });
+
+        const originalResolveDID = gatekeeper.resolveDID.bind(gatekeeper);
+        let pauseAgentResolution = true;
+        let signalResolution: () => void = () => { };
+        let releaseResolution: () => void = () => { };
+        const resolutionStarted = new Promise<void>(resolve => (signalResolution = resolve));
+        const resolutionRelease = new Promise<void>(resolve => (releaseResolution = resolve));
+        const resolveDID = jest.spyOn(gatekeeper, 'resolveDID').mockImplementation(async (did, options) => {
+            const doc = await originalResolveDID(did, options);
+            if (did === agentDID && pauseAgentResolution) {
+                pauseAgentResolution = false;
+                signalResolution();
+                await resolutionRelease;
+            }
+            return doc;
+        });
+
+        jest.useFakeTimers();
+        jest.setSystemTime(expiresAt + 1);
+        const gc = gatekeeper.verifyDb({ chatty: false });
+        try {
+            await resolutionStarted;
+            const agentDoc = await originalResolveDID(agentDID);
+            agentDoc.mdip!.validUntil = new Date(expiresAt + 60_000).toISOString();
+            expect(await gatekeeper.updateDID(
+                await helper.createUpdateOp(keypair, agentDID, agentDoc),
+            )).toBe(true);
+
+            releaseResolution();
+            expect(await gc).toStrictEqual({
+                total: 2,
+                verified: 2,
+                expired: 0,
+                invalid: 0,
+            });
+            expect(await gatekeeper.getDIDs()).toStrictEqual([agentDID, assetDID]);
+        }
+        finally {
+            releaseResolution();
+            await gc.catch(() => { });
+            jest.useRealTimers();
+            resolveDID.mockRestore();
+        }
+    });
+
+    it('should retry an expired agent when dependent revalidation fails', async () => {
+        const expiredKeys = cipher.generateRandomJwk();
+        const liveKeys = cipher.generateRandomJwk();
+        const expiredAgent = await gatekeeper.createDID(await helper.createAgentOp(expiredKeys, {
+            validUntil: new Date(Date.now() - 1_000).toISOString(),
+        }));
+        const liveAgent = await gatekeeper.createDID(await helper.createAgentOp(liveKeys));
+        const assetDID = await gatekeeper.createDID(await helper.createAssetOp(expiredAgent, expiredKeys));
+        const originalResolveDID = gatekeeper.resolveDID.bind(gatekeeper);
+        const staleAssetDoc = await originalResolveDID(assetDID);
+        const assetDoc = await originalResolveDID(assetDID);
+        assetDoc.didDocument!.controller = liveAgent;
+        expect(await gatekeeper.updateDID(
+            await helper.createUpdateOp(expiredKeys, assetDID, assetDoc),
+        )).toBe(true);
+
+        const originalGetEvents = db.getEvents.bind(db);
+        let failAssetRead = true;
+        const getEvents = jest.spyOn(db, 'getEvents').mockImplementation(async did => {
+            if (did === assetDID && failAssetRead) {
+                failAssetRead = false;
+                throw new Error('transient read failure');
+            }
+            return originalGetEvents(did);
+        });
+        let assetResolutions = 0;
+        const resolveDID = jest.spyOn(gatekeeper, 'resolveDID').mockImplementation(async (did, options) => {
+            if (did === assetDID && ++assetResolutions === 1) {
+                return staleAssetDoc;
+            }
+            return originalResolveDID(did, options);
+        });
+
+        try {
+            expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+                total: 3,
+                verified: 3,
+                expired: 0,
+                invalid: 0,
+            });
+            expect((await originalResolveDID(assetDID)).didDocument?.controller).toBe(liveAgent);
+            expect(await gatekeeper.getDIDs()).toStrictEqual([expiredAgent, liveAgent, assetDID]);
+        }
+        finally {
+            getEvents.mockRestore();
+            resolveDID.mockRestore();
+        }
+
+        expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+            total: 3,
+            verified: 2,
+            expired: 1,
+            invalid: 0,
+        });
+        expect(await gatekeeper.getDIDs()).toStrictEqual([liveAgent, assetDID]);
+    });
+
+    it('should retry failed dependency discovery before removing an expired agent', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const agentDID = await gatekeeper.createDID(await helper.createAgentOp(keypair, {
+            validUntil: new Date(Date.now() - 1_000).toISOString(),
+        }));
+        const assetDID = await gatekeeper.createDID(await helper.createAssetOp(agentDID, keypair));
+        const originalGetEvents = db.getEvents.bind(db);
+        let failedAssetReads = 0;
+        const getEvents = jest.spyOn(db, 'getEvents').mockImplementation(async did => {
+            if (did === assetDID && failedAssetReads < 2) {
+                failedAssetReads += 1;
+                throw new Error('transient read failure');
+            }
+            return originalGetEvents(did);
+        });
+
+        try {
+            expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+                total: 2,
+                verified: 2,
+                expired: 0,
+                invalid: 0,
+            });
+            expect(await gatekeeper.getDIDs()).toStrictEqual([agentDID, assetDID]);
+        }
+        finally {
+            getEvents.mockRestore();
+        }
+
+        expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+            total: 2,
+            verified: 0,
+            expired: 2,
+            invalid: 0,
+        });
+        expect(await gatekeeper.getDIDs()).toStrictEqual([]);
+    });
+
+    it('should remove malformed DIDs without blocking expired agents', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const agentDID = await gatekeeper.createDID(await helper.createAgentOp(keypair, {
+            validUntil: new Date(Date.now() - 1_000).toISOString(),
+        }));
+        await gatekeeper.createDID(await helper.createAssetOp(agentDID, keypair));
+        const malformedDID = await gatekeeper.createDID(await helper.createAgentOp(keypair));
+        const events = await db.getEvents(malformedDID);
+        events[0].time = 'not-a-date';
+        await db.setEvents(malformedDID, events);
+
+        expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+            total: 3,
+            verified: 0,
+            expired: 2,
+            invalid: 1,
+        });
+        expect(await gatekeeper.getDIDs()).toStrictEqual([]);
+    });
+
+    it('should retain a renewed DID when cleanup revalidation fails', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const agentDID = await gatekeeper.createDID(await helper.createAgentOp(keypair));
+        const assetDID = await gatekeeper.createDID(await helper.createAssetOp(agentDID, keypair, {
+            validUntil: new Date(Date.now() - 1_000).toISOString(),
+        }));
+        const originalResolveDID = gatekeeper.resolveDID.bind(gatekeeper);
+        const staleAssetDoc = await originalResolveDID(assetDID);
+        const renewedAssetDoc = await originalResolveDID(assetDID);
+        renewedAssetDoc.mdip!.validUntil = new Date(Date.now() + 60_000).toISOString();
+        expect(await gatekeeper.updateDID(
+            await helper.createUpdateOp(keypair, assetDID, renewedAssetDoc),
+        )).toBe(true);
+
+        const originalGetEvents = db.getEvents.bind(db);
+        let failAssetRead = true;
+        const getEvents = jest.spyOn(db, 'getEvents').mockImplementation(async did => {
+            if (did === assetDID && failAssetRead) {
+                failAssetRead = false;
+                throw new Error('transient read failure');
+            }
+            return originalGetEvents(did);
+        });
+        let assetResolutions = 0;
+        const resolveDID = jest.spyOn(gatekeeper, 'resolveDID').mockImplementation(async (did, options) => {
+            if (did === assetDID && ++assetResolutions === 1) {
+                return staleAssetDoc;
+            }
+            return originalResolveDID(did, options);
+        });
+
+        try {
+            expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+                total: 2,
+                verified: 2,
+                expired: 0,
+                invalid: 0,
+            });
+            expect(await gatekeeper.getDIDs()).toStrictEqual([agentDID, assetDID]);
+        }
+        finally {
+            getEvents.mockRestore();
+            resolveDID.mockRestore();
+        }
+    });
+
+    it('should remove an expired agent when its dependent is already missing', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const agentDID = await gatekeeper.createDID(await helper.createAgentOp(keypair, {
+            validUntil: new Date(Date.now() - 1_000).toISOString(),
+        }));
+        const assetDID = await gatekeeper.createDID(await helper.createAssetOp(agentDID, keypair));
+        const originalResolveDID = gatekeeper.resolveDID.bind(gatekeeper);
+        const staleAssetDoc = await originalResolveDID(assetDID);
+        await gatekeeper.removeDIDs([assetDID]);
+        const getDIDs = jest.spyOn(gatekeeper, 'getDIDs').mockResolvedValueOnce([agentDID, assetDID]);
+        let assetResolutions = 0;
+        const resolveDID = jest.spyOn(gatekeeper, 'resolveDID').mockImplementation(async (did, options) => {
+            if (did === assetDID && ++assetResolutions === 1) {
+                return staleAssetDoc;
+            }
+            return originalResolveDID(did, options);
+        });
+
+        try {
+            expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+                total: 2,
+                verified: 0,
+                expired: 2,
+                invalid: 0,
+            });
+            expect(await gatekeeper.getDIDs()).toStrictEqual([]);
+        }
+        finally {
+            getDIDs.mockRestore();
+            resolveDID.mockRestore();
+        }
+    });
+
+    it('should retry scanned dependents when their expired agent is already missing', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const agentDID = await gatekeeper.createDID(await helper.createAgentOp(keypair, {
+            validUntil: new Date(Date.now() - 1_000).toISOString(),
+        }));
+        const assetDID = await gatekeeper.createDID(await helper.createAssetOp(agentDID, keypair));
+        const originalResolveDID = gatekeeper.resolveDID.bind(gatekeeper);
+        const staleAgentDoc = await originalResolveDID(agentDID);
+        await gatekeeper.removeDIDs([agentDID]);
+        const getDIDs = jest.spyOn(gatekeeper, 'getDIDs').mockResolvedValueOnce([agentDID, assetDID]);
+        let agentResolutions = 0;
+        const originalGetEvents = db.getEvents.bind(db);
+        let assetReads = 0;
+        const getEvents = jest.spyOn(db, 'getEvents').mockImplementation(async did => {
+            if (did === assetDID && ++assetReads === 2) {
+                throw new Error('transient read failure');
+            }
+            return originalGetEvents(did);
+        });
+        const resolveDID = jest.spyOn(gatekeeper, 'resolveDID').mockImplementation(async (did, options) => {
+            if (did === agentDID && ++agentResolutions === 1) {
+                return staleAgentDoc;
+            }
+            return originalResolveDID(did, options);
+        });
+
+        try {
+            expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+                total: 2,
+                verified: 1,
+                expired: 1,
+                invalid: 0,
+            });
+            expect(await gatekeeper.getDIDs()).toStrictEqual([assetDID]);
+        }
+        finally {
+            getDIDs.mockRestore();
+            getEvents.mockRestore();
+            resolveDID.mockRestore();
+        }
+
+        const resetDb = jest.spyOn(db, 'resetDb').mockRejectedValueOnce(new Error('reset failed'));
+        try {
+            await expect(gatekeeper.resetDb()).rejects.toThrow('reset failed');
+        }
+        finally {
+            resetDb.mockRestore();
+        }
+
+        expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+            total: 1,
+            verified: 0,
+            expired: 1,
+            invalid: 0,
+        });
+        expect(await gatekeeper.getDIDs()).toStrictEqual([]);
+    });
+
+    it('should classify a pending invalid controller only once', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const agentDID = await gatekeeper.createDID(await helper.createAgentOp(keypair, {
+            validUntil: new Date(Date.now() - 1_000).toISOString(),
+        }));
+        await gatekeeper.createDID(await helper.createAssetOp(agentDID, keypair));
+        const pending = (gatekeeper as unknown as {
+            pendingExpiredControllers: Map<string, string>;
+        }).pendingExpiredControllers;
+        pending.set(agentDID.split(':').pop()!, agentDID);
+        const originalResolveDID = gatekeeper.resolveDID.bind(gatekeeper);
+        let agentResolutions = 0;
+        const resolveDID = jest.spyOn(gatekeeper, 'resolveDID').mockImplementation(async (did, options) => {
+            if (did === agentDID && ++agentResolutions <= 2) {
+                return { didResolutionMetadata: { error: 'invalidDid' } };
+            }
+            return originalResolveDID(did, options);
+        });
+
+        try {
+            expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+                total: 2,
+                verified: 0,
+                expired: 1,
+                invalid: 1,
+            });
+            expect(await gatekeeper.getDIDs()).toStrictEqual([]);
+        }
+        finally {
+            resolveDID.mockRestore();
+        }
+    });
+
+    it('should invalidate cached expiry metadata through a DID alias', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const agentDID = await gatekeeper.createDID(await helper.createAgentOp(keypair, {
+            prefix: 'did:custom',
+        }));
+        await gatekeeper.verifyDb({ chatty: false });
+
+        const agentDoc = await gatekeeper.resolveDID(agentDID);
+        agentDoc.mdip!.validUntil = new Date(Date.now() - 1_000).toISOString();
+        expect(await gatekeeper.updateDID(
+            await helper.createUpdateOp(keypair, agentDID, agentDoc),
+        )).toBe(true);
+
+        expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+            total: 1,
+            verified: 0,
+            expired: 1,
+            invalid: 0,
+        });
+        expect(await gatekeeper.getDIDs()).toStrictEqual([]);
+    });
+
+    it('should invalidate cached expiry before an ambiguous write failure', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const agentDID = await gatekeeper.createDID(await helper.createAgentOp(keypair));
+        await gatekeeper.verifyDb({ chatty: false });
+
+        const agentDoc = await gatekeeper.resolveDID(agentDID);
+        agentDoc.mdip!.validUntil = new Date(Date.now() - 1_000).toISOString();
+        const updateOp = await helper.createUpdateOp(keypair, agentDID, agentDoc);
+        const originalAddEvent = db.addEvent.bind(db);
+        const addEvent = jest.spyOn(db, 'addEvent').mockImplementationOnce(async (did, event) => {
+            await originalAddEvent(did, event);
+            throw new Error('connection lost after commit');
+        });
+
+        try {
+            await expect(gatekeeper.updateDID(updateOp)).rejects.toThrow('connection lost after commit');
+            expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+                total: 1,
+                verified: 0,
+                expired: 1,
+                invalid: 0,
+            });
+            expect(await gatekeeper.getDIDs()).toStrictEqual([]);
+        }
+        finally {
+            addEvent.mockRestore();
+        }
+    });
+
+    it('should not cache a DID while its expiry update is pending', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const agentDID = await gatekeeper.createDID(await helper.createAgentOp(keypair));
+        await gatekeeper.verifyDb({ chatty: false });
+
+        const agentDoc = await gatekeeper.resolveDID(agentDID);
+        agentDoc.mdip!.validUntil = new Date(Date.now() - 1_000).toISOString();
+        const updateOp = await helper.createUpdateOp(keypair, agentDID, agentDoc);
+        const originalAddEvent = db.addEvent.bind(db);
+        let signalWrite: () => void = () => { };
+        let releaseWrite: () => void = () => { };
+        const writeStarted = new Promise<void>(resolve => (signalWrite = resolve));
+        const writeRelease = new Promise<void>(resolve => (releaseWrite = resolve));
+        const addEvent = jest.spyOn(db, 'addEvent').mockImplementationOnce(async (did, event) => {
+            signalWrite();
+            await writeRelease;
+            return originalAddEvent(did, event);
+        });
+
+        const update = gatekeeper.updateDID(updateOp);
+        try {
+            await writeStarted;
+            expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+                total: 1,
+                verified: 1,
+                expired: 0,
+                invalid: 0,
+            });
+
+            releaseWrite();
+            await update;
+            expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+                total: 1,
+                verified: 0,
+                expired: 1,
+                invalid: 0,
+            });
+            expect(await gatekeeper.getDIDs()).toStrictEqual([]);
+        }
+        finally {
+            releaseWrite();
+            await update.catch(() => { });
+            addEvent.mockRestore();
+        }
+    });
+
+    it('should retain a DID with a malformed expiry', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const agentDID = await gatekeeper.createDID(await helper.createAgentOp(keypair));
+        const agentDoc = await gatekeeper.resolveDID(agentDID);
+        agentDoc.mdip!.validUntil = 'not-a-date';
+        expect(await gatekeeper.updateDID(
+            await helper.createUpdateOp(keypair, agentDID, agentDoc),
+        )).toBe(true);
+
+        expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+            total: 1,
+            verified: 1,
+            expired: 0,
+            invalid: 0,
+        });
+        expect(await gatekeeper.getDIDs()).toStrictEqual([agentDID]);
+    });
+
+    it('should not restore cache invalidated during resolution', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const agentDID = await gatekeeper.createDID(await helper.createAgentOp(keypair));
+        const assetDID = await gatekeeper.createDID(await helper.createAssetOp(agentDID, keypair));
+        const originalResolveDID = gatekeeper.resolveDID.bind(gatekeeper);
+        let pauseAssetResolution = true;
+        let signalResolution: () => void = () => { };
+        let releaseResolution: () => void = () => { };
+        const resolutionStarted = new Promise<void>(resolve => (signalResolution = resolve));
+        const resolutionRelease = new Promise<void>(resolve => (releaseResolution = resolve));
+        const resolveDID = jest.spyOn(gatekeeper, 'resolveDID').mockImplementation(async (did, options) => {
+            const doc = await originalResolveDID(did, options);
+            if (did === assetDID && pauseAssetResolution) {
+                pauseAssetResolution = false;
+                signalResolution();
+                await resolutionRelease;
+            }
+            return doc;
+        });
+
+        const firstGc = gatekeeper.verifyDb({ chatty: false });
+        try {
+            await resolutionStarted;
+            const assetDoc = await originalResolveDID(assetDID);
+            assetDoc.mdip!.validUntil = new Date(Date.now() - 1_000).toISOString();
+            expect(await gatekeeper.updateDID(
+                await helper.createUpdateOp(keypair, assetDID, assetDoc),
+            )).toBe(true);
+
+            releaseResolution();
+            expect(await firstGc).toStrictEqual({
+                total: 2,
+                verified: 2,
+                expired: 0,
+                invalid: 0,
+            });
+
+            expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+                total: 2,
+                verified: 1,
+                expired: 1,
+                invalid: 0,
+            });
+            expect(await gatekeeper.getDIDs()).toStrictEqual([agentDID]);
+        }
+        finally {
+            releaseResolution();
+            await firstGc.catch(() => { });
+            resolveDID.mockRestore();
+        }
+    });
+
+    it('should not cascade from an agent deactivated by an operation', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const agentDID = await gatekeeper.createDID(await helper.createAgentOp(keypair));
+        const assetDID = await gatekeeper.createDID(await helper.createAssetOp(agentDID, keypair));
+        expect(await gatekeeper.deleteDID(await helper.createDeleteOp(keypair, agentDID))).toBe(true);
+
+        expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+            total: 2,
+            verified: 2,
+            expired: 0,
+            invalid: 0,
+        });
+        expect(await gatekeeper.getDIDs()).toStrictEqual([agentDID, assetDID]);
     });
 });
 

--- a/tests/gatekeeper/verify.test.ts
+++ b/tests/gatekeeper/verify.test.ts
@@ -258,6 +258,103 @@ describe('verifyDb', () => {
         }
     });
 
+    it('should re-resolve scan failures before classifying DIDs', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const expired = new Date(Date.now() - 1_000).toISOString();
+        const controllerDID = await gatekeeper.createDID(await helper.createAgentOp(keypair));
+        const assetDID1 = await gatekeeper.createDID(await helper.createAssetOp(controllerDID, keypair, {
+            validUntil: expired,
+        }));
+        const assetDID2 = await gatekeeper.createDID(await helper.createAssetOp(controllerDID, keypair, {
+            validUntil: expired,
+        }));
+        const expiredAgentDID = await gatekeeper.createDID(await helper.createAgentOp(keypair, {
+            validUntil: expired,
+        }));
+        const failOnce = new Set([controllerDID, assetDID1, assetDID2, expiredAgentDID]);
+        const originalGetEvents = db.getEvents.bind(db);
+        const getEvents = jest.spyOn(db, 'getEvents').mockImplementation(async did => {
+            if (failOnce.delete(did)) {
+                throw 'scan read failed';
+            }
+            return originalGetEvents(did);
+        });
+
+        try {
+            expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+                total: 4,
+                verified: 1,
+                expired: 3,
+                invalid: 0,
+            });
+            expect(await gatekeeper.getDIDs()).toStrictEqual([controllerDID]);
+        }
+        finally {
+            getEvents.mockRestore();
+        }
+    });
+
+    it('should retry when an expired agent cannot be revalidated', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const agentDID = await gatekeeper.createDID(await helper.createAgentOp(keypair, {
+            validUntil: new Date(Date.now() - 1_000).toISOString(),
+        }));
+        const assetDID = await gatekeeper.createDID(await helper.createAssetOp(agentDID, keypair));
+        const originalGetEvents = db.getEvents.bind(db);
+        let agentReads = 0;
+        const getEvents = jest.spyOn(db, 'getEvents').mockImplementation(async did => {
+            if (did === agentDID && ++agentReads === 2) {
+                throw new Error('transient revalidation failure');
+            }
+            return originalGetEvents(did);
+        });
+
+        try {
+            expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+                total: 2,
+                verified: 2,
+                expired: 0,
+                invalid: 0,
+            });
+            expect(await gatekeeper.getDIDs()).toStrictEqual([agentDID, assetDID]);
+        }
+        finally {
+            getEvents.mockRestore();
+        }
+
+        expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+            total: 2,
+            verified: 0,
+            expired: 2,
+            invalid: 0,
+        });
+        expect(await gatekeeper.getDIDs()).toStrictEqual([]);
+    });
+
+    it('should retain a pending controller with an invalid resolution', async () => {
+        const did = 'did:test:pending-invalid';
+        const pending = (gatekeeper as unknown as {
+            pendingExpiredControllers: Map<string, string>;
+        }).pendingExpiredControllers;
+        pending.set('pending-invalid', did);
+        const resolveDID = jest.spyOn(gatekeeper, 'resolveDID').mockResolvedValue({
+            didResolutionMetadata: { error: 'invalidDid' },
+        });
+
+        try {
+            expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+                total: 0,
+                verified: 0,
+                expired: 0,
+                invalid: 0,
+            });
+            expect(pending.get('pending-invalid')).toBe(did);
+        }
+        finally {
+            resolveDID.mockRestore();
+        }
+    });
+
     it('should not remove an agent renewed after the GC scan', async () => {
         const keypair = cipher.generateRandomJwk();
         const expiresAt = Date.now() + 60_000;
@@ -366,6 +463,43 @@ describe('verifyDb', () => {
             invalid: 0,
         });
         expect(await gatekeeper.getDIDs()).toStrictEqual([liveAgent, assetDID]);
+    });
+
+    it('should preserve an asset moved to a live controller after the scan', async () => {
+        const expiredKeys = cipher.generateRandomJwk();
+        const liveKeys = cipher.generateRandomJwk();
+        const expiredAgent = await gatekeeper.createDID(await helper.createAgentOp(expiredKeys, {
+            validUntil: new Date(Date.now() - 1_000).toISOString(),
+        }));
+        const liveAgent = await gatekeeper.createDID(await helper.createAgentOp(liveKeys));
+        const assetDID = await gatekeeper.createDID(await helper.createAssetOp(expiredAgent, expiredKeys));
+        const originalResolveDID = gatekeeper.resolveDID.bind(gatekeeper);
+        const staleAssetDoc = await originalResolveDID(assetDID);
+        const currentAssetDoc = await originalResolveDID(assetDID);
+        currentAssetDoc.didDocument!.controller = liveAgent;
+        expect(await gatekeeper.updateDID(
+            await helper.createUpdateOp(expiredKeys, assetDID, currentAssetDoc),
+        )).toBe(true);
+        let assetResolutions = 0;
+        const resolveDID = jest.spyOn(gatekeeper, 'resolveDID').mockImplementation(async (did, options) => {
+            if (did === assetDID && ++assetResolutions === 1) {
+                return staleAssetDoc;
+            }
+            return originalResolveDID(did, options);
+        });
+
+        try {
+            expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+                total: 3,
+                verified: 2,
+                expired: 1,
+                invalid: 0,
+            });
+            expect(await gatekeeper.getDIDs()).toStrictEqual([liveAgent, assetDID]);
+        }
+        finally {
+            resolveDID.mockRestore();
+        }
     });
 
     it('should retry failed dependency discovery before removing an expired agent', async () => {
@@ -709,6 +843,53 @@ describe('verifyDb', () => {
             invalid: 0,
         });
         expect(await gatekeeper.getDIDs()).toStrictEqual([agentDID]);
+    });
+
+    it('should reclassify stale expired assets before deletion', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const agentDID = await gatekeeper.createDID(await helper.createAgentOp(keypair));
+        const expired = new Date(Date.now() - 1_000).toISOString();
+        const invalidAsset = await gatekeeper.createDID(await helper.createAssetOp(agentDID, keypair, {
+            validUntil: expired,
+        }));
+        const renewedAsset = await gatekeeper.createDID(await helper.createAssetOp(agentDID, keypair, {
+            validUntil: expired,
+        }));
+        const originalResolveDID = gatekeeper.resolveDID.bind(gatekeeper);
+        const staleDocs = new Map([
+            [invalidAsset, await originalResolveDID(invalidAsset)],
+            [renewedAsset, await originalResolveDID(renewedAsset)],
+        ]);
+
+        const invalidEvents = await db.getEvents(invalidAsset);
+        invalidEvents[0].time = 'not-a-date';
+        await db.setEvents(invalidAsset, invalidEvents);
+        const renewedDoc = await originalResolveDID(renewedAsset);
+        renewedDoc.mdip!.validUntil = new Date(Date.now() + 60_000).toISOString();
+        expect(await gatekeeper.updateDID(
+            await helper.createUpdateOp(keypair, renewedAsset, renewedDoc),
+        )).toBe(true);
+
+        const staleReads = new Set(staleDocs.keys());
+        const resolveDID = jest.spyOn(gatekeeper, 'resolveDID').mockImplementation(async (did, options) => {
+            if (did && staleReads.delete(did)) {
+                return staleDocs.get(did)!;
+            }
+            return originalResolveDID(did, options);
+        });
+
+        try {
+            expect(await gatekeeper.verifyDb({ chatty: false })).toStrictEqual({
+                total: 3,
+                verified: 2,
+                expired: 0,
+                invalid: 1,
+            });
+            expect(await gatekeeper.getDIDs()).toStrictEqual([agentDID, renewedAsset]);
+        }
+        finally {
+            resolveDID.mockRestore();
+        }
     });
 
     it('should not restore cache invalidated during resolution', async () => {


### PR DESCRIPTION
## Overview

This PR updates verifyDb() from a full signature-revalidation pass into expiration-aware garbage collection while preserving its existing public interface and result shape.

GC now resolves DIDs without { verify: true }, retains cached stable DIDs, and removes expired agents together with their directly controlled assets. Dependents are deleted before their controller.

## Key changes

- Recheck expiring DIDs while retaining the existing verifiedDIDs cache for stable DIDs.
- Discover controller relationships when an expired agent requires cleanup.
- Re-resolve removal candidates under per-DID locks before deleting them.
- Retry cleanup after transient database failures or concurrent removals.
- Treat malformed expiry dates as non-expiring rather than deleting them.
- Leave cryptographic signature auditing to explicit resolveDID(..., { verify: true }) calls.
- Serialise scheduled and manual verifyDb() calls through one shared in-flight run.
- Normalise cache and lock keys to the DID’s CID suffix so prefix aliases cannot bypass coordination.
- Invalidate cached verification state before database mutations, including ambiguous write failures.
- Lock removeDIDs(), updates, imports, creation, and GC deletion consistently.
- Prevent stale GC decisions from deleting DIDs renewed after the initial scan.
- Preserve assets when dependency discovery or locked revalidation fails, allowing a later GC run to retry.