### PR TITLE
Surface Keymaster wallet recovery failures

### DIFF
--- a/packages/keymaster/src/keymaster.ts
+++ b/packages/keymaster/src/keymaster.ts
@@ -534,63 +534,57 @@ export default class Keymaster implements KeymasterInterface {
     }
 
     async recoverWallet(did?: string): Promise<WalletFile> {
-        try {
+        if (!did) {
+            const seedBank = await this.resolveSeedBank();
+            if (seedBank.didDocumentData && typeof seedBank.didDocumentData === 'object' && !Array.isArray(seedBank.didDocumentData)) {
+                const data = seedBank.didDocumentData as { wallet?: string };
+                did = data.wallet;
+            }
             if (!did) {
-                const seedBank = await this.resolveSeedBank();
-                if (seedBank.didDocumentData && typeof seedBank.didDocumentData === 'object' && !Array.isArray(seedBank.didDocumentData)) {
-                    const data = seedBank.didDocumentData as { wallet?: string };
-                    did = data.wallet;
-                }
-                if (!did) {
-                    throw new InvalidParameterError('No backup DID found');
-                }
+                throw new InvalidParameterError('No backup DID found');
             }
-
-            const keypair = await this.hdKeyPair();
-            const data = await this.resolveAsset(did);
-            if (!data) {
-                throw new InvalidParameterError('No asset data found');
-            }
-
-            const castData = data as { backup?: string };
-
-            if (typeof castData.backup !== 'string') {
-                throw new InvalidParameterError('Asset "backup" is missing or not a string');
-            }
-
-            const backup = this.cipher.decryptMessage(keypair.publicJwk, keypair.privateJwk, castData.backup);
-            let wallet = JSON.parse(backup);
-
-            if (isV1Decrypted(wallet)) {
-                const mnemonic = await this.decryptMnemonic();
-                // Backup might have a different mnemonic passphase so re-encrypt
-                wallet.seed.mnemonicEnc = await encMnemonic(mnemonic, this.passphrase);
-            }
-
-            await this.mutateWallet(async (current) => {
-                // Clear all existing properties from the current wallet
-                // This ensures a clean slate before restoring the recovered wallet
-                for (const k in current) {
-                    delete current[k as keyof StoredWallet];
-                }
-
-                // Upgrade the recovered wallet to the latest version if needed
-                wallet = await this.upgradeWallet(wallet);
-
-                // Decrypt the wallet if needed
-                wallet = isV1WithEnc(wallet) ? await this.decryptWalletFromStorage(wallet) : wallet;
-
-                // Copy all properties from the recovered wallet into the cleared current wallet
-                // This effectively replaces the current wallet with the recovered one
-                Object.assign(current, wallet);
-            });
-
-            return this.loadWallet();
         }
-        catch {
-            // If we can't recover the wallet, just return the current one
-            return this.loadWallet();
+
+        const keypair = await this.hdKeyPair();
+        const data = await this.resolveAsset(did);
+        if (!data) {
+            throw new InvalidParameterError('No asset data found');
         }
+
+        const castData = data as { backup?: string };
+
+        if (typeof castData.backup !== 'string') {
+            throw new InvalidParameterError('Asset "backup" is missing or not a string');
+        }
+
+        const backup = this.cipher.decryptMessage(keypair.publicJwk, keypair.privateJwk, castData.backup);
+        let wallet = JSON.parse(backup);
+
+        if (isV1Decrypted(wallet)) {
+            const mnemonic = await this.decryptMnemonic();
+            // Backup might have a different mnemonic passphase so re-encrypt
+            wallet.seed.mnemonicEnc = await encMnemonic(mnemonic, this.passphrase);
+        }
+
+        await this.mutateWallet(async (current) => {
+            // Clear all existing properties from the current wallet
+            // This ensures a clean slate before restoring the recovered wallet
+            for (const k in current) {
+                delete current[k as keyof StoredWallet];
+            }
+
+            // Upgrade the recovered wallet to the latest version if needed
+            wallet = await this.upgradeWallet(wallet);
+
+            // Decrypt the wallet if needed
+            wallet = isV1WithEnc(wallet) ? await this.decryptWalletFromStorage(wallet) : wallet;
+
+            // Copy all properties from the recovered wallet into the cleared current wallet
+            // This effectively replaces the current wallet with the recovered one
+            Object.assign(current, wallet);
+        });
+
+        return this.loadWallet();
     }
 
     async listIds(): Promise<string[]> {

--- a/tests/keymaster/wallet.test.ts
+++ b/tests/keymaster/wallet.test.ts
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import Gatekeeper from '@mdip/gatekeeper';
 import Keymaster from '@mdip/keymaster';
 import {
@@ -626,26 +627,52 @@ describe('recoverWallet', () => {
         );
     });
 
-    it('should do nothing if wallet was not backed up', async () => {
+    it('should reject recovery if wallet was not backed up', async () => {
         await keymaster.createId('Bob');
         const mnemonic = await keymaster.decryptMnemonic();
 
         // Recover wallet from mnemonic
         await keymaster.newWallet(mnemonic, true);
-        const recovered = await keymaster.recoverWallet();
 
-        expect(recovered.ids).toStrictEqual({});
+        await expect(keymaster.recoverWallet()).rejects.toThrow('Invalid parameter: No backup DID found');
     });
 
-    it('should do nothing if backup DID is invalid', async () => {
+    it('should reject recovery if backup DID is invalid', async () => {
         const agentDID = await keymaster.createId('Bob');
         const mnemonic = await keymaster.decryptMnemonic();
 
         // Recover wallet from mnemonic
         await keymaster.newWallet(mnemonic, true);
-        const recovered = await keymaster.recoverWallet(agentDID);
 
-        expect(recovered.ids).toStrictEqual({});
+        await expect(keymaster.recoverWallet(agentDID))
+            .rejects
+            .toThrow('Invalid parameter: Asset "backup" is missing or not a string');
+    });
+
+    it('should propagate backup decryption failures', async () => {
+        await keymaster.createId('Bob');
+        const did = await keymaster.backupWallet();
+        jest.spyOn(cipher, 'decryptMessage').mockImplementationOnce(() => {
+            throw new Error('decryption failed');
+        });
+
+        await expect(keymaster.recoverWallet(did)).rejects.toThrow('decryption failed');
+    });
+
+    it('should reject malformed backup data', async () => {
+        await keymaster.createId('Bob');
+        const did = await keymaster.backupWallet();
+        jest.spyOn(cipher, 'decryptMessage').mockReturnValueOnce('not JSON');
+
+        await expect(keymaster.recoverWallet(did)).rejects.toThrow(SyntaxError);
+    });
+
+    it('should propagate wallet storage failures', async () => {
+        await keymaster.createId('Bob');
+        await keymaster.backupWallet();
+        jest.spyOn(wallet, 'saveWallet').mockResolvedValueOnce(false);
+
+        await expect(keymaster.recoverWallet()).rejects.toThrow('Keymaster: save wallet failed');
     });
 });
 


### PR DESCRIPTION
## Overview

`recoverWallet()` previously caught every error and returned the current wallet. Missing backups, invalid backup assets, decryption failures, malformed backup data, and storage failures could therefore appear to be successful recoveries.

This change removes the blanket error suppression so recovery failures propagate through the existing API, CLI, and UI error handlers.

## Changes

- Propagate errors encountered during wallet recovery
- Reject missing and invalid backup references
- Add regression tests for decryption, malformed data, and storage failures
- Update tests that previously expected failed recovery to return the current wallet
