### PR TITLE
Add cross-agent repository onboarding documentation

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,34 @@
+# Agent Guide
+
+This directory is the canonical starting point for AI agents working in this
+repository. Read these documents before making changes:
+
+1. [Architecture](architecture.md) explains the repository layout, ownership
+   boundaries, and main data flows.
+2. [Development](development.md) explains how to investigate, implement, test,
+   document, and validate changes.
+
+The root [AGENTS.md](../AGENTS.md) is the short cross-agent entry point. Keep
+tool-specific files minimal: load or point to these documents when the tool
+supports it, and repeat only essential guardrails when it does not.
+
+## Existing Sources
+
+- [README.md](../README.md): project overview, supported runtime, and node setup.
+- [CONTRIBUTING.md](../CONTRIBUTING.md): contribution and pull-request process.
+- Component READMEs: package, service, application, SDK, and demo usage.
+- [Gatekeeper OpenAPI](../doc/gatekeeper-api.json) and
+  [Keymaster OpenAPI](../doc/keymaster-api.json): generated REST API references.
+- [Unit-test workflow](../.github/workflows/unit-test.yml): required root CI
+  commands.
+
+Do not copy detailed deployment configuration, public APIs, or component usage
+into these files. Link to their maintained source instead. If this guide
+disagrees with the code, tests, CI, or a component README, verify the current
+behavior and correct the stale documentation in the same change.
+
+## Reading A Task
+
+Before editing, locate the owning component, then read its README, public
+types, implementation, callers, and existing tests. Start with the repository
+map rather than assuming the directory named in an issue owns the behavior.

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1,0 +1,97 @@
+# Repository Architecture
+
+Keychain is the reference implementation of the Multi-Dimensional Identity
+Protocol (MDIP). The repository contains reusable protocol libraries,
+deployable services, network mediators, applications, SDKs, examples, and
+their tests.
+
+## Core Packages
+
+The TypeScript packages under `packages/` are the heart of the software and
+the root npm workspaces. Reusable MDIP domain behavior belongs here rather than
+being duplicated in a service or user interface. Transport-specific
+synchronization, HTTP orchestration, projections, and UIs remain in their
+owning service or application.
+
+| Package | Responsibility |
+| --- | --- |
+| `packages/gatekeeper` | Validates and stores DID operations, maintains DID histories, and resolves DID documents. Gatekeeper is the authority on whether an operation is valid. |
+| `packages/keymaster` | Manages wallets, keys, identities, assets, credentials, challenges, and signed operations. It delegates DID storage and resolution to Gatekeeper. |
+| `packages/cipher` | Node and browser cryptography, encryption, signatures, and key utilities. |
+| `packages/common` | Shared errors, logging, environment handling, and utilities. |
+| `packages/ipfs` | Content-addressed storage and IPFS clients/utilities. |
+| `packages/inscription` | Creates and fee-bumps Taproot inscription transactions. |
+
+When changing Gatekeeper or Keymaster behavior, begin in these packages even
+if the behavior was observed through a REST service, CLI, mediator, or app.
+Keep database-specific behavior behind the package's existing adapters.
+
+## Services
+
+`services/` contains processes that expose, transport, or project core data:
+
+| Area | Responsibility |
+| --- | --- |
+| `services/gatekeeper/server` | Gatekeeper REST API, database selection, runtime loops, and server lifecycle. |
+| `services/gatekeeper/client` | Browser wallet served with the Gatekeeper deployment. |
+| `services/keymaster/server` | REST API around Keymaster for server wallets and non-TypeScript clients. |
+| `services/keymaster/client` | Browser UI for the server-side Keymaster wallet. |
+| `services/mediators/hyperswarm` | Exchanges Gatekeeper operations between peers using ordered catch-up and Negentropy reconciliation. It transports operations; Gatekeeper still decides validity. |
+| `services/mediators/satoshi` | Exchanges operations through supported Bitcoin-family registries. |
+| `services/mediators/satoshi-inscription` | Publishes operation batches as Bitcoin inscriptions. |
+| `services/search-server` | Builds a disposable, rebuildable read model from Gatekeeper's index export and exposes search and network metrics. |
+| `services/explorer` | React/Vite DID explorer backed by Search Server. |
+
+Do not move core validation or wallet rules into HTTP handlers, mediators, or
+search projections. Services should translate protocols, configure core
+libraries, and manage process lifecycle.
+
+## Applications And SDKs
+
+- `apps/react-wallet` is the React/Capacitor browser and Android demonstration
+  wallet.
+- `apps/chrome-extension` packages an MDIP wallet as a Chrome extension.
+- `java/` contains Java CID, cryptography, Gatekeeper client, and Keymaster
+  libraries, plus a demo. It uses Gradle independently of the npm workspace.
+- `python/keymaster_sdk` is the Python client for the Keymaster REST service.
+- `demo/commonjs-demo` demonstrates consuming the built npm packages from
+  CommonJS.
+- `demo/inscription-demo` demonstrates creating Taproot inscriptions.
+
+These consumers may need updates when a public package, REST, operation, or
+wallet contract changes. They should not become alternate sources of core
+protocol behavior.
+
+## Tests And Supporting Files
+
+- `tests/` contains the root Jest suites, grouped by the production domain:
+  `cipher`, `common`, `gatekeeper`, `hyperswarm`, `inscription`, `ipfs`,
+  `keymaster`, and `search-server`.
+- `tests/cli-tests` contains Docker-backed Expect/Tcl CLI tests with separate
+  setup requirements. Read its README before running them.
+- `doc/` contains protocol/client documentation and generated Gatekeeper and
+  Keymaster OpenAPI JSON.
+- `scripts/` contains CLI entry points, operational helpers, release tooling,
+  and examples.
+- `share/` contains shared sample data and schemas, not application state.
+- `data/` contains local container volumes, node configuration, and mediator
+  checkpoints. Treat runtime contents as state and do not delete them unless
+  explicitly requested.
+- `.github/` contains CI and release workflows.
+- Root Dockerfiles, `docker-compose.yml`, `sample.env`, and wrappers such as
+  `kc`, `admin`, `start-node`, and `stop-node` define and operate the
+  containerized deployment.
+
+## Main Data Flows
+
+1. Keymaster constructs and signs operations, then submits them to Gatekeeper.
+2. Gatekeeper validates accepted operations, stores DID histories, and exposes
+   registry queues and index changes.
+3. Mediators carry operations over Hyperswarm or blockchain registries and
+   import received operations back through Gatekeeper validation.
+4. Search Server consumes Gatekeeper index exports into a rebuildable read
+   model used by Explorer and search-enabled clients.
+
+The Gatekeeper operation history is authoritative. Mediator sync stores and
+Search Server databases are synchronization indexes or projections and must
+not replace Gatekeeper validation as the source of accepted history.

--- a/.agents/development.md
+++ b/.agents/development.md
@@ -1,0 +1,103 @@
+# Development Workflow
+
+## Before Editing
+
+1. Run `git status --short` and preserve unrelated user changes.
+2. Read the owning component's README, public types, implementation, callers,
+   and existing tests.
+3. Confirm whether the behavior belongs in a core package or in a transport,
+   API, projection, or UI adapter.
+4. Prefer existing helpers and patterns. Keep the change scoped to the stated
+   behavior and avoid unrelated refactors.
+
+Never reset or delete existing persistent runtime data, SSH to or operate
+deployment hosts, run live network synchronization, publish packages, or
+create releases unless the user asks explicitly. Tests may create and reset
+their own isolated fixtures. Do not expose secrets from `.env`; use
+`sample.env` for documented configuration.
+
+## TypeScript Imports
+
+Core packages and Node services use NodeNext module resolution. Keep `.js`
+extensions on their relative imports in TypeScript so the emitted JavaScript
+resolves correctly. Browser applications and clients are bundled separately;
+follow the import convention in the project being changed rather than
+normalizing imports across the repository.
+
+## Tests And Validation
+
+Behavior changes require a focused regression test in the matching `tests/`
+area. Test the public behavior and failure mode, not only implementation
+details or coverage lines. Reuse existing fixtures and helpers where possible.
+
+For a fresh checkout, install root dependencies with `npm ci`. From the
+repository root, the standard checks are:
+
+```bash
+npm run build
+npm run typecheck
+npm run lint
+npm test
+```
+
+During development, pass a test path to the root Jest command, for example:
+
+```bash
+npm test -- --runTestsByPath tests/gatekeeper/crud.test.ts
+```
+
+Run the full suite for shared package, protocol, persistence, or cross-service
+changes. The root build compiles the npm workspaces in `packages/`; standalone
+services, apps, and demos have their own `package.json` commands. Install their
+dependencies and run their local build or typecheck when changing them.
+
+Run Java tests with `(cd java && ./gradlew test)`. The Python SDK suite is an
+integration test that requires running Gatekeeper and Keymaster services with
+the local registry enabled. Follow the
+[Python SDK workflow](../.github/workflows/python-sdk-tests.yml), then run
+`pytest -q tests/test_keymaster_sdk.py` from `python/keymaster_sdk`.
+
+CLI integration tests have destructive local setup, so follow
+`tests/cli-tests/README.md` and run them only when relevant and safe.
+The Docker smoke test required before merge is documented in
+`CONTRIBUTING.md`; because it changes local state and may join configured
+networks, run it only in a confirmed test environment.
+
+## Change Impact
+
+| Change | Expected follow-up |
+| --- | --- |
+| Gatekeeper validation, resolution, or persistence | Update `tests/gatekeeper`; consider every supported database adapter and Gatekeeper service behavior. |
+| Keymaster wallet or identity workflow | Update `tests/keymaster`; review CLI, browser clients, apps, and SDK contracts. |
+| REST route or request/response shape | Update API tests and clients; run `npm run generate-openapi`; commit the affected file under `doc/`. |
+| Hyperswarm protocol or synchronization | Update protocol, lifecycle, and black-box behavior tests under `tests/hyperswarm`; review rolling-network compatibility. |
+| Search projection or metric | Update `tests/search-server`; remember that its database is a rebuildable index. |
+| Environment variable or deployment default | Update `sample.env`, `docker-compose.yml`, the relevant service README, and deployment files that expose it. |
+| Frontend behavior | Run the local app/client typecheck or build and update existing UI tests where available. |
+| Public package or REST contract | Review Java and Python clients and both demos for compatibility. |
+
+## Documentation
+
+Update documentation in the same change when behavior, public APIs,
+configuration, commands, architecture, or directory ownership changes:
+
+- Package behavior and usage belong in the package README.
+- Service configuration and runtime behavior belong in the service README.
+- Public HTTP changes belong in source annotations and generated OpenAPI.
+- Repository architecture and development conventions belong in `.agents/`.
+- Contributor process belongs in `CONTRIBUTING.md`.
+
+Do not duplicate large API or configuration tables in agent documentation.
+Link to the maintained source.
+
+## Completion
+
+Before finishing:
+
+1. Review the diff for scope, compatibility, error handling, and accidental
+   generated or unrelated changes.
+2. Run the narrowest relevant checks, then broader checks in proportion to the
+   change's blast radius.
+3. Report which checks passed and any checks that could not be run.
+4. Ensure code, tests, documentation, examples, and public clients describe the
+   same behavior.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,9 @@
+Use `AGENTS.md` and the canonical guides under `.agents/` as the repository
+instructions. Read the architecture and development guides before editing.
+
+Core MDIP behavior belongs in `packages/`, especially `packages/gatekeeper`
+and `packages/keymaster`. Behavior changes require focused tests and matching
+documentation updates. Preserve unrelated changes and do not perform
+destructive operations on persistent runtime data, operate deployment hosts,
+run live synchronization, publish, or release unless explicitly requested.
+Isolated test fixtures may manage their own state.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Repository Instructions
+
+Keychain is the reference MDIP implementation. Begin with
+[`.agents/README.md`](.agents/README.md), then read
+[`.agents/architecture.md`](.agents/architecture.md) and
+[`.agents/development.md`](.agents/development.md).
+
+## Architecture
+
+- `packages/` contains the reusable core and is the root npm workspace.
+- `packages/gatekeeper` owns DID operation validation, histories, persistence,
+  and resolution.
+- `packages/keymaster` owns wallets, identities, assets, credentials, and
+  signed-operation workflows.
+- Services, mediators, apps, and SDKs consume the packages. Keep reusable MDIP
+  domain behavior in packages and transport, HTTP, projection, and UI
+  orchestration in their owning component.
+- Read the relevant component README and existing tests before editing.
+
+## Working Rules
+
+- Inspect `git status --short` first and preserve unrelated changes.
+- Keep changes narrowly scoped and follow existing patterns.
+- Add or update focused behavioral tests whenever behavior changes.
+- Update affected READMEs, OpenAPI output, examples, configuration, and SDKs
+  when their contract changes.
+- Do not wipe existing persistent runtime data, SSH to or operate deployment
+  hosts, run live synchronization, publish, or release unless explicitly
+  requested. Isolated test fixtures may manage their own state.
+
+## Root Checks
+
+```bash
+npm run build
+npm run typecheck
+npm run lint
+npm test
+```
+
+Use focused Jest paths while developing. The root build covers `packages/*`;
+standalone services and apps may require their own build or typecheck.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,4 @@
+@AGENTS.md
+@.agents/README.md
+@.agents/architecture.md
+@.agents/development.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,10 @@
 # Contributing to the MDIP Keychain open source project
 
+AI coding agents should start with [AGENTS.md](AGENTS.md) and the canonical
+[agent guide](.agents/README.md). Update that guide in the same PR when a
+change alters repository architecture, ownership, commands, or development
+conventions.
+
 1. [Create an issue](https://github.com/KeychainMDIP/kc/issues) first
     - Requirements and acceptance criteria should be discussed in the issue
 2. Create a development branch from the issue

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,4 @@
+@./AGENTS.md
+@./.agents/README.md
+@./.agents/architecture.md
+@./.agents/development.md


### PR DESCRIPTION
### Overview

Adds a canonical agent guide under .agents/ covering the repository architecture, core package ownership, development workflow, testing, documentation, and validation expectations.

Provides compatible entry points for Codex, Cursor, Claude, Gemini, and GitHub Copilot.