### PR TITLE
Fix syncing metadata-free DID updates

### DIFF
--- a/packages/gatekeeper/src/gatekeeper.ts
+++ b/packages/gatekeeper/src/gatekeeper.ts
@@ -1007,7 +1007,7 @@ export default class Gatekeeper implements GatekeeperInterface {
         else if (operation.type === 'update') {
             const doc = operation.doc;
 
-            if (!doc || !doc.didDocument || !doc.didDocumentMetadata || !doc.didDocumentData || !doc.mdip) {
+            if (!doc || !doc.didDocument || !doc.didDocumentData || !doc.mdip) {
                 return false;
             }
 

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -1108,6 +1108,8 @@ export default class Keymaster implements KeymasterInterface {
             return true;
         }
 
+        doc.didDocumentMetadata = {};
+
         const block = await this.gatekeeper.getBlock(current.mdip!.registry);
         const blockid = block?.hash;
 

--- a/tests/gatekeeper/sync.test.ts
+++ b/tests/gatekeeper/sync.test.ts
@@ -266,6 +266,29 @@ describe('importBatch', () => {
         expect(response.queued).toBe(1);
     });
 
+    it('should import updates without generated document metadata', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const did = await gatekeeper.createDID(await helper.createAgentOp(keypair));
+        const doc = await gatekeeper.resolveDID(did);
+        doc.didDocumentData = { published: true };
+        delete doc.didDocumentMetadata;
+        delete doc.didResolutionMetadata;
+        const update = await helper.createUpdateOp(keypair, did, doc);
+
+        const imported = await gatekeeper.importBatch([{
+            registry: 'local',
+            time: new Date().toISOString(),
+            operation: update,
+        }]);
+
+        expect(imported).toMatchObject({ queued: 1, rejected: 0 });
+        await expect(gatekeeper.processEvents()).resolves.toMatchObject({ rejected: 0 });
+        await expect(gatekeeper.resolveDID(did)).resolves.toMatchObject({
+            didDocumentData: { published: true },
+            didDocumentMetadata: { version: '2' },
+        });
+    });
+
     it('should report when event already processed', async () => {
         const keypair = cipher.generateRandomJwk();
         const agentOp = await helper.createAgentOp(keypair);

--- a/tests/keymaster/utils.test.ts
+++ b/tests/keymaster/utils.test.ts
@@ -203,6 +203,28 @@ describe('updateDID', () => {
         expect(doc2.didDocumentMetadata!.version).toBe("2");
     });
 
+    it('should create updates accepted by another gatekeeper', async () => {
+        const did = await keymaster.createId('Bob', { registry: 'hyperswarm' });
+        const doc = await keymaster.resolveDID(did);
+        doc.didDocumentData = { published: true };
+
+        await keymaster.updateDID(doc);
+        const events = await gatekeeper.exportDID(did);
+        const remote = new Gatekeeper({
+            db: new DbJsonMemory('remote'),
+            ipfs,
+            registries: ['local', 'hyperswarm', 'TFTC'],
+        });
+
+        expect(events[1].operation.doc?.didDocumentMetadata).toStrictEqual({});
+        await expect(remote.importBatch(events)).resolves.toMatchObject({ queued: 2, rejected: 0 });
+        await expect(remote.processEvents()).resolves.toMatchObject({ added: 2, rejected: 0 });
+        await expect(remote.resolveDID(did)).resolves.toMatchObject({
+            didDocumentData: { published: true },
+            didDocumentMetadata: { version: '2' },
+        });
+    });
+
     it('should not update an asset DID if no changes', async () => {
         await keymaster.createId('Bob');
         const mockAnchor = { name: 'mockAnchor', val: 1234 };


### PR DESCRIPTION
- Include an empty didDocumentMetadata object in new Keymaster update operations for compatibility with existing Gatekeepers.
- Allow Gatekeeper to import previously signed updates that omit generated document metadata.
- Preserve document structure, signature, controller, and version validation.
- Reconstruct document metadata normally during DID resolution.
- Add regressions covering both legacy update recovery and cross-Gatekeeper propagation.