### PR TITLE
Verify presentation content against credential hashes

### DIFF
--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -2130,7 +2130,20 @@ export default class Keymaster implements KeymasterInterface {
                 continue;
             }
 
-            const vp = await this.decryptJSON(credential.vp) as VerifiableCredential;
+            const vpPlaintext = await this.decryptMessage(credential.vp);
+            let vp: VerifiableCredential;
+
+            try {
+                vp = JSON.parse(vpPlaintext) as VerifiableCredential;
+            }
+            catch {
+                throw new InvalidParameterError('did not encrypted JSON');
+            }
+
+            if (this.cipher.hashMessage(vpPlaintext) !== vcHash.cipher_hash) {
+                continue;
+            }
+
             const isValid = await this.verifySignature(vp);
 
             if (!isValid) {

--- a/tests/keymaster/response.test.ts
+++ b/tests/keymaster/response.test.ts
@@ -283,6 +283,31 @@ describe('verifyResponse', () => {
         expect(verification.vps).toStrictEqual([]);
     });
 
+    it('should reject a presentation that is not encrypted JSON', async () => {
+        await keymaster.createId('Carol');
+        const victor = await keymaster.createId('Victor');
+
+        await keymaster.setCurrentId('Victor');
+        const challenge = await keymaster.createChallenge();
+
+        await keymaster.setCurrentId('Carol');
+        const invalid = await keymaster.encryptMessage('not JSON', victor, { includeHash: true });
+        const response = await keymaster.encryptJSON({
+            response: {
+                challenge,
+                credentials: [{ vc: invalid, vp: invalid }],
+                requested: 0,
+                fulfilled: 1,
+                match: false,
+                responseNonce: 'mock-nonce',
+            },
+        }, victor);
+
+        await keymaster.setCurrentId('Victor');
+        await expect(keymaster.verifyResponse(response, { publish: false }))
+            .rejects.toThrow('Invalid parameter: did not encrypted JSON');
+    });
+
     it('should not count a presentation more than once', async () => {
         const alice = await keymaster.createId('Alice');
         const carol = await keymaster.createId('Carol');

--- a/tests/keymaster/response.test.ts
+++ b/tests/keymaster/response.test.ts
@@ -238,6 +238,51 @@ describe('verifyResponse', () => {
         expect(verification.vps).toStrictEqual([]);
     });
 
+    it('should reject a presentation whose plaintext does not match the credential hash', async () => {
+        const alice = await keymaster.createId('Alice');
+        const carol = await keymaster.createId('Carol');
+        const victor = await keymaster.createId('Victor');
+
+        await keymaster.setCurrentId('Alice');
+        const schemaA = await keymaster.createSchema(mockSchema);
+        const schemaB = await keymaster.createSchema(mockSchema);
+        const vcA = await keymaster.issueCredential(await keymaster.bindCredential(schemaA, carol));
+        const vcB = await keymaster.issueCredential(await keymaster.bindCredential(schemaB, carol));
+
+        await keymaster.setCurrentId('Victor');
+        const challenge = await keymaster.createChallenge({
+            credentials: [{ schema: schemaB, issuers: [alice] }],
+        });
+
+        await keymaster.setCurrentId('Carol');
+        const vp = await keymaster.encryptMessage(
+            await keymaster.decryptMessage(vcB),
+            victor,
+            { includeHash: true }
+        );
+        const vcData = await keymaster.resolveAsset(vcA);
+        const vpData = await keymaster.resolveAsset(vp);
+        vpData.encrypted.cipher_hash = vcData.encrypted.cipher_hash;
+        await keymaster.updateAsset(vp, vpData);
+
+        const response = await keymaster.encryptJSON({
+            response: {
+                challenge,
+                credentials: [{ vc: vcA, vp }],
+                requested: 1,
+                fulfilled: 1,
+                match: true,
+                responseNonce: 'mock-nonce',
+            },
+        }, victor);
+
+        await keymaster.setCurrentId('Victor');
+        const verification = await keymaster.verifyResponse(response, { publish: false });
+
+        expect(verification.match).toBe(false);
+        expect(verification.vps).toStrictEqual([]);
+    });
+
     it('should not count a presentation more than once', async () => {
         const alice = await keymaster.createId('Alice');
         const carol = await keymaster.createId('Carol');


### PR DESCRIPTION
## Overview

Previously, `verifyResponse` only compared the public `cipher_hash` metadata on the referenced VC and its VP. Because the VP metadata can be changed independently, a responder could copy the hash from one credential onto a VP containing a different credential.

The substituted credential could then pass verification if its signature, schema, and issuer satisfied the challenge, even though its contents did not match the referenced VC.

## Changes

- Hash the exact decrypted VP plaintext using the same function used during credential issuance
- Compare that hash with the referenced VC's `cipher_hash`
- Reject presentations whose decrypted contents do not match the referenced credential
- Add a regression test covering forged hash metadata and credential substitution
