### PR TITLE
Allow arbitrary DID prefix scopes in Search Server

### DIFF
--- a/services/search-server/README.md
+++ b/services/search-server/README.md
@@ -271,9 +271,10 @@ credential unpublishing, keeping historical schema links resolvable in the same
 network scope. Conflicting manifest prefixes fall back to `did:test`. Prefix
 aliases sharing a CID suffix are deduplicated.
 
-Set `KC_SEARCH_SERVER_DID_PREFIX` to `did:test` or `did:mdip` to return only
-that network from DID, search, event, credential, challenge-receipt, and metric
-endpoints. Explicit DIDs using another prefix are excluded from both scopes.
+Set `KC_SEARCH_SERVER_DID_PREFIX` to any `did:<method>` prefix, such as
+`did:test`, `did:mdip`, or `did:arbitrary`, to return only that network from
+DID, search, event, credential, challenge-receipt, and metric endpoints.
+Explicit DIDs using another prefix are excluded from the configured scope.
 Leave the setting empty to return every indexed network.
 
 Changing the configured scope invalidates the stored snapshot scope before a

--- a/services/search-server/src/config.ts
+++ b/services/search-server/src/config.ts
@@ -57,15 +57,15 @@ function parseCsv(value: string | undefined): string[] {
         .filter(Boolean);
 }
 
-export function parseDidPrefix(value: string | undefined): 'did:test' | 'did:mdip' | undefined {
+export function parseDidPrefix(value: string | undefined): string | undefined {
     const normalized = value?.trim();
     if (!normalized) {
         return undefined;
     }
-    if (normalized === 'did:test' || normalized === 'did:mdip') {
+    if (/^did:[^:]+$/.test(normalized)) {
         return normalized;
     }
-    throw new Error('KC_SEARCH_SERVER_DID_PREFIX must be did:test, did:mdip, or empty');
+    throw new Error('KC_SEARCH_SERVER_DID_PREFIX must be a did:<method> prefix or empty');
 }
 
 const configuredSkipPaths = parseCsv(process.env.KC_SEARCH_SERVER_RATE_LIMIT_SKIP_PATHS);

--- a/tests/search-server/config.test.ts
+++ b/tests/search-server/config.test.ts
@@ -1,13 +1,15 @@
 import { parseDidPrefix } from '../../services/search-server/src/config.ts';
 
 describe('search-server DID prefix configuration', () => {
-    it('accepts supported scopes and treats blank values as unfiltered', () => {
+    it('accepts DID method scopes and treats blank values as unfiltered', () => {
         expect(parseDidPrefix(undefined)).toBeUndefined();
         expect(parseDidPrefix('   ')).toBeUndefined();
         expect(parseDidPrefix('did:test')).toBe('did:test');
         expect(parseDidPrefix(' did:mdip ')).toBe('did:mdip');
-        expect(() => parseDidPrefix('did:other')).toThrow(
-            'KC_SEARCH_SERVER_DID_PREFIX must be did:test, did:mdip, or empty'
+        expect(parseDidPrefix('did:arbitrary')).toBe('did:arbitrary');
+        expect(() => parseDidPrefix('test')).toThrow(
+            'KC_SEARCH_SERVER_DID_PREFIX must be a did:<method> prefix or empty'
         );
+        expect(() => parseDidPrefix('did:mdip:test')).toThrow();
     });
 });


### PR DESCRIPTION
## Overview

Updates `KC_SEARCH_SERVER_DID_PREFIX` to accept any did:<method> prefix instead of limiting deployments to `did:test` and `did:mdip`.

This allows Explorer/Search Server deployments to scope results to custom networks such as `did:arbitrary`. An empty value continues to return all indexed networks, while malformed and legacy multi-part prefixes remain rejected.

The Explorer UI already renders prefixes dynamically, so no frontend changes were required.
