### PR TITLE
Bind credential signatures to declared issuers

### DIFF
--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -1733,6 +1733,17 @@ export default class Keymaster implements KeymasterInterface {
         return !(!Array.isArray(vc["@context"]) || !Array.isArray(vc.type) || !vc.issuer || !vc.credentialSubject);
     }
 
+    private async verifyCredentialSignature(obj: unknown): Promise<boolean> {
+        const vc = obj as Partial<VerifiableCredential> | null | undefined;
+        if (typeof vc?.issuer !== 'string' ||
+            typeof vc?.signature?.signer !== 'string' ||
+            vc.signature.signer !== vc.issuer) {
+            return false;
+        }
+
+        return this.verifySignature(vc);
+    }
+
     async updateCredential(
         did: string,
         credential: VerifiableCredential
@@ -1812,8 +1823,9 @@ export default class Keymaster implements KeymasterInterface {
             const credential = await this.lookupDID(did);
             const vc = await this.decryptJSON(credential);
 
-            if (this.isVerifiableCredential(vc) &&
-                vc.credentialSubject?.id !== id.did) {
+            if (!this.isVerifiableCredential(vc) ||
+                vc.credentialSubject?.id !== id.did ||
+                !await this.verifyCredentialSignature(vc)) {
                 return false;
             }
 
@@ -2144,9 +2156,7 @@ export default class Keymaster implements KeymasterInterface {
                 continue;
             }
 
-            const isValid = await this.verifySignature(vp);
-
-            if (!isValid) {
+            if (!await this.verifyCredentialSignature(vp)) {
                 continue;
             }
 

--- a/tests/keymaster/credential.test.ts
+++ b/tests/keymaster/credential.test.ts
@@ -658,4 +658,61 @@ describe('acceptCredential', () => {
         const ok = await keymaster.acceptCredential(credentialDid);
         expect(ok).toBe(false);
     });
+
+    it('should return false for decryptable non-credential data', async () => {
+        await keymaster.createId('Alice');
+        const bob = await keymaster.createId('Bob');
+
+        await keymaster.setCurrentId('Alice');
+        const did = await keymaster.encryptJSON({ message: 'not a credential' }, bob);
+
+        await keymaster.setCurrentId('Bob');
+        await expect(keymaster.acceptCredential(did)).resolves.toBe(false);
+    });
+
+    it('should return false for an unsigned credential', async () => {
+        await keymaster.createId('Alice');
+        const bob = await keymaster.createId('Bob');
+
+        await keymaster.setCurrentId('Alice');
+        const schema = await keymaster.createSchema(mockSchema);
+        const credential = await keymaster.bindCredential(schema, bob);
+        const did = await keymaster.encryptJSON(credential, bob);
+
+        await keymaster.setCurrentId('Bob');
+        await expect(keymaster.acceptCredential(did)).resolves.toBe(false);
+    });
+
+    it('should return false when the credential signer is not its issuer', async () => {
+        const alice = await keymaster.createId('Alice');
+        const bob = await keymaster.createId('Bob');
+        await keymaster.createId('Mallory');
+
+        await keymaster.setCurrentId('Alice');
+        const schema = await keymaster.createSchema(mockSchema);
+
+        await keymaster.setCurrentId('Mallory');
+        const credential = await keymaster.bindCredential(schema, bob);
+        credential.issuer = alice;
+        const signed = await keymaster.addSignature(credential);
+        const did = await keymaster.encryptJSON(signed, bob);
+
+        await keymaster.setCurrentId('Bob');
+        await expect(keymaster.acceptCredential(did)).resolves.toBe(false);
+    });
+
+    it('should return false when the credential signature is invalid', async () => {
+        await keymaster.createId('Alice');
+        const bob = await keymaster.createId('Bob');
+
+        await keymaster.setCurrentId('Alice');
+        const schema = await keymaster.createSchema(mockSchema);
+        const credential = await keymaster.bindCredential(schema, bob);
+        const signed = await keymaster.addSignature(credential);
+        signed.credential!.email = 'tampered@example.com';
+        const did = await keymaster.encryptJSON(signed, bob);
+
+        await keymaster.setCurrentId('Bob');
+        await expect(keymaster.acceptCredential(did)).resolves.toBe(false);
+    });
 });

--- a/tests/keymaster/response.test.ts
+++ b/tests/keymaster/response.test.ts
@@ -201,6 +201,50 @@ describe('verifyResponse', () => {
         expect(verify1.vps!.length).toBe(1);
     });
 
+    it('should reject a presentation whose signer is not its issuer', async () => {
+        const alice = await keymaster.createId('Alice');
+        const carol = await keymaster.createId('Carol');
+        await keymaster.createId('Mallory');
+        const victor = await keymaster.createId('Victor');
+
+        await keymaster.setCurrentId('Alice');
+        const schema = await keymaster.createSchema(mockSchema);
+
+        await keymaster.setCurrentId('Victor');
+        const challenge = await keymaster.createChallenge({
+            credentials: [{ schema, issuers: [alice] }],
+        });
+
+        await keymaster.setCurrentId('Mallory');
+        const credential = await keymaster.bindCredential(schema, carol);
+        credential.issuer = alice;
+        const signed = await keymaster.addSignature(credential);
+        const vc = await keymaster.encryptJSON(signed, carol, { includeHash: true });
+
+        await keymaster.setCurrentId('Carol');
+        const vp = await keymaster.encryptMessage(
+            await keymaster.decryptMessage(vc),
+            victor,
+            { includeHash: true }
+        );
+        const response = await keymaster.encryptJSON({
+            response: {
+                challenge,
+                credentials: [{ vc, vp }],
+                requested: 1,
+                fulfilled: 1,
+                match: true,
+                responseNonce: 'mock-nonce',
+            },
+        }, victor);
+
+        await keymaster.setCurrentId('Victor');
+        const verification = await keymaster.verifyResponse(response, { publish: false });
+
+        expect(verification.match).toBe(false);
+        expect(verification.vps).toStrictEqual([]);
+    });
+
     it('should reject a presentation without the requested schema', async () => {
         await keymaster.createId('Alice');
         const carol = await keymaster.createId('Carol');


### PR DESCRIPTION
## Changes

### acceptCredential()

Previously, credential acceptance did not verify signatures and allowed non-credential data to fall through into the holder’s wallet.

It now:

- Rejects data not recognized as a verifiable credential
- Retains the existing credential-subject check
- Rejects missing signatures
- Requires signature.signer to equal issuer
- Cryptographically verifies the credential signature before accepting it

### verifyResponse()

verifyResponse() already cryptographically verified presentation signatures. This remains unchanged.

It now additionally:

- Requires the declared issuer to be a string
- Requires signature.signer to be a string
- Requires signature.signer to equal issuer
- Performs these checks directly on the presentation without relying on acceptCredential()