### PR TITLE
Fix Keymaster challenge response matching

### DIFF
--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -2103,9 +2103,8 @@ export default class Keymaster implements KeymasterInterface {
         }
 
         const requestedCredentials = challenge.credentials ?? [];
-        const matchedCredentials = new Set<number>();
         const matchedPresentations = new Set<string>();
-        const vps: VerifiableCredential[] = [];
+        const candidates: { vp: VerifiableCredential; credentialIndexes: number[] }[] = [];
 
         for (let credential of response.credentials) {
             if (matchedPresentations.has(credential.vp)) {
@@ -2147,20 +2146,46 @@ export default class Keymaster implements KeymasterInterface {
                 continue;
             }
 
-            const credentialIndex = requestedCredentials.findIndex((item, index) =>
-                !matchedCredentials.has(index) &&
-                item.schema === schema &&
-                (!item.issuers?.length || item.issuers.includes(vp.issuer))
-            );
+            const credentialIndexes: number[] = [];
+            requestedCredentials.forEach((item, index) => {
+                if (item.schema === schema && (!item.issuers?.length || item.issuers.includes(vp.issuer))) {
+                    credentialIndexes.push(index);
+                }
+            });
 
-            if (credentialIndex === -1) {
+            if (credentialIndexes.length === 0) {
                 continue;
             }
 
-            matchedCredentials.add(credentialIndex);
             matchedPresentations.add(credential.vp);
-            vps.push(vp);
+            candidates.push({ vp, credentialIndexes });
         }
+
+        const matchedCredentials = new Map<number, number>();
+        const assignPresentation = (presentationIndex: number, visited: Set<number>): boolean => {
+            for (const credentialIndex of candidates[presentationIndex].credentialIndexes) {
+                if (visited.has(credentialIndex)) {
+                    continue;
+                }
+
+                visited.add(credentialIndex);
+                const assignedPresentation = matchedCredentials.get(credentialIndex);
+
+                if (assignedPresentation === undefined || assignPresentation(assignedPresentation, visited)) {
+                    matchedCredentials.set(credentialIndex, presentationIndex);
+                    return true;
+                }
+            }
+
+            return false;
+        };
+
+        candidates.forEach((_, index) => assignPresentation(index, new Set()));
+
+        const matchedCandidateIndexes = new Set(matchedCredentials.values());
+        const vps = candidates
+            .filter((_, index) => matchedCandidateIndexes.has(index))
+            .map(candidate => candidate.vp);
 
         response.vps = vps;
         response.match = matchedCredentials.size === requestedCredentials.length;

--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -2102,9 +2102,16 @@ export default class Keymaster implements KeymasterInterface {
             throw new InvalidParameterError('challengeDID');
         }
 
+        const requestedCredentials = challenge.credentials ?? [];
+        const matchedCredentials = new Set<number>();
+        const matchedPresentations = new Set<string>();
         const vps: VerifiableCredential[] = [];
 
         for (let credential of response.credentials) {
+            if (matchedPresentations.has(credential.vp)) {
+                continue;
+            }
+
             const vcData = await this.resolveAsset(credential.vc);
             const vpData = await this.resolveAsset(credential.vp);
 
@@ -2135,26 +2142,28 @@ export default class Keymaster implements KeymasterInterface {
                 continue;
             }
 
-            // Check VP against VCs specified in challenge
-            if (vp.type.length >= 2 && vp.type[1].startsWith('did:')) {
-                const schema = vp.type[1];
-                const credential = challenge.credentials?.find(item => item.schema === schema);
-
-                if (!credential) {
-                    continue;
-                }
-
-                // Check if issuer of VP is in the trusted issuer list
-                if (credential.issuers && credential.issuers.length > 0 && !credential.issuers.includes(vp.issuer)) {
-                    continue;
-                }
+            const schema = vp.type[1];
+            if (typeof schema !== 'string' || !schema.startsWith('did:')) {
+                continue;
             }
 
+            const credentialIndex = requestedCredentials.findIndex((item, index) =>
+                !matchedCredentials.has(index) &&
+                item.schema === schema &&
+                (!item.issuers?.length || item.issuers.includes(vp.issuer))
+            );
+
+            if (credentialIndex === -1) {
+                continue;
+            }
+
+            matchedCredentials.add(credentialIndex);
+            matchedPresentations.add(credential.vp);
             vps.push(vp);
         }
 
         response.vps = vps;
-        response.match = vps.length === (challenge.credentials?.length ?? 0);
+        response.match = matchedCredentials.size === requestedCredentials.length;
         response.responder = responseDoc.didDocument?.controller;
 
         if (publish && response.match) {

--- a/tests/keymaster/response.test.ts
+++ b/tests/keymaster/response.test.ts
@@ -201,6 +201,83 @@ describe('verifyResponse', () => {
         expect(verify1.vps!.length).toBe(1);
     });
 
+    it('should reject a presentation without the requested schema', async () => {
+        await keymaster.createId('Alice');
+        const carol = await keymaster.createId('Carol');
+        const victor = await keymaster.createId('Victor');
+
+        await keymaster.setCurrentId('Alice');
+        const schema = await keymaster.createSchema(mockSchema);
+        const credential = await keymaster.bindCredential(schema, carol);
+        credential.type = ['VerifiableCredential'];
+        const vc = await keymaster.issueCredential(credential);
+
+        await keymaster.setCurrentId('Victor');
+        const challenge = await keymaster.createChallenge({
+            credentials: [{ schema }],
+        });
+
+        await keymaster.setCurrentId('Carol');
+        const plaintext = await keymaster.decryptMessage(vc);
+        const vp = await keymaster.encryptMessage(plaintext, victor, { includeHash: true });
+        const response = await keymaster.encryptJSON({
+            response: {
+                challenge,
+                credentials: [{ vc, vp }],
+                requested: 1,
+                fulfilled: 1,
+                match: true,
+                responseNonce: 'mock-nonce',
+            },
+        }, victor);
+
+        await keymaster.setCurrentId('Victor');
+        const verification = await keymaster.verifyResponse(response, { publish: false });
+
+        expect(verification.match).toBe(false);
+        expect(verification.vps).toStrictEqual([]);
+    });
+
+    it('should not count a presentation more than once', async () => {
+        const alice = await keymaster.createId('Alice');
+        const carol = await keymaster.createId('Carol');
+        const victor = await keymaster.createId('Victor');
+
+        await keymaster.setCurrentId('Alice');
+        const schema1 = await keymaster.createSchema(mockSchema);
+        const schema2 = await keymaster.createSchema(mockSchema);
+        const credential = await keymaster.bindCredential(schema1, carol);
+        const vc = await keymaster.issueCredential(credential);
+
+        await keymaster.setCurrentId('Victor');
+        const challenge = await keymaster.createChallenge({
+            credentials: [
+                { schema: schema1, issuers: [alice] },
+                { schema: schema2, issuers: [alice] },
+            ],
+        });
+
+        await keymaster.setCurrentId('Carol');
+        const plaintext = await keymaster.decryptMessage(vc);
+        const vp = await keymaster.encryptMessage(plaintext, victor, { includeHash: true });
+        const response = await keymaster.encryptJSON({
+            response: {
+                challenge,
+                credentials: [{ vc, vp }, { vc, vp }],
+                requested: 2,
+                fulfilled: 2,
+                match: true,
+                responseNonce: 'mock-nonce',
+            },
+        }, victor);
+
+        await keymaster.setCurrentId('Victor');
+        const verification = await keymaster.verifyResponse(response, { publish: false });
+
+        expect(verification.match).toBe(false);
+        expect(verification.vps).toHaveLength(1);
+    });
+
     it('should not verify a invalid response to a single credential challenge', async () => {
         await keymaster.createId('Alice');
         await keymaster.createId('Carol');

--- a/tests/keymaster/response.test.ts
+++ b/tests/keymaster/response.test.ts
@@ -278,6 +278,59 @@ describe('verifyResponse', () => {
         expect(verification.vps).toHaveLength(1);
     });
 
+    it('should match credentials independently of presentation order', async () => {
+        const alice = await keymaster.createId('Alice');
+        await keymaster.createId('Bob');
+        const carol = await keymaster.createId('Carol');
+        const victor = await keymaster.createId('Victor');
+
+        await keymaster.setCurrentId('Alice');
+        const schema = await keymaster.createSchema(mockSchema);
+        const vcAlice = await keymaster.issueCredential(await keymaster.bindCredential(schema, carol));
+
+        await keymaster.setCurrentId('Bob');
+        const vcBob = await keymaster.issueCredential(await keymaster.bindCredential(schema, carol));
+
+        await keymaster.setCurrentId('Victor');
+        const challenge = await keymaster.createChallenge({
+            credentials: [
+                { schema },
+                { schema, issuers: [alice] },
+            ],
+        });
+
+        await keymaster.setCurrentId('Carol');
+        const vpAlice = await keymaster.encryptMessage(
+            await keymaster.decryptMessage(vcAlice),
+            victor,
+            { includeHash: true }
+        );
+        const vpBob = await keymaster.encryptMessage(
+            await keymaster.decryptMessage(vcBob),
+            victor,
+            { includeHash: true }
+        );
+        const response = await keymaster.encryptJSON({
+            response: {
+                challenge,
+                credentials: [
+                    { vc: vcAlice, vp: vpAlice },
+                    { vc: vcBob, vp: vpBob },
+                ],
+                requested: 2,
+                fulfilled: 2,
+                match: true,
+                responseNonce: 'mock-nonce',
+            },
+        }, victor);
+
+        await keymaster.setCurrentId('Victor');
+        const verification = await keymaster.verifyResponse(response, { publish: false });
+
+        expect(verification.match).toBe(true);
+        expect(verification.vps).toHaveLength(2);
+    });
+
     it('should not verify a invalid response to a single credential challenge', async () => {
         await keymaster.createId('Alice');
         await keymaster.createId('Carol');


### PR DESCRIPTION
## Overview

Previously, `verifyResponse` only checked a presentation’s schema and trusted issuer when `credential.vp.type[1]` existed and started with `did:`. A signed presentation without that schema entry skipped both checks and was still counted as valid.

Verification also compared only the number of accepted presentations with the number requested. The same presentation DID could therefore be included twice and counted twice. For example, a challenge requesting schemas A and B could incorrectly pass with two copies of a schema A presentation, leaving schema B unsatisfied.

The fix computes a one-to-one matching between accepted presentations and challenge requirements. Each presentation must satisfy a distinct requested schema and issuer restriction. Matching remains correct when requirements overlap, regardless of presentation order. Empty challenges remain valid because they require zero presentations.

## Changes

  - Require each accepted presentation to declare a DID schema matching a requested credential
  - Apply trusted-issuer restrictions to every accepted presentation
  - Prevent repeated use of the same presentation DID
  - Match presentations to requirements independently of presentation order
  - Add regression tests for missing schemas, repeated presentations, and overlapping requirements