### PR TITLE
Remove obsolete IPFS writes from opid generation

### DIFF
--- a/packages/gatekeeper/src/gatekeeper.ts
+++ b/packages/gatekeeper/src/gatekeeper.ts
@@ -519,13 +519,8 @@ export default class Gatekeeper implements GatekeeperInterface {
         return true;
     }
 
-    async generateCID(operation: unknown, save: boolean = false): Promise<string> {
+    async generateCID(operation: unknown): Promise<string> {
         const canonical = this.cipher.canonicalizeJSON(operation);
-
-        if (save && this.ipfs) {
-            return this.ipfs.addJSON(JSON.parse(canonical));
-        }
-
         return generateCID(JSON.parse(canonical));
     }
 

--- a/packages/gatekeeper/src/gatekeeper.ts
+++ b/packages/gatekeeper/src/gatekeeper.ts
@@ -966,12 +966,12 @@ export default class Gatekeeper implements GatekeeperInterface {
 
                 for (const e of currentEvents) {
                     if (!e.opid) {
-                        e.opid = await this.generateCID(e.operation, true);
+                        e.opid = await this.generateCID(e.operation);
                     }
                 }
 
                 if (!event.opid) {
-                    event.opid = await this.generateCID(event.operation, true);
+                    event.opid = await this.generateCID(event.operation);
                 }
 
                 const opMatch = currentEvents.find(item => item.operation.signature?.value === event.operation.signature?.value);

--- a/tests/gatekeeper/sync.test.ts
+++ b/tests/gatekeeper/sync.test.ts
@@ -766,6 +766,27 @@ describe('processEvents', () => {
         expect(response.added).toBe(3);
     });
 
+    it('should reject an event when DID generation returns no DID', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const operation = await helper.createAgentOp(keypair);
+        const generateDID = jest.spyOn(gatekeeper, 'generateDID').mockResolvedValue('');
+
+        try {
+            await gatekeeper.importBatch([{
+                registry: 'local',
+                time: operation.created!,
+                operation,
+            }]);
+
+            await expect(gatekeeper.processEvents()).resolves.toMatchObject({
+                rejected: 1,
+                pending: 0,
+            });
+        } finally {
+            generateDID.mockRestore();
+        }
+    });
+
     it('should report 0 ops added when DID exists', async () => {
         const keypair = cipher.generateRandomJwk();
         const agentOp = await helper.createAgentOp(keypair);

--- a/tests/gatekeeper/sync.test.ts
+++ b/tests/gatekeeper/sync.test.ts
@@ -932,6 +932,26 @@ describe('processEvents', () => {
         }
     });
 
+    it('should generate missing opids without writing operations to IPFS', async () => {
+        const keypair = cipher.generateRandomJwk();
+        const agentOp = await helper.createAgentOp(keypair);
+        const did = await gatekeeper.createDID(agentOp);
+        const [event] = await gatekeeper.exportDID(did);
+        const expectedOpid = await gatekeeper.generateCID(event.operation);
+        const addJSON = jest.spyOn(ipfs, 'addJSON');
+
+        try {
+            event.registry = 'hyperswarm';
+            await gatekeeper.importBatch([event]);
+            await gatekeeper.processEvents();
+
+            expect(event.opid).toBe(expectedOpid);
+            expect(addJSON).not.toHaveBeenCalled();
+        } finally {
+            addJSON.mockRestore();
+        }
+    });
+
     it('should not overwrite events when verified DID is later synced from another registry', async () => {
         const keypair = cipher.generateRandomJwk();
         const agentOp = await helper.createAgentOp(keypair, { version: 1, registry: 'TFTC' });

--- a/tests/gatekeeper/utils.test.ts
+++ b/tests/gatekeeper/utils.test.ts
@@ -267,7 +267,7 @@ describe('ipfs disabled', () => {
         await expect(gatekeeper.getJSON('cid')).rejects.toThrow('IPFS disabled');
     });
 
-    it('should still generate CID when save=true and disabled', async () => {
+    it('should still generate CID when disabled', async () => {
         const gatekeeper = new Gatekeeper({ db, ipfsEnabled: false });
         const operation: Operation = {
             type: "create",
@@ -279,7 +279,7 @@ describe('ipfs disabled', () => {
             }
         };
 
-        const cid = await gatekeeper.generateCID(operation, true);
+        const cid = await gatekeeper.generateCID(operation);
         expect(typeof cid).toBe('string');
     });
 


### PR DESCRIPTION
## Overview

Gatekeeper previously wrote complete operation JSON to IPFS when generating missing opid values during legacy event imports. This was a remnant of the older CAS anchoring design. Operations are now stored in Gatekeeper’s event database, and resolution does not retrieve them from IPFS.

This change:

- Generates missing opid values locally from canonical operation JSON
- Removes the obsolete save option from generateCID()
- Preserves deterministic DID, opid, versionId, and previd behavior
- Adds regression coverage
- Resolves: https://github.com/KeychainMDIP/kc/issues/1258