### PR TITLE
Fix CLI wallet recovery and poll voting flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Recommended system requirements:
 
 - GNU/Linux OS with [Docker](https://www.docker.com/) for containerized operation
 - Node.js 22.15.0 and npm 10.8.2 or newer for manual and local operation
-- Enough memory and storage for the selected services and registries
+- At least 3 GB RAM for Gatekeeper, Keymaster, the Hyperswarm mediator, Search Server, Explorer, IPFS, and their database dependencies. Other services require additional memory.
 
 ```
 $ git clone https://github.com/KeychainMDIP/kc
@@ -37,7 +37,16 @@ npm run build
 
 [Gatekeeper](https://github.com/KeychainMDIP/kc/blob/main/services/gatekeeper/server/README.md) validates DID operations and maintains the local DID event database. [Keymaster](https://github.com/KeychainMDIP/kc/blob/main/services/keymaster/server/README.md) holds the server wallet and signs operations sent to Gatekeeper. Hyperswarm and Satoshi mediators distribute those operations over P2P and blockchain registries. Search Server builds a read model from Gatekeeper for Explorer and wallet search.
 
-The browser wallet hosts the Keymaster library and stores its wallet locally. The server wallet and `kc` CLI use Keymaster's HTTP client. The `admin` CLI and mediators use Gatekeeper's HTTP client. See the [deployment guide](https://keychain.org/docs/server/deployment/) for the current service list and startup options.
+The Gatekeeper service runs the browser wallet, which hosts the Keymaster library and stores its wallet locally in the browser. The Keymaster service runs the server wallet, which uses Keymaster's HTTP client and shares the service wallet with the `kc` CLI. Both web wallets are demonstration clients that show what the software can do. They run by default and can be disabled with environment variables. The `admin` CLI and mediators use Gatekeeper's HTTP client. See the [deployment guide](https://keychain.org/docs/server/deployment/) for the current service list and startup options.
+
+### Other implementations and examples
+
+- The [browser extension](https://github.com/KeychainMDIP/kc/blob/main/apps/chrome-extension/README.md) packages an MDIP wallet as a Chrome extension.
+- The [React wallet](https://github.com/KeychainMDIP/kc/blob/main/apps/react-wallet/README.md) is a React and Capacitor demonstration wallet for browsers and Android.
+- The [Java implementation](https://github.com/KeychainMDIP/kc/blob/main/java/README.md) provides Keymaster and a Gatekeeper REST client for Java applications.
+- The [Python SDK](https://github.com/KeychainMDIP/kc/blob/main/python/keymaster_sdk/README.md) provides a Python client for the Keymaster service.
+- The [CommonJS demo](https://github.com/KeychainMDIP/kc/tree/main/demo/commonjs-demo) shows how to load the MDIP packages and create and resolve a DID.
+- The [inscription demo](https://github.com/KeychainMDIP/kc/blob/main/demo/inscription-demo/README.md) shows how to export operations as Taproot inscriptions.
 
 ## Node configuration
 

--- a/doc/keymaster-api.json
+++ b/doc/keymaster-api.json
@@ -499,6 +499,21 @@
     "/wallet/recover": {
       "post": {
         "summary": "Recover the wallet from an existing backup.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "did": {
+                    "type": "string",
+                    "description": "The optional DID of the wallet backup."
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "The recovered wallet object.",

--- a/packages/keymaster/src/keymaster-client.ts
+++ b/packages/keymaster/src/keymaster-client.ts
@@ -169,9 +169,9 @@ export default class KeymasterClient implements KeymasterInterface {
         }
     }
 
-    async recoverWallet(): Promise<WalletFile> {
+    async recoverWallet(did?: string): Promise<WalletFile> {
         try {
-            const response = await axios.post(`${this.API}/wallet/recover`);
+            const response = await axios.post(`${this.API}/wallet/recover`, { did });
             return response.data.wallet;
         }
         catch (error) {

--- a/packages/keymaster/src/types.ts
+++ b/packages/keymaster/src/types.ts
@@ -325,7 +325,7 @@ export interface KeymasterInterface {
     saveWallet(wallet: StoredWallet, overwrite?: boolean): Promise<boolean>;
     newWallet(mnemonic?: string, overwrite?: boolean): Promise<WalletFile>;
     backupWallet(): Promise<boolean | string>;
-    recoverWallet(): Promise<WalletFile>;
+    recoverWallet(did?: string): Promise<WalletFile>;
     checkWallet(): Promise<CheckWalletResult>;
     fixWallet(): Promise<FixWalletResult>;
     decryptMnemonic(): Promise<string>;

--- a/scripts/keychain-cli.js
+++ b/scripts/keychain-cli.js
@@ -161,7 +161,7 @@ program
     .description('Create new wallet from a recovery phrase')
     .action(async (recoveryPhrase) => {
         try {
-            const wallet = await keymaster.newWallet(recoveryPhrase);
+            const wallet = await keymaster.newWallet(recoveryPhrase, true);
             console.log(JSON.stringify(wallet, null, 4));
         }
         catch (error) {
@@ -1140,7 +1140,7 @@ program
     .description('Vote in a poll')
     .action(async (poll, vote, spoil) => {
         try {
-            const did = await keymaster.votePoll(poll, vote, spoil);
+            const did = await keymaster.votePoll(poll, Number(vote), { spoil: spoil !== undefined });
             console.log(did);
         }
         catch (error) {

--- a/services/keymaster/server/src/keymaster-api.ts
+++ b/services/keymaster/server/src/keymaster-api.ts
@@ -451,6 +451,15 @@ v1router.post('/wallet/backup', async (req, res) => {
  * /wallet/recover:
  *   post:
  *     summary: Recover the wallet from an existing backup.
+ *     requestBody:
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               did:
+ *                 type: string
+ *                 description: The optional DID of the wallet backup.
  *     responses:
  *       200:
  *         description: The recovered wallet object.
@@ -473,7 +482,7 @@ v1router.post('/wallet/backup', async (req, res) => {
  */
 v1router.post('/wallet/recover', async (req, res) => {
     try {
-        const wallet = await keymaster.recoverWallet();
+        const wallet = await keymaster.recoverWallet(req.body?.did);
         res.json({ wallet });
     } catch (error: any) {
         res.status(500).send({ error: error.toString() });

--- a/tests/keymaster/client.test.ts
+++ b/tests/keymaster/client.test.ts
@@ -286,14 +286,26 @@ describe('backupWallet', () => {
 
 describe('recoverWallet', () => {
     const mockWallet = { seed: 1 };
+    const mockDID = 'did:mock:backup';
 
     it('should recover wallet', async () => {
         nock(KeymasterURL)
-            .post(Endpoints.wallet_recover)
+            .post(Endpoints.wallet_recover, {})
             .reply(200, { wallet: mockWallet });
 
         const keymaster = await KeymasterClient.create({ url: KeymasterURL });
         const wallet = await keymaster.recoverWallet();
+
+        expect(wallet).toStrictEqual(mockWallet);
+    });
+
+    it('should recover wallet from a backup DID', async () => {
+        nock(KeymasterURL)
+            .post(Endpoints.wallet_recover, { did: mockDID })
+            .reply(200, { wallet: mockWallet });
+
+        const keymaster = await KeymasterClient.create({ url: KeymasterURL });
+        const wallet = await keymaster.recoverWallet(mockDID);
 
         expect(wallet).toStrictEqual(mockWallet);
     });


### PR DESCRIPTION
## Overview

- Allow kc import-wallet to replace the wallet created during Keymaster startup.
- Forward the optional backup DID from recover-wallet-did through the Keymaster client and REST API.
- Parse poll votes as numbers and pass the spoil flag through the expected options object.
- Update the generated OpenAPI specification and add client coverage for recovery by DID.
- Minor README updates